### PR TITLE
Logging change + portia.py small tidy

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -13,6 +13,7 @@ import builtins
 import importlib.metadata
 import json
 import os
+import sys
 from enum import Enum
 from functools import wraps
 from pathlib import Path
@@ -25,6 +26,7 @@ from pydantic_core import PydanticUndefined
 
 from portia.clarification_handler import ClarificationHandler
 from portia.config import Config
+from portia.errors import InvalidConfigError
 from portia.execution_context import execution_context
 from portia.logger import logger
 from portia.portia import ExecutionHooks, Portia
@@ -331,7 +333,11 @@ def _get_config(
     cli_config = CLIConfig(**kwargs)
     if cli_config.env_location == EnvLocation.ENV_FILE:
         load_dotenv(override=True)
-    config = Config.from_default(**kwargs)
+    try:
+        config = Config.from_default(**kwargs)
+    except InvalidConfigError as e:
+        logger().error(e.message)
+        sys.exit(1)
 
     keys = [
         os.getenv("OPENAI_API_KEY"),

--- a/portia/errors.py
+++ b/portia/errors.py
@@ -61,7 +61,8 @@ class InvalidConfigError(PortiaBaseError):
 
     def __init__(self, value: str, issue: str) -> None:
         """Set custom error message."""
-        super().__init__(f"Config value {value.upper()} is not valid - {issue}")
+        self.message = f"Config value {value.upper()} is not valid - {issue}"
+        super().__init__(self.message)
 
 
 class PlanError(PortiaBaseError):

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -443,7 +443,7 @@ class Portia:
         return plan_run
 
     def _set_plan_run_state(self, plan_run: PlanRun, state: PlanRunState) -> None:
-        """Set the state of a plan run."""
+        """Set the state of a plan run and persist it to storage."""
         plan_run.state = state
         self.storage.save_plan_run(plan_run)
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -338,9 +338,8 @@ class Portia:
         matched_clarification.response = response
 
         if len(plan_run.get_outstanding_clarifications()) == 0:
-            plan_run.state = PlanRunState.READY_TO_RESUME
+            self._set_plan_run_state(plan_run, PlanRunState.READY_TO_RESUME)
 
-        self.storage.save_plan_run(plan_run)
         return plan_run
 
     def error_clarification(
@@ -355,8 +354,7 @@ class Portia:
         )
         if plan_run is None:
             plan_run = self.storage.get_plan_run(clarification.plan_run_id)
-        plan_run.state = PlanRunState.FAILED
-        self.storage.save_plan_run(plan_run)
+        self._set_plan_run_state(plan_run, PlanRunState.FAILED)
         return plan_run
 
     def wait_for_ready(  # noqa: C901
@@ -436,14 +434,18 @@ class Portia:
                             clarification.resolved = True
                             clarification.response = "complete"
                     if len(plan_run.get_outstanding_clarifications()) == 0:
-                        plan_run.state = PlanRunState.READY_TO_RESUME
-                        self.storage.save_plan_run(plan_run)
+                        self._set_plan_run_state(plan_run, PlanRunState.READY_TO_RESUME)
 
             logger().debug(f"New run state for {plan_run.id} is {plan_run.state}")
 
         logger().info(f"Run {plan_run.id} is ready to resume")
 
         return plan_run
+
+    def _set_plan_run_state(self, plan_run: PlanRun, state: PlanRunState) -> None:
+        """Set the state of a plan run."""
+        plan_run.state = state
+        self.storage.save_plan_run(plan_run)
 
     def _create_plan_run(self, plan: Plan) -> PlanRun:
         """Create a PlanRun from a Plan.
@@ -474,8 +476,7 @@ class Portia:
             Run: The updated run after execution.
 
         """
-        plan_run.state = PlanRunState.IN_PROGRESS
-        self.storage.save_plan_run(plan_run)
+        self._set_plan_run_state(plan_run, PlanRunState.IN_PROGRESS)
         logger().debug(
             f"Executing run from step {plan_run.current_step_index}",
             extra={"plan": plan.id, "plan_run": plan_run.id},
@@ -502,9 +503,8 @@ class Portia:
             except Exception as e:  # noqa: BLE001 - We want to capture all failures here
                 error_output = Output(value=str(e))
                 plan_run.outputs.step_outputs[step.output] = error_output
-                plan_run.state = PlanRunState.FAILED
                 plan_run.outputs.final_output = error_output
-                self.storage.save_plan_run(plan_run)
+                self._set_plan_run_state(plan_run, PlanRunState.FAILED)
                 logger().error(
                     "error: {error}",
                     error=e,
@@ -538,8 +538,7 @@ class Portia:
                 plan_run=plan_run.model_dump_json(indent=4),
             )
 
-        plan_run.state = PlanRunState.COMPLETE
-        self.storage.save_plan_run(plan_run)
+        self._set_plan_run_state(plan_run, PlanRunState.COMPLETE)
         logger().debug(
             f"Final run status: {plan_run.state}",
             extra={"plan": plan.id, "plan_run": plan_run.id},
@@ -619,8 +618,7 @@ class Portia:
                 clarification.step = plan_run.current_step_index
 
             plan_run.outputs.clarifications = plan_run.outputs.clarifications + new_clarifications
-            plan_run.state = PlanRunState.NEED_CLARIFICATION
-            self.storage.save_plan_run(plan_run)
+            self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
             logger().info(
                 f"{len(new_clarifications)} Clarification(s) requested",
                 extra={"plan": plan.id, "plan_run": plan_run.id},


### PR DESCRIPTION
* Suppress stack trace from config.py when there is invalid config
* Add a method to set and save the plan run state in portia.py - I saw this pattern quite a lot and thought it would be safer to have it behind a method so we always make sure to save to the cloud when updating the state