### PR TITLE
[POR-691] Summary should be populated with values if it is None

### DIFF
--- a/portia/agents/execution_utils.py
+++ b/portia/agents/execution_utils.py
@@ -139,6 +139,8 @@ def process_output(
             tool_output = Output(value=last_message.artifact)
         else:
             tool_output = Output(value=last_message.content)
+        if not tool_output.summary:
+            tool_output.summary = tool_output.serialize_value(tool_output.value)
         return tool_output
     if isinstance(last_message, HumanMessage):
         return Output(value=last_message.content)

--- a/tests/unit/agents/test_execution_utils.py
+++ b/tests/unit/agents/test_execution_utils.py
@@ -133,6 +133,7 @@ def test_process_output_with_output_artifacts() -> None:
 
     assert isinstance(result, Output)
     assert result.value == "test"
+    assert result.summary == "test"
 
 
 def test_process_output_with_artifacts() -> None:
@@ -163,3 +164,32 @@ def test_process_output_with_human_message() -> None:
 
     assert isinstance(result, Output)
     assert result.value == "test"
+
+
+def test_process_output_summary_matches_serialized_value() -> None:
+    """Test process_output summary matches serialized value."""
+    dict_value = {"key1": "value1", "key2": "value2"}
+    message = ToolMessage(tool_call_id="1", content="test", artifact=Output(value=dict_value))
+
+    result = process_output(message, clarifications=[])
+
+    assert isinstance(result, Output)
+    assert result.value == dict_value
+    assert result.summary == result.serialize_value(result.value)
+
+
+def test_process_output_summary_not_updated_if_provided() -> None:
+    """Test process_output does not update summary if already provided."""
+    dict_value = {"key1": "value1", "key2": "value2"}
+    provided_summary = "This is a provided summary."
+    message = ToolMessage(
+        tool_call_id="1",
+        content="test",
+        artifact=Output(value=dict_value, summary=provided_summary),
+    )
+
+    result = process_output(message, clarifications=[])
+
+    assert isinstance(result, Output)
+    assert result.value == dict_value
+    assert result.summary == provided_summary


### PR DESCRIPTION
### Issue

Step summary is only populated for tools that has summary flag turned on. We should always have something in the summary (user feedback), because so it can be always used if needed rather than checking if it's None.

### Fix
- Serialise the output value into the summary if not provided.

