### PR TITLE
Fix wait_for_ready to pull workflow once

### DIFF
--- a/portia/runner.py
+++ b/portia/runner.py
@@ -338,6 +338,7 @@ class Runner:
             return workflow
 
         plan = self.storage.get_plan(workflow.plan_id)
+        workflow = self.storage.get_workflow(workflow.id)
         current_step_clarifications = workflow.get_clarifications_for_step()
         while workflow.state != WorkflowState.READY_TO_RESUME:
             if tries >= max_retries:
@@ -350,9 +351,6 @@ class Runner:
 
             # wait a couple of seconds as we're long polling
             time.sleep(backoff_time_seconds)
-
-            # refresh state
-            workflow = self.storage.get_workflow(workflow.id)
 
             # if its not ready we can see if the tool is ready
             if workflow.state != WorkflowState.READY_TO_RESUME:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portia-sdk-python"
-version = "0.0.1-alpha.58"
+version = "0.0.1-alpha.59"
 description = "Portia Labs Python SDK for building agentic workflows."
 authors = ["Hello <hello@portialabs.ai>"]
 readme = "README.md"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -364,6 +364,36 @@ def test_runner_wait_for_ready_tool(runner: Runner) -> None:
             assert clarification.response == "complete"
 
 
+def test_get_clarifications_and_get_workflow_called_once(runner: Runner) -> None:
+    """Test that get_clarifications_for_step is called once after get_workflow."""
+    query = "example query"
+    mock_response = StepsOrError(
+        steps=[Step(task="Example task", inputs=[], output="$output")],
+        error=None,
+    )
+    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
+
+    plan = runner.generate_plan(query)
+    workflow = runner.create_workflow(plan)
+
+    # Set the workflow state to NEED_CLARIFICATION to ensure it goes through the wait logic
+    workflow.state = WorkflowState.NEED_CLARIFICATION
+    workflow.current_step_index = 0  # Set to a valid index
+
+    # Mock the storage methods
+    with mock.patch.object(runner.storage, "get_workflow", return_value=workflow) as mock_get_workflow, \
+         mock.patch.object(Workflow, "get_clarifications_for_step", return_value=[]) as mock_get_clarifications:  # noqa: E501
+
+        # Call wait_for_ready
+        runner.wait_for_ready(workflow)
+
+        # Assert that get_workflow was called once
+        mock_get_workflow.assert_called_once_with(workflow.id)
+
+        # Assert that get_clarifications_for_step was called once after get_workflow
+        mock_get_clarifications.assert_called_once()
+
+
 def test_runner_execute_query_with_summary(runner: Runner) -> None:
     """Test execute_query sets both final output and summary correctly."""
     query = "What activities can I do in London based on weather?"
@@ -494,6 +524,7 @@ def test_runner_wait_for_ready_max_retries(runner: Runner) -> None:
     plan, workflow = get_test_workflow()
     workflow.state = WorkflowState.NEED_CLARIFICATION
     runner.storage.save_plan(plan)
+    runner.storage.save_workflow(workflow)
     with pytest.raises(InvalidWorkflowStateError):
         runner.wait_for_ready(workflow, max_retries=0)
 


### PR DESCRIPTION
### Issue

`wait_for_ready` was not resolving the clarifications correctly, since we pull workflow object every-time in the loop. This has resulted in `current_step_clarifications` to have references to old workflow object. This bug has surfaced once we merged the change to remove cloud resolving clarifications in prod.


### Fix
Pull once the workflow, and no need to re-pull since SDK is the one responsible for writing states now.
 