### PR TITLE
[POR-713] Initialise llmtools in the plans to ensure it's wrapped wit…

### DIFF
--- a/portia/agents/verifier_agent.py
+++ b/portia/agents/verifier_agent.py
@@ -24,10 +24,9 @@ from portia.agents.execution_utils import (
 )
 from portia.agents.utils.step_summarizer import StepSummarizer
 from portia.clarification import Clarification, InputClarification
-from portia.errors import InvalidWorkflowStateError
+from portia.errors import InvalidAgentError, InvalidWorkflowStateError
 from portia.execution_context import get_execution_context
 from portia.llm_wrapper import LLMWrapper
-from portia.open_source_tools.llm_tool import LLMTool
 from portia.tool import ToolRunContext
 
 if TYPE_CHECKING:
@@ -551,8 +550,7 @@ class VerifierAgent(BaseAgent):
 
         """
         if not self.tool:
-            self.tool = LLMTool()
-
+            raise InvalidAgentError("Tool is required for VerifierAgent")
         context = self.get_system_context()
         execution_context = get_execution_context()
         execution_context.workflow_run_context = context

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -17,11 +17,12 @@ class LLMToolSchema(BaseModel):
         description="The task to be completed by the LLM tool.",
     )
 
+LLM_TOOL_ID = "llm_tool"
 
 class LLMTool(Tool[str]):
     """General purpose LLM tool. Customizable to user requirements. Won't call other tools."""
 
-    id: str = "llm_tool"
+    id: str = LLM_TOOL_ID
     name: str = "LLM Tool"
     description: str = (
         "Jack of all trades tool to respond to a prompt by relying solely on LLM capabilities. "

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from langchain.schema import HumanMessage
 from pydantic import BaseModel, Field
 
@@ -17,11 +19,11 @@ class LLMToolSchema(BaseModel):
         description="The task to be completed by the LLM tool.",
     )
 
-LLM_TOOL_ID = "llm_tool"
 
 class LLMTool(Tool[str]):
     """General purpose LLM tool. Customizable to user requirements. Won't call other tools."""
 
+    LLM_TOOL_ID: ClassVar[str] = "llm_tool"
     id: str = LLM_TOOL_ID
     name: str = "LLM Tool"
     description: str = (

--- a/portia/planners/one_shot_planner.py
+++ b/portia/planners/one_shot_planner.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from portia.execution_context import ExecutionContext, get_execution_context
 from portia.llm_wrapper import LLMWrapper
-from portia.open_source_tools.llm_tool import LLM_TOOL_ID
+from portia.open_source_tools.llm_tool import LLMTool
 from portia.planners.context import render_prompt_insert_defaults
 from portia.planners.planner import Planner, StepsOrError
 
@@ -67,7 +67,7 @@ class OneShotPlanner(Planner):
         # Add LLMTool to the steps that don't have a tool_id.
         for step in response.steps:
             if step.tool_id is None:
-                step.tool_id = LLM_TOOL_ID
+                step.tool_id = LLMTool.LLM_TOOL_ID
 
         return StepsOrError(
             steps=response.steps,

--- a/portia/planners/one_shot_planner.py
+++ b/portia/planners/one_shot_planner.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING
 
 from portia.execution_context import ExecutionContext, get_execution_context
 from portia.llm_wrapper import LLMWrapper
+from portia.open_source_tools.llm_tool import LLM_TOOL_ID
 from portia.planners.context import render_prompt_insert_defaults
 from portia.planners.planner import Planner, StepsOrError
 
 if TYPE_CHECKING:
     from portia.config import Config
-    from portia.plan import Plan
+    from portia.plan import Plan, Step
     from portia.tool import Tool
 
 logger = logging.getLogger(__name__)
@@ -59,7 +60,40 @@ class OneShotPlanner(Planner):
                 {"role": "user", "content": prompt},
             ],
         )
+
+        if not response.error:
+            response.error = self._validate_tools_in_response(response.steps, tool_list)
+
+        # Add LLMTool to the steps that don't have a tool_id.
+        for step in response.steps:
+            if step.tool_id is None:
+                step.tool_id = LLM_TOOL_ID
+
         return StepsOrError(
             steps=response.steps,
             error=response.error,
         )
+
+    def _validate_tools_in_response(self, steps: list[Step], tool_list: list[Tool]) -> str | None:
+        """Validate that all tools in the response steps exist in the provided tool list.
+
+        Args:
+            steps (list[Step]): List of steps from the response
+            tool_list (list[Tool]): List of available tools
+
+        Returns:
+            Error message if tools are missing, None otherwise
+
+        """
+        tool_ids = [tool.id for tool in tool_list]
+        missing_tools = [
+            step.tool_id
+            for step in steps
+            if step.tool_id and step.tool_id not in tool_ids
+        ]
+        return (
+            f"Missing tools {', '.join(missing_tools)} from the provided tool_list"
+            if missing_tools
+            else None
+        )
+

--- a/portia/runner.py
+++ b/portia/runner.py
@@ -42,7 +42,6 @@ from portia.execution_context import (
     is_execution_context_set,
 )
 from portia.logger import logger, logger_manager
-from portia.open_source_tools.llm_tool import LLMTool
 from portia.plan import Plan, PlanContext, ReadOnlyPlan, ReadOnlyStep, Step
 from portia.planners.one_shot_planner import OneShotPlanner
 from portia.storage import (
@@ -536,9 +535,9 @@ class Runner:
         return False
 
     def _get_tool_for_step(self, step: Step, workflow: Workflow) -> Tool | None:
-        # We don't expect to have a none tool_id for a step,
-        # but if we do, we use the LLM tool
-        child_tool = self.tool_registry.get_tool(step.tool_id) if step.tool_id else LLMTool()
+        if not step.tool_id:
+            return None
+        child_tool = self.tool_registry.get_tool(step.tool_id)
         return ToolCallWrapper(
             child_tool=child_tool,
             storage=self.storage,

--- a/portia/runner.py
+++ b/portia/runner.py
@@ -42,6 +42,7 @@ from portia.execution_context import (
     is_execution_context_set,
 )
 from portia.logger import logger, logger_manager
+from portia.open_source_tools.llm_tool import LLMTool
 from portia.plan import Plan, PlanContext, ReadOnlyPlan, ReadOnlyStep, Step
 from portia.planners.one_shot_planner import OneShotPlanner
 from portia.storage import (
@@ -535,9 +536,9 @@ class Runner:
         return False
 
     def _get_tool_for_step(self, step: Step, workflow: Workflow) -> Tool | None:
-        if not step.tool_id:
-            return None
-        child_tool = self.tool_registry.get_tool(step.tool_id)
+        # We don't expect to have a none tool_id for a step,
+        # but if we do, we use the LLM tool
+        child_tool = self.tool_registry.get_tool(step.tool_id) if step.tool_id else LLMTool()
         return ToolCallWrapper(
             child_tool=child_tool,
             storage=self.storage,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portia-sdk-python"
-version = "0.0.1-alpha.53"
+version = "0.0.1-alpha.54"
 description = "Portia Labs Python SDK for building agentic workflows."
 authors = ["Hello <hello@portialabs.ai>"]
 readme = "README.md"

--- a/tests/unit/agents/test_verifier_agent.py
+++ b/tests/unit/agents/test_verifier_agent.py
@@ -661,7 +661,7 @@ def test_get_last_resolved_clarification() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=AdditionTool(),
+        tool=None,
     )
     assert agent.get_last_resolved_clarification("arg") == resolved_clarification2
 
@@ -681,7 +681,7 @@ def test_clarifications_or_continue() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=AdditionTool(),
+        tool=None,
     )
     inputs = VerifiedToolInputs(
         args=[
@@ -719,7 +719,7 @@ def test_clarifications_or_continue() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=AdditionTool(),
+        tool=None,
     )
 
     inputs = VerifiedToolInputs(

--- a/tests/unit/agents/test_verifier_agent.py
+++ b/tests/unit/agents/test_verifier_agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import suppress
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -27,9 +26,8 @@ from portia.agents.verifier_agent import (
     VerifierModel,
 )
 from portia.clarification import InputClarification
-from portia.errors import InvalidWorkflowStateError
+from portia.errors import InvalidAgentError, InvalidWorkflowStateError
 from portia.llm_wrapper import LLMWrapper
-from portia.open_source_tools.llm_tool import LLMTool
 from portia.plan import Step
 from tests.utils import AdditionTool, get_test_config, get_test_tool_context, get_test_workflow
 
@@ -663,7 +661,7 @@ def test_get_last_resolved_clarification() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=None,
+        tool=AdditionTool(),
     )
     assert agent.get_last_resolved_clarification("arg") == resolved_clarification2
 
@@ -683,7 +681,7 @@ def test_clarifications_or_continue() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=None,
+        tool=AdditionTool(),
     )
     inputs = VerifiedToolInputs(
         args=[
@@ -721,7 +719,7 @@ def test_clarifications_or_continue() -> None:
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
-        tool=None,
+        tool=AdditionTool(),
     )
 
     inputs = VerifiedToolInputs(
@@ -744,16 +742,19 @@ def test_clarifications_or_continue() -> None:
     assert len(agent.new_clarifications) == 0
 
 
-def test_verifier_agent_without_tool_uses_llm_tool() -> None:
-    """Test verifier agent without tool uses LLM tool."""
+def test_verifier_agent_none_tool_init() -> None:
+    """Test that executing VerifierAgent with None tool raises an exception."""
     (plan, workflow) = get_test_workflow()
+
     agent = VerifierAgent(
         step=plan.steps[0],
         workflow=workflow,
         config=get_test_config(),
         tool=None,
     )
-    # try to run the tool and fail, but sets the tool to an LLM tool
-    with suppress(Exception):
+
+    with pytest.raises(InvalidAgentError) as exc_info:
         agent.execute_sync()
-    assert isinstance(agent.tool, LLMTool)
+
+    assert "Tool is required for VerifierAgent" in str(exc_info.value)
+

--- a/tests/unit/agents/test_verifier_agent.py
+++ b/tests/unit/agents/test_verifier_agent.py
@@ -742,7 +742,7 @@ def test_clarifications_or_continue() -> None:
     assert len(agent.new_clarifications) == 0
 
 
-def test_verifier_agent_none_tool_init() -> None:
+def test_verifier_agent_none_tool_execute_sync() -> None:
     """Test that executing VerifierAgent with None tool raises an exception."""
     (plan, workflow) = get_test_workflow()
 

--- a/tests/unit/planners/test_one_shot_planner.py
+++ b/tests/unit/planners/test_one_shot_planner.py
@@ -10,7 +10,7 @@ import pytest
 
 from portia.execution_context import ExecutionContext, get_execution_context
 from portia.llm_wrapper import LLMWrapper
-from portia.open_source_tools.llm_tool import LLM_TOOL_ID
+from portia.open_source_tools.llm_tool import LLMTool
 from portia.plan import Plan, PlanContext, Step, Variable
 from portia.planners.context import default_query_system_context, render_prompt_insert_defaults
 from portia.planners.one_shot_planner import OneShotPlanner
@@ -221,6 +221,6 @@ def test_generate_steps_assigns_llm_tool_id(planner: OneShotPlanner) -> None:
         tool_list=[AdditionTool()],
     )
 
-    assert all(step.tool_id == LLM_TOOL_ID for step in result.steps)
+    assert all(step.tool_id == LLMTool.LLM_TOOL_ID for step in result.steps)
     assert len(result.steps) == 2
     assert result.error is None

--- a/tests/unit/planners/test_one_shot_planner.py
+++ b/tests/unit/planners/test_one_shot_planner.py
@@ -10,6 +10,7 @@ import pytest
 
 from portia.execution_context import ExecutionContext, get_execution_context
 from portia.llm_wrapper import LLMWrapper
+from portia.open_source_tools.llm_tool import LLM_TOOL_ID
 from portia.plan import Plan, PlanContext, Step, Variable
 from portia.planners.context import default_query_system_context, render_prompt_insert_defaults
 from portia.planners.one_shot_planner import OneShotPlanner
@@ -155,3 +156,71 @@ def test_render_prompt() -> None:
     assert "test query" in request_content
     assert "add_tool" in request_content
     assert "extension" in system_context_content
+
+
+def test_generate_steps_or_error_invalid_tool_id(planner: OneShotPlanner) -> None:
+    """Test handling of invalid tool ID in generated steps."""
+    query = "Calculate something"
+
+    mock_response = StepsOrError(
+        steps=[
+            Step(
+                task="Calculate sum",
+                tool_id="no_tool_1",
+                inputs=[],
+                output="$result",
+            ),
+            Step(
+                task="Calculate sum2",
+                tool_id="no_tool_2",
+                inputs=[],
+                output="$result2",
+            ),
+        ],
+        error=None,
+    )
+    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
+
+    result = planner.generate_steps_or_error(
+        ctx=get_execution_context(),
+        query=query,
+        tool_list=[AdditionTool()],
+    )
+
+    assert result.error == "Missing tools no_tool_1, no_tool_2 from the provided tool_list"
+    assert result.steps == mock_response.steps
+
+
+def test_generate_steps_assigns_llm_tool_id(planner: OneShotPlanner) -> None:
+    """Test that steps without tool_id get assigned to LLMTool."""
+    query = "Generate a creative story"
+
+    # Mock response with steps that have no tool_id
+    mock_response = StepsOrError(
+        steps=[
+            Step(
+                task="Write a story opening",
+                tool_id=None,
+                inputs=[],
+                output="$story_opening",
+            ),
+            Step(
+                task="Write story conclusion",
+                tool_id=None,
+                inputs=[],
+                output="$story_conclusion",
+            ),
+        ],
+        error=None,
+    )
+    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
+
+    result = planner.generate_steps_or_error(
+        ctx=get_execution_context(),
+        query=query,
+        tool_list=[AdditionTool()],
+    )
+
+    assert all(step.tool_id == LLM_TOOL_ID for step in result.steps)
+    assert len(result.steps) == 2
+    assert result.error is None

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -15,11 +15,13 @@ from portia.clarification import ActionClarification, Clarification, InputClarif
 from portia.config import StorageClass
 from portia.errors import InvalidWorkflowStateError, PlanError, WorkflowNotFoundError
 from portia.llm_wrapper import LLMWrapper
+from portia.open_source_tools.llm_tool import LLMTool
 from portia.plan import Plan, PlanContext, ReadOnlyPlan, Step
 from portia.planners.planner import StepsOrError
 from portia.runner import Runner
 from portia.tool import Tool, ToolRunContext
 from portia.tool_registry import InMemoryToolRegistry
+from portia.tool_wrapper import ToolCallWrapper
 from portia.workflow import ReadOnlyWorkflow, Workflow, WorkflowState, WorkflowUUID
 from tests.utils import AdditionTool, ClarificationTool, get_test_config, get_test_workflow
 
@@ -434,6 +436,12 @@ def test_runner_wait_for_ready_backoff_period(runner: Runner) -> None:
     workflow.state = WorkflowState.NEED_CLARIFICATION
     runner.storage.save_plan(plan)
     runner.storage.get_workflow = mock.MagicMock(return_value=workflow)
+
+    # Mock the tool and its ready method to return False
+    mock_tool = mock.MagicMock()
+    mock_tool.ready.return_value = False
+    runner._get_tool_for_step = mock.MagicMock(return_value=mock_tool)  # noqa: SLF001
+
     with pytest.raises(InvalidWorkflowStateError):
         runner.wait_for_ready(workflow, max_retries=1, backoff_start_time_seconds=0)
 
@@ -472,3 +480,23 @@ def test_runner_resolve_clarification(runner: Runner) -> None:
 
     workflow = runner.resolve_clarification(clarification, "test", workflow)
     assert workflow.state == WorkflowState.READY_TO_RESUME
+
+
+def test_runner_get_tool_for_step_none_tool_id() -> None:
+    """Test that when step.tool_id is None, LLMTool is used as fallback."""
+    runner = Runner(config=get_test_config(), tools=[AdditionTool()])
+    plan, workflow = get_test_workflow()
+
+    # Create a step with no tool_id
+    step = Step(
+        task="Some task",
+        inputs=[],
+        output="$output",
+        tool_id=None,
+    )
+
+    tool = runner._get_tool_for_step(step, workflow)  # noqa: SLF001
+
+    # Verify the tool is a ToolCallWrapper with LLMTool as child_tool
+    assert isinstance(tool, ToolCallWrapper)
+    assert isinstance(tool._child_tool, LLMTool)  # noqa: SLF001


### PR DESCRIPTION
### Issues

- Steps that are executed by `LLMTool` doesn't get stored in the cloud/dashboard. This is because we don't wrap the call with `ToolWrapper`
- Planner sometimes producing plans with `LLMTool` and sometimes not which is affecting Evals.
- I faced an error before where planner is hallucinating tool_ids,  because we don't check that tools produced by the planner are actually contained in the `tool_list` that was given.


### Fix
- Verify the tool_ids are existent in the tool list, in the planner stage.
- Refill the steps that doesn't contain tool ids with  `LLMTool`.
- Fallback to the LLMTool (just in case) in the runner instead of delegating this decision to verifier agent. 
   - We don't expect this to happen, but just in case to be safe.
   - Raise exception in the verifier agent if no tool found on `execute_sync`