### PR TITLE
Makes ParserModel more robust to errors

### DIFF
--- a/portia/agents/verifier_agent.py
+++ b/portia/agents/verifier_agent.py
@@ -167,7 +167,15 @@ class ParserModel:
                 "- You may take values from the task, inputs, previous steps or clarifications\n"
                 "- Prefer values clarified in follow-up inputs over initial inputs.\n"
                 "- Do not provide placeholder values (e.g., 'example@example.com').\n"
-                "- Ensure arguments align with the tool's schema and intended use.\n",
+                "- Ensure arguments align with the tool's schema and intended use.\n\n"
+                "You must return the arguments in the following JSON format:\n"
+                "class ToolInputs:\n"
+                "  args: List[ToolArgument]  # List of tool arguments.\n\n"
+                "class ToolArgument:\n"
+                "  name: str  # Name of the argument requested by the tool.\n"
+                "  value: Any | None  # Value of the argument from the goal or context.\n"
+                "  valid: bool  # Whether the value is valid for the argument.\n"
+                "  explanation: str  # Explanation of the source for the value of the argument.\n\n",
             ),
         ],
     )
@@ -203,32 +211,36 @@ class ParserModel:
         if not self.agent.tool:
             raise InvalidWorkflowStateError(None)
         model = self.llm.with_structured_output(ToolInputs)
-        response = model.invoke(
-            self.arg_parser_prompt.format_messages(
-                context=self.context,
-                task=self.agent.step.task,
-                tool_name=self.agent.tool.name,
-                tool_args=self.agent.tool.args_json_schema(),
-                tool_description=self.agent.tool.description,
-                previous_errors=",".join(self.previous_errors),
-            ),
+        message = self.arg_parser_prompt.format_messages(
+            context=self.context,
+            task=self.agent.step.task,
+            tool_name=self.agent.tool.name,
+            tool_args=self.agent.tool.args_json_schema(),
+            tool_description=self.agent.tool.description,
+            previous_errors=",".join(self.previous_errors),
         )
-        response = ToolInputs.model_validate(response)
 
-        test_args = {}
         errors = []
-        for arg in response.args:
-            test_args[arg.name] = arg.value
-            if not arg.valid:
-                errors.append(f"Error in argument {arg.name}: {arg.explanation}\n")
-
-        # also test the ToolInputs that have come back
-        # actually work for the schema of the tool
-        # if not we can retry
+        tool_inputs: ToolInputs | None = None
         try:
-            self.agent.tool.args_schema.model_validate(test_args)
+            response = model.invoke(message)
+            tool_inputs = ToolInputs.model_validate(response)
         except ValidationError as e:
-            errors.append(str(e) + "\n")
+            errors.append("Invalid JSON for ToolInputs: " + str(e) + "\n")
+        else:
+            test_args = {}
+            for arg in tool_inputs.args:
+                test_args[arg.name] = arg.value
+                if not arg.valid:
+                    errors.append(f"Error in argument {arg.name}: {arg.explanation}\n")
+
+            # also test the ToolInputs that have come back
+            # actually work for the schema of the tool
+            # if not we can retry
+            try:
+                self.agent.tool.args_schema.model_validate(test_args)
+            except ValidationError as e:
+                errors.append(str(e) + "\n")
 
         if errors:
             self.previous_errors.extend(errors)
@@ -243,7 +255,7 @@ class ParserModel:
             # Here is a Linear ticket to fix this:
             # https://linear.app/portialabs/issue/POR-456
 
-        return {"messages": [response.model_dump_json(indent=2)]}
+        return {"messages": [tool_inputs.model_dump_json(indent=2)] if tool_inputs else []}
 
 
 class VerifierModel:


### PR DESCRIPTION
- Includes the JSON schema for the output of the ParserModel in the prompt
- Includes schema validation errors in the retry loop

This is roughly neutral on our evals: [LangSmith run](https://smith.langchain.com/o/e2eb5117-7ff4-446a-b9ac-b768f33886e1/datasets/f88d61ea-6a05-4fd5-b42c-c49e9e3d64c8/compare?selectedSessions=cd91cd53-5d7f-42ee-9825-dd04cc446ea7%2C10a2d0f2-1d4d-416b-9a28-ed89ce2109fa%2C71175260-9f4a-467f-b11e-7bf9a1014b7a&baseline=cd91cd53-5d7f-42ee-9825-dd04cc446ea7)

I was able to then run this on a stock comparison query comparing up to 8 stocks with 100% success rate (10 reps at each number of stocks). Previously we had a 65% error rate when comparing 2 stocks (20 reps).

Towards POR-840