### PR TITLE
Warn if no Portia API key is present

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -104,7 +104,9 @@ class Portia:
         logger_manager.configure_from_config(self.config)
         self.execution_hooks = execution_hooks if execution_hooks else ExecutionHooks()
         if not self.config.has_api_key("portia_api_key"):
-            logger().warning("No Portia API key found, Portia cloud tools and storage will not be available.")
+            logger().warning(
+                "No Portia API key found, Portia cloud tools and storage will not be available.",
+            )
 
         if isinstance(tools, ToolRegistry):
             self.tool_registry = tools

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -103,6 +103,8 @@ class Portia:
         self.config = config if config else Config.from_default()
         logger_manager.configure_from_config(self.config)
         self.execution_hooks = execution_hooks if execution_hooks else ExecutionHooks()
+        if not self.config.has_api_key("portia_api_key"):
+            logger().warning("No Portia API key found, Portia cloud tools and storage will not be available.")
 
         if isinstance(tools, ToolRegistry):
             self.tool_registry = tools


### PR DESCRIPTION
Output a warning message on startup if no API key is present indicating that Portia Cloud tools are not available
![image](https://github.com/user-attachments/assets/58c9c2b2-2df5-4df7-85e4-b2775615609e)
