### PR TITLE
Prevent automatic SDK rollouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
 name: Version Tag Creation
 
 on:
-  push:
-    branches:
-      - main
-      - production
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to create tag from'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - main
+          - production
 
 permissions:
   contents: write
@@ -17,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,6 +43,15 @@ jobs:
           VERSION=$(poetry version --short)
           echo "Version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Check if version is already tagged
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists. Skipping tag creation."
+            echo "tag_exists=true" >> $GITHUB_ENV
+          else
+            echo "Tag $VERSION does not exist. Creating new tag."
+          fi
 
       - name: Check if version is already tagged
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,6 @@ jobs:
             echo "Tag $VERSION does not exist. Creating new tag."
           fi
 
-      - name: Check if version is already tagged
-        run: |
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
-            echo "Tag $VERSION already exists. Skipping tag creation."
-            echo "tag_exists=true" >> $GITHUB_ENV
-          else
-            echo "Tag $VERSION does not exist. Creating new tag."
-          fi
-
       - name: Create Git tag
         if: env.tag_exists != 'true'
         run: |


### PR DESCRIPTION
This means SDK rollouts need to be triggered manually, rather than automatically from a PR. Once this is merged, I'll make the other changes in https://portiaai.slack.com/archives/C07UK7NB49L/p1741346336545249.