### PR TITLE
bump version to make evals use new verifier prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portia-sdk-python"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 description = "Portia Labs Python SDK for building agentic workflows."
 authors = ["Hello <hello@portialabs.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Evals run locally good: https://smith.langchain.com/o/e2eb5117-7ff4-446a-b9ac-b768f33886e1/datasets/0992e8df-137f-4881-b019-59399acb5e80?paginationState=%7B%22pageIndex%22%3A0%2C%22pageSize%22%3A10%7D 


I'll follow up to update evals as well to use this latest.