### PR TITLE
Fix CLI + FIx clarification formatting 

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -21,6 +21,7 @@ import click
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_core import PydanticUndefined
+from typing_extensions import get_origin
 
 from portia.clarification_handler import ClarificationHandler
 from portia.config import Config
@@ -100,6 +101,7 @@ def generate_cli_option_from_pydantic_field(  # noqa: C901
 
     field_type = click.STRING
     field_default = info.default
+    callback = None
     if info.default_factory:
         field_default = info.default_factory()  # type: ignore  # noqa: PGH003
 
@@ -114,6 +116,17 @@ def generate_cli_option_from_pydantic_field(  # noqa: C901
             field_type = click.STRING
         case builtins.list:
             field_type = click.Tuple([str])
+        case _ if get_origin(info.annotation) is dict:
+
+            def dict_callback(_1: click.Context, _2: click.Parameter, value: str) -> dict:
+                if value is None:
+                    return field_default
+                try:
+                    return json.loads(value)
+                except json.JSONDecodeError as e:
+                    raise click.BadParameter(f"Invalid JSON: {value}") from e
+
+            callback = dict_callback
         case _:
             if isinstance(info.annotation, type) and issubclass(info.annotation, Enum):
                 field_type = click.Choice(
@@ -134,6 +147,7 @@ def generate_cli_option_from_pydantic_field(  # noqa: C901
         type=field_type,
         default=field_default,
         help=field_help,
+        callback=callback,
     )(f)
 
 
@@ -189,7 +203,7 @@ class CLIClarificationHandler(ClarificationHandler):
     ) -> None:
         """Handle a user input clarifications by asking the user for input from the CLI."""
         user_input = click.prompt(
-            click.style(clarification.user_guidance + "\nPlease enter a value:", fg=87),
+            click.style(clarification.user_guidance + "\nPlease enter a value", fg=87),
         )
         return on_resolution(clarification, user_input)
 

--- a/portia/cli.py
+++ b/portia/cli.py
@@ -190,7 +190,7 @@ class CLIClarificationHandler(ClarificationHandler):
     ) -> None:
         """Handle a user input clarifications by asking the user for input from the CLI."""
         user_input = click.prompt(
-            click.style(clarification.user_guidance + "\nPlease enter a value:\n", fg=87),
+            click.style(clarification.user_guidance + "\nPlease enter a value:", fg=87),
         )
         return on_resolution(clarification, user_input)
 

--- a/portia/config.py
+++ b/portia/config.py
@@ -545,7 +545,7 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
 
     """
     llm_model_name = kwargs.pop("llm_model_name", None)
-    models = {}
+    models = kwargs.pop("models", {})
     for model_usage in [
         PLANNING_MODEL_KEY,
         EXECUTION_MODEL_KEY,
@@ -554,7 +554,7 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
         SUMMARISER_MODEL_KEY,
     ]:
         model_name = kwargs.pop(model_usage, llm_model_name)
-        if model_name:
+        if model_name and model_name not in models:
             models[model_usage] = parse_str_to_enum(model_name, LLMModel)
 
     llm_provider = parse_str_to_enum(


### PR DESCRIPTION
2 changes here:
* Small change to the formatting of clarifications to make them nicer (click already ads on the `:` so we don't want two)
* Fix CLI - my recent LLM change broke it due to the new models param not being handled properly because it was a dict - I've now added dict handling to the CLI options