### PR TITLE
[RUN-26] Fix wait_for_ready to resolve all action clarifications when ready_to_resume

### DIFF
--- a/portia/runner.py
+++ b/portia/runner.py
@@ -366,8 +366,8 @@ class Runner:
                         for clarification in current_step_clarifications:
                             if clarification.category is ClarificationCategory.ACTION:
                                 clarification.resolved = True
-                        self.storage.save_workflow(workflow)
                         workflow.state = WorkflowState.READY_TO_RESUME
+                        self.storage.save_workflow(workflow)
 
             logger().debug(f"New workflow state for {workflow.id} is {workflow.state}")
 

--- a/portia/runner.py
+++ b/portia/runner.py
@@ -29,7 +29,6 @@ from portia.agents.one_shot_agent import OneShotAgent
 from portia.agents.utils.final_output_summarizer import FinalOutputSummarizer
 from portia.agents.verifier_agent import VerifierAgent
 from portia.clarification import (
-    ActionClarification,
     Clarification,
     ClarificationCategory,
 )
@@ -288,7 +287,7 @@ class Runner:
         self.storage.save_workflow(workflow)
         return workflow
 
-    def wait_for_ready(
+    def wait_for_ready(  # noqa: C901
         self,
         workflow: Workflow,
         max_retries: int = 6,

--- a/portia/runner.py
+++ b/portia/runner.py
@@ -366,6 +366,7 @@ class Runner:
                         for clarification in current_step_clarifications:
                             if clarification.category is ClarificationCategory.ACTION:
                                 clarification.resolved = True
+                                clarification.response = "complete"
                         workflow.state = WorkflowState.READY_TO_RESUME
                         self.storage.save_workflow(workflow)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portia-sdk-python"
-version = "0.0.1-alpha.56"
+version = "0.0.1-alpha.57"
 description = "Portia Labs Python SDK for building agentic workflows."
 authors = ["Hello <hello@portialabs.ai>"]
 readme = "README.md"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -321,6 +321,10 @@ def test_runner_wait_for_ready_tool(runner: Runner) -> None:
     workflow = runner.wait_for_ready(workflow)
     assert workflow.state == WorkflowState.READY_TO_RESUME
     assert workflow.get_outstanding_clarifications() == []
+    for clarification in workflow.outputs.clarifications:
+        if clarification.step == 1:
+            assert clarification.resolved
+            assert clarification.response == "complete"
 
 
 def test_runner_execute_query_with_summary(runner: Runner) -> None:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -11,7 +11,7 @@ import pytest
 from pydantic import HttpUrl
 
 from portia.agents.base_agent import Output
-from portia.clarification import ActionClarification, Clarification, InputClarification
+from portia.clarification import ActionClarification, InputClarification
 from portia.config import StorageClass
 from portia.errors import InvalidWorkflowStateError, PlanError, WorkflowNotFoundError
 from portia.llm_wrapper import LLMWrapper


### PR DESCRIPTION
### Issue

`wait_for_ready` isn't resolving actions clarifications when the tool is ready. Which leads to hanging auth clarifications. (**non-cloud storage**).

### Fix 
Updating tests and resolve all action clars. when the tool is ready.