### PR TITLE
Eval quality improvements

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -35,6 +35,8 @@ from portia.execution_context import execution_context
 from portia.logger import logger
 from portia.open_source_tools import example_tool_registry
 from portia.open_source_tools.llm_tool import LLMTool
+from portia.plan import Plan, PlanContext, Step, Variable
+from portia.prefixed_uuid import PlanUUID
 from portia.runner import Runner
 from portia.tool_registry import PortiaToolRegistry
 from portia.workflow import WorkflowState
@@ -250,13 +252,66 @@ def plan(
     **kwargs,  # noqa: ANN003
 ) -> None:
     """Plan a query."""
+    load_dotenv()
     cli_config, config = _get_config(**kwargs)
+
+    config = Config.from_default(
+        storage_class=StorageClass.CLOUD,
+    )
+
+    plan_instance = Plan(
+        id=PlanUUID(),
+        plan_context=PlanContext(
+            query="Send an email to robbie@acme.ai saying 'if you deep fry it it all tastes the same'.",
+            tool_ids=[
+                "portia::google_docs::get_document_tool",
+                "google::docs::get_structured_document_tool",
+                "portia::google_drive_search_tool",
+                "portia::google_calendar_check_availability_tool",
+                "portia::google_calendar_create_event_tool",
+                "portia::google_calendar_delete_event_tool",
+                "portia::google_calendar_get_event_details_tool",
+                "portia::google_calendar_get_events_by_properties_tool",
+                "portia::google_calendar_modify_event_tool",
+                "portia::google_gmail::draft_email_tool",
+                "portia::google_gmail::search_email_tool",
+                "portia::google_gmail::send_draft_email_tool",
+                "portia::google_gmail::send_email_tool",
+                "portia::google_people_search_contacts_tool",
+                "portia::google_sheets_get_spreadsheet_tool",
+                "portia::slack::bot::list_conversation_ids",
+                "portia::slack::bot::list_user_ids",
+                "portia::slack::bot::send_message",
+                "portia::slack::bot::conversation_history",
+                "portia::slack::user::find_message",
+            ],
+        ),
+        steps=[
+            Step(
+                task="Send an email to robbie@acme.ai saying 'if you deep fry it it all tastes the same'.",
+                inputs=[
+                    Variable(
+                        name="$email_body",
+                        value="if you deep fry it it all tastes the sanme'.",
+                        description="The body of the email confirming the answer.",
+                    ),
+                    Variable(
+                        name="$recipient_email",
+                        value="portiademo@portialabs.ai",
+                        description="The email address to send the confirmation to.",
+                    ),
+                ],
+                tool_id="portia::google_gmail::send_email_tool",
+                output="$email_sent_status",
+            ),
+        ],
+    )
 
     registry = example_tool_registry
     if config.has_api_key(PORTIA_API_KEY):
         registry += PortiaToolRegistry(config)
 
-    runner = Runner(config=config, tools=registry)
+    runner = Runner(config=config, tools=PortiaToolRegistry(config))
 
     with execution_context(end_user_id=cli_config.end_user_id):
         output = runner.generate_plan(query)

--- a/portia/llm_wrapper.py
+++ b/portia/llm_wrapper.py
@@ -28,6 +28,7 @@ from anthropic import Anthropic
 from langchain_anthropic import ChatAnthropic
 from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
+from langsmith import wrappers
 from mistralai import Mistral
 from openai import OpenAI
 from pydantic import BaseModel
@@ -195,8 +196,10 @@ class LLMWrapper(BaseLLMWrapper):
         match self.llm_provider:
             case LLMProvider.OPENAI:
                 client = instructor.from_openai(
-                    client=OpenAI(
-                        api_key=self.config.must_get_raw_api_key("openai_api_key"),
+                    client=wrappers.wrap_openai(
+                        OpenAI(
+                            api_key=self.config.must_get_raw_api_key("openai_api_key"),
+                        ),
                     ),
                     mode=instructor.Mode.JSON,
                 )

--- a/portia/open_source_tools/search_tool.py
+++ b/portia/open_source_tools/search_tool.py
@@ -30,7 +30,7 @@ class SearchTool(Tool[str]):
     id: str = "search_tool"
     name: str = "Search Tool"
     description: str = (
-        "Searches the internet to find answers to the search query provided and "
+        "Searches the internet (using Tavily) to find answers to the search query provided and "
         "returns those answers, including images, links and a natural language answer. "
         "The search tool has access to general information but can not return specific "
         "information on users or information not available on the internet"

--- a/portia/templates/example_plans.py
+++ b/portia/templates/example_plans.py
@@ -6,7 +6,11 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
     Plan(
         plan_context=PlanContext(
             query="Send hello@portialabs.ai an email with a summary of the latest news on AI",
-            tool_ids=["search_tool", "send_email_tool", "other_tool"],
+            tool_ids=[
+                "search_tool",
+                "portia::google_gmail::send_email_tool",
+                "portia::provider::other_tool",
+            ],
         ),
         steps=[
             Step(
@@ -27,7 +31,7 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
                         description="The email address to send the email to",
                     ),
                 ],
-                tool_id="send_email_tool",
+                tool_id="portia::google_gmail::send_email_tool",
                 output="$final_output",
             ),
         ],
@@ -35,7 +39,12 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
     Plan(
         plan_context=PlanContext(
             query="Compare the weather of a city in the Southern hemisphere with that of a city in the Northern hemisphere. Email the results to hello@portialabs.ai.",  # noqa: E501
-            tool_ids=["search_tool", "send_email_tool", "other_tool", "weather_tool"],
+            tool_ids=[
+                "search_tool",
+                "portia::google_gmail::send_email_tool",
+                "portia::provider::other_tool",
+                "weather_tool",
+            ],
         ),
         steps=[
             Step(
@@ -92,7 +101,7 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
                         description="Comparison of the weather in the two cities",
                     ),
                 ],
-                tool_id="send_email_tool",
+                tool_id="portia::google_gmail::send_email_tool",
                 output="If the email was successfully sent",
             ),
         ],
@@ -100,7 +109,11 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
     Plan(
         plan_context=PlanContext(
             query="Send an email to hello@portialabs.ai with the weather in London",
-            tool_ids=["weather_tool", "send_email_tool", "other_tool"],
+            tool_ids=[
+                "weather_tool",
+                "portia::google_gmail::send_email_tool",
+                "portia::provider::other_tool",
+            ],
         ),
         steps=[
             Step(
@@ -121,7 +134,7 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
                         description="The email address",
                     ),
                 ],
-                tool_id="send_email_tool",
+                tool_id="portia::google_gmail::send_email_tool",
                 output="If the email was successfully sent",
             ),
         ],
@@ -130,16 +143,16 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
         plan_context=PlanContext(
             query="Get the latest messages on the Dev channel and send a summary to nathan",
             tool_ids=[
-                "list_conversation_ids",
-                "conversation_history",
-                "list_user_ids",
-                "send_message",
+                "portia::slack::bot::list_conversation_ids",
+                "portia::slack::bot::conversation_history",
+                "portia::slack::bot::list_user_ids",
+                "portia::slack::bot::send_message",
             ],
         ),
         steps=[
             Step(
                 task="Get the id of the Dev channel",
-                tool_id="list_conversation_ids",
+                tool_id="portia::slack::bot::list_conversation_ids",
                 output="$conversation_ids",
             ),
             Step(
@@ -150,12 +163,12 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
                         description="The id of the Dev channel",
                     ),
                 ],
-                tool_id="conversation_history",
+                tool_id="portia::slack::bot::conversation_history",
                 output="$conversation_history",
             ),
             Step(
                 task="get the user id of nathan",
-                tool_id="list_user_ids",
+                tool_id="portia::slack::bot::list_user_ids",
                 output="$nathan_user_id",
             ),
             Step(
@@ -170,7 +183,7 @@ DEFAULT_EXAMPLE_PLANS: list[Plan] = [
                         description="The user id of nathan",
                     ),
                 ],
-                tool_id="send_message",
+                tool_id="portia::slack::bot::send_message",
                 output="If the message was successfully sent",
             ),
         ],

--- a/portia/templates/query_planner.xml.jinja
+++ b/portia/templates/query_planner.xml.jinja
@@ -1,7 +1,7 @@
 <Instructions>
     Enumerate the steps you plan on taking to answer the query.
     If applicable, at each step indicate whether you would use a tool from those defined in <Tools>.
-    IMPORTANT: Ensure you the tool id exactly as it is defined in <Tools> below (including whether it has a portia:: prefix or not)
+    IMPORTANT: Ensure you use the tool id exactly as it is defined in <Tools> below (including whether it has a portia:: prefix or not)
     Each step should:
      - include a description, input used to complete the step, and an explicit mention of the tool used if applicable.
      - give a name to the variable for the output is from the step if it is successful.
@@ -14,7 +14,7 @@
     <Example>
         <Request>
             <Tools>
-            {{example.plan_context.tool_ids | replace('"', '') }}
+            {{example.plan_context.tool_ids | safe }}
             </Tools>
             <Query>
             {{example.plan_context.query}}

--- a/portia/templates/query_planner.xml.jinja
+++ b/portia/templates/query_planner.xml.jinja
@@ -1,6 +1,7 @@
 <Instructions>
     Enumerate the steps you plan on taking to answer the query.
     If applicable, at each step indicate whether you would use a tool from those defined in <Tools>.
+    IMPORTANT: Ensure you the tool id exactly as it is defined in <Tools> below (including whether it has a portia:: prefix or not)
     Each step should:
      - include a description, input used to complete the step, and an explicit mention of the tool used if applicable.
      - give a name to the variable for the output is from the step if it is successful.
@@ -28,7 +29,7 @@
 </Examples>
 
 <Tools>{% for tool in tools %}
-    <Tool name={{tool.id}}>
+    <Tool id={{tool.id}}>
         {{tool.description}}
     </Tool>{% endfor %}
 </Tools>

--- a/portia/templates/query_planner.xml.jinja
+++ b/portia/templates/query_planner.xml.jinja
@@ -13,7 +13,7 @@
     <Example>
         <Request>
             <Tools>
-            {{example.plan_context.tool_ids}}
+            {{example.plan_context.tool_ids | replace('"', '') }}
             </Tools>
             <Query>
             {{example.plan_context.query}}
@@ -34,9 +34,6 @@
 </Tools>
 
 <Request>
-    <Tools>
-        {{tools}}
-    </Tools>
     <Query>
         {{query}}
     </Query>

--- a/tests/unit/planners/test_one_shot_planner.py
+++ b/tests/unit/planners/test_one_shot_planner.py
@@ -154,7 +154,6 @@ def test_render_prompt() -> None:
     assert "add_tool" in tools_content
 
     assert "test query" in request_content
-    assert "add_tool" in request_content
     assert "extension" in system_context_content
 
 


### PR DESCRIPTION
* Explicitly mention Tavily in the search tool so the LLM can link it up with evals that say 'search Tavily to xxx'
* Use real tools in the example plans to make them more realistic
* Changes to improve the planner prompt. The most important one here was removing the second 'tools' usage - this was massive and made the prompt huge which then reduced accuracy. I found even with just removing this, example plans started to work.
* Add a wrapper around OpenAI client in the planner so we can get traces to Langsmith. Unfortuantely they don't have equivalents for Anthropic / Mistral, but I still found this v v useful for testing so thought it was worth committing.