### PR TITLE
More log improvements

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -279,6 +279,10 @@ class Config(BaseModel):
         default_factory=lambda: os.getenv("PORTIA_API_ENDPOINT") or "https://api.portialabs.ai",
         description="The API endpoint for the Portia Cloud API",
     )
+    portia_dashboard_url: str = Field(
+        default_factory=lambda: os.getenv("PORTIA_DASHBOARD_URL") or "https://app.portialabs.ai",
+        description="The URL for the Portia Cloud Dashboard",
+    )
     portia_api_key: SecretStr | None = Field(
         default_factory=lambda: SecretStr(os.getenv("PORTIA_API_KEY") or ""),
         description="The API Key for the Portia Cloud API available from the dashboard at https://app.portialabs.ai",

--- a/portia/logger.py
+++ b/portia/logger.py
@@ -28,6 +28,13 @@ from loguru import logger as default_logger
 if TYPE_CHECKING:
     from portia.config import Config
 
+FUNCTION_COLOR_MAP = {
+    "tool": "fg 87",
+    "clarification": "fg 87",
+    "run": "fg 129",
+    "step": "fg 129",
+    "plan": "fg 39",
+}
 
 class LoggerInterface(Protocol):
     """General Interface for loggers.
@@ -49,6 +56,7 @@ class LoggerInterface(Protocol):
     def warning(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
     def error(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
     def critical(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
+
 
 class Formatter:
     """A class used to format log records.
@@ -90,15 +98,17 @@ class Formatter:
         if isinstance(msg, str):
             msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
             msg = re.sub(r"(?<!\})\}(?!\})", "}}", msg)
-            msg = self._truncated_message(msg)
+            msg = self._truncated_message_(msg)
+
+        function_color = self._get_function_color_(record)
 
         # Create the base format string
         result = (
             f"<green>{record['time'].strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}</green> | "
             f"<level>{record['level'].name}</level> | "
-            f"<cyan>{record['name']}</cyan>:"
-            f"<cyan>{record['function']}</cyan>:"
-            f"<cyan>{record['line']}</cyan> - "
+            f"<{function_color}>{record['name']}</{function_color}>:"
+            f"<{function_color}>{record['function']}</{function_color}>:"
+            f"<{function_color}>{record['line']}</{function_color}> - "
             f"<level>{msg}</level>"
         )
 
@@ -109,7 +119,18 @@ class Formatter:
         result += "\n"
         return result
 
-    def _truncated_message(self, msg: str) -> str:
+    def _get_function_color_(self, record: Any) -> str:  # noqa: ANN401
+        """Get color based on function/module name. Default is white."""
+        return next(
+            (
+                color
+                for key, color in FUNCTION_COLOR_MAP.items()
+                if any(key in field for field in [record["function"], record["name"]])
+            ),
+            "white",
+        )
+
+    def _truncated_message_(self, msg: str) -> str:
         lines = msg.split("\n")
         if len(lines) > self.max_lines:
             # Keep first and last parts, truncate the middle
@@ -122,6 +143,7 @@ class Formatter:
             truncated_lines.extend(lines[-tail_lines:])
             msg = "\n".join(truncated_lines)
         return msg
+
 
 class LoggerManager:
     """Manages the package-level logger.

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -485,12 +485,17 @@ class Portia:
             Run: The updated run after execution.
 
         """
-        self._set_plan_run_state(plan_run, PlanRunState.IN_PROGRESS)
+        plan_run.state = PlanRunState.IN_PROGRESS
+        self.storage.save_plan_run(plan_run)
+
+        dashboard_url = self.config.must_get("portia_dashboard_url", str)
+
         logger().info(
-            f"Plan run state updated with change in state {plan_run.state!s}",
-            plan=str(plan.id),
-            plan_run=str(plan_run.id),
+            f"Plan Run State is updated to {plan_run.state!s}. "
+            f"View in your Portia AI dashboard: "
+            f"{dashboard_url}/dashboard/plan-runs?plan_run_id={plan_run.id!s}",
         )
+
         for index in range(plan_run.current_step_index, len(plan.steps)):
             step = plan.steps[index]
             plan_run.current_step_index = index

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -485,8 +485,7 @@ class Portia:
             Run: The updated run after execution.
 
         """
-        plan_run.state = PlanRunState.IN_PROGRESS
-        self.storage.save_plan_run(plan_run)
+        self._set_plan_run_state(plan_run, PlanRunState.IN_PROGRESS)
 
         dashboard_url = self.config.must_get("portia_dashboard_url", str)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -209,7 +209,6 @@ def test_getters() -> None:
         c.must_get("portia_dashboard_url", str)
 
     # no Portia API Key
-    # mismatch between provider and model
     with pytest.raises(InvalidConfigError):
         Config.from_default(
             storage_class=StorageClass.CLOUD,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -208,6 +208,7 @@ def test_getters() -> None:
     with pytest.raises(InvalidConfigError):
         c.must_get("portia_dashboard_url", str)
 
+    # no Portia API Key
     # mismatch between provider and model
     with pytest.raises(InvalidConfigError):
         Config.from_default(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -194,6 +194,7 @@ def test_getters() -> None:
         portia_api_key=SecretStr("123"),
         anthropic_api_key=SecretStr(""),
         portia_api_endpoint="",
+        portia_dashboard_url="",
     )
     with pytest.raises(InvalidConfigError):
         c.must_get("portia_api_key", int)
@@ -204,7 +205,10 @@ def test_getters() -> None:
     with pytest.raises(InvalidConfigError):
         c.must_get("portia_api_endpoint", str)
 
-    # no Portia API Key
+    with pytest.raises(InvalidConfigError):
+        c.must_get("portia_dashboard_url", str)
+
+    # mismatch between provider and model
     with pytest.raises(InvalidConfigError):
         Config.from_default(
             storage_class=StorageClass.CLOUD,

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -2,8 +2,48 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from portia.config import LogLevel
-from portia.logger import LoggerInterface, LoggerManager, logger, logger_manager
+from portia.logger import (
+    FUNCTION_COLOR_MAP,
+    Formatter,
+    LoggerInterface,
+    LoggerManager,
+    logger,
+    logger_manager,
+)
+
+
+@pytest.mark.parametrize(
+    ("record", "expected_color"),
+    [
+        (
+            {"name": "portia.portia", "function": "_execute_plan_run"},
+            FUNCTION_COLOR_MAP["run"],
+        ),
+        (
+            {"name": "portia.storage", "function": "save_tool_call"},
+            FUNCTION_COLOR_MAP["tool"],
+        ),
+        (
+            {"name": "portia.portia", "function": "plan"},
+            FUNCTION_COLOR_MAP["plan"],
+        ),
+        (
+            {"name": "portia.portia", "function": "_raise_clarifications"},
+            FUNCTION_COLOR_MAP["clarification"],
+        ),
+        (
+            {"name": "portia.tool_wrapper", "function": "run"},
+            FUNCTION_COLOR_MAP["tool"],
+        ),
+    ],
+)
+def test_logger_formatter_get_function_color(record: dict, expected_color: str) -> None:
+    """Test the logger formatter get_function_color method."""
+    logger_formatter = Formatter()
+    assert logger_formatter._get_function_color_(record) == expected_color
 
 
 def test_logger_manager_initialization() -> None:


### PR DESCRIPTION
- color the function name in the log according to 
  - plan announcements -> code 39
  - plan run and step announcements -> code 129
  - tool call and clarification announcements -> 87
 - include the link to the dashboard in the plan execution
<img width="1454" alt="Screenshot 2025-03-07 at 16 47 10" src="https://github.com/user-attachments/assets/dde6e827-8a4f-429f-9ef5-55b69d5ebc77" />