### PR TITLE
Add MCP tool integration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2509,6 +2509,25 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3"},
+    {file = "pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -3529,4 +3548,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "48bed622f1ecf44f11724d8b939f31f075bfcc14601a14cdad19d5c2d6ebaf05"
+content-hash = "92d6fc29058b517cf1bd0c7c5e6af7d680ecc0ddffafcd2af8c153604abbdad0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1514,6 +1514,32 @@ files = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.3.0"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mcp-1.3.0-py3-none-any.whl", hash = "sha256:2829d67ce339a249f803f22eba5e90385eafcac45c94b00cab6cef7e8f217211"},
+    {file = "mcp-1.3.0.tar.gz", hash = "sha256:f409ae4482ce9d53e7ac03f3f7808bcab735bdfc0fba937453782efb43882d45"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27"
+httpx-sse = ">=0.4"
+pydantic = ">=2.7.2,<3.0.0"
+pydantic-settings = ">=2.5.2"
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+uvicorn = ">=0.23.1"
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
+rich = ["rich (>=13.9.4)"]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -2405,6 +2431,27 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.8.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c"},
+    {file = "pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2981,6 +3028,44 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sse-starlette"
+version = "2.2.1"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99"},
+    {file = "sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.41.3"
+
+[package.extras]
+examples = ["fastapi"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
+name = "starlette"
+version = "0.46.1"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227"},
+    {file = "starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
 name = "tenacity"
 version = "9.0.0"
 description = "Retry code until it succeeds"
@@ -3174,6 +3259,25 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.0"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4"},
+    {file = "uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
 name = "virtualenv"
@@ -3425,4 +3529,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "9efdcf45e8f80d52b3bd01a7f20f07652dce00134349f82c5879ba6bffad6575"
+content-hash = "48bed622f1ecf44f11724d8b939f31f075bfcc14601a14cdad19d5c2d6ebaf05"

--- a/portia/__init__.py
+++ b/portia/__init__.py
@@ -57,11 +57,14 @@ from portia.execution_context import (
 
 # Logging
 from portia.logger import logger
+
+# MCP related classes
+from portia.mcp_session import SseMcpClientConfig, StdioMcpClientConfig
+
+# Open source tools
 from portia.open_source_tools.llm_tool import LLMTool
 from portia.open_source_tools.local_file_reader_tool import FileReaderTool
 from portia.open_source_tools.local_file_writer_tool import FileWriterTool
-
-# Open source tools
 from portia.open_source_tools.registry import (
     example_tool_registry,
     open_source_tool_registry,
@@ -81,6 +84,7 @@ from portia.tool import Tool, ToolRunContext
 from portia.tool_registry import (
     DefaultToolRegistry,
     InMemoryToolRegistry,
+    McpToolRegistry,
     PortiaToolRegistry,
     ToolRegistry,
 )
@@ -117,6 +121,7 @@ __all__ = [
     "LLMProvider",
     "LLMTool",
     "LogLevel",
+    "McpToolRegistry",
     "MultipleChoiceClarification",
     "Plan",
     "PlanContext",
@@ -130,6 +135,8 @@ __all__ = [
     "PortiaBaseError",
     "PortiaToolRegistry",
     "SearchTool",
+    "SseMcpClientConfig",
+    "StdioMcpClientConfig",
     "Step",
     "StorageClass",
     "StorageError",

--- a/portia/mcp_session.py
+++ b/portia/mcp_session.py
@@ -1,0 +1,88 @@
+"""Configuration and client code for interactions with Model Context Protocol (MCP) servers.
+
+This module provides a context manager for creating MCP ClientSessions, which are used to
+interact with MCP servers. It supports both the SSE and stdio transports.
+
+NB. The MCP Python SDK is asynchronous, so care must be taken when using MCP functionality
+from this module in an async context.
+
+Classes:
+    SseMcpClientConfig: Configuration for an MCP client that connects via SSE.
+    StdioMcpClientConfig: Configuration for an MCP client that connects via stdio.
+    McpClientConfig: The configuration to connect to an MCP server.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, Literal
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.client.sse import sse_client
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class SseMcpClientConfig(BaseModel):
+    """Configuration for an MCP client that connects via SSE."""
+
+    server_name: str
+    url: str
+    headers: dict[str, Any] | None = None
+    timeout: float = 5
+    sse_read_timeout: float = 60 * 5
+
+
+class StdioMcpClientConfig(BaseModel):
+    """Configuration for an MCP client that connects via stdio."""
+
+    server_name: str
+    command: str
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] | None = None
+    encoding: str = "utf-8"
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+
+
+McpClientConfig = SseMcpClientConfig | StdioMcpClientConfig
+
+
+@asynccontextmanager
+async def get_mcp_session(mcp_client_config: McpClientConfig) -> AsyncIterator[ClientSession]:
+    """Context manager for an MCP ClientSession.
+
+    Args:
+        mcp_client_config: The configuration to connect to an MCP server
+
+    Returns:
+        An MCP ClientSession
+
+    """
+    if isinstance(mcp_client_config, StdioMcpClientConfig):
+        async with (
+            stdio_client(
+                StdioServerParameters(
+                    command=mcp_client_config.command,
+                    args=mcp_client_config.args,
+                    env=mcp_client_config.env,
+                    encoding=mcp_client_config.encoding,
+                    encoding_error_handler=mcp_client_config.encoding_error_handler,
+                ),
+            ) as stdio_transport,
+            ClientSession(*stdio_transport) as session,
+        ):
+            await session.initialize()
+            yield session
+    elif isinstance(mcp_client_config, SseMcpClientConfig):
+        async with (
+            sse_client(
+                url=mcp_client_config.url,
+                headers=mcp_client_config.headers,
+                timeout=mcp_client_config.timeout,
+                sse_read_timeout=mcp_client_config.sse_read_timeout,
+            ) as sse_transport,
+            ClientSession(*sse_transport) as session,
+        ):
+            await session.initialize()
+            yield session

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -10,10 +10,12 @@ Classes:
     AggregatedToolRegistry: A registry that aggregates multiple tool registries.
     InMemoryToolRegistry: A simple in-memory implementation of `ToolRegistry`.
     PortiaToolRegistry: A tool registry that interacts with the Portia API to manage tools.
+    MCPToolRegistry: A tool registry that interacts with a locally running MCP server.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 from abc import ABC, abstractmethod
@@ -24,6 +26,7 @@ from pydantic import BaseModel, Field, create_model
 
 from portia.errors import DuplicateToolError, ToolNotFoundError
 from portia.logger import logger
+from portia.mcp_session import McpClientConfig, get_mcp_session
 from portia.open_source_tools.calculator_tool import CalculatorTool
 from portia.open_source_tools.image_understanding_tool import ImageUnderstandingTool
 from portia.open_source_tools.llm_tool import LLMTool
@@ -31,10 +34,12 @@ from portia.open_source_tools.local_file_reader_tool import FileReaderTool
 from portia.open_source_tools.local_file_writer_tool import FileWriterTool
 from portia.open_source_tools.search_tool import SearchTool
 from portia.open_source_tools.weather import WeatherTool
-from portia.tool import PortiaRemoteTool, Tool
+from portia.tool import PortiaMcpTool, PortiaRemoteTool, Tool
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    import mcp
 
     from portia.config import Config
 
@@ -340,7 +345,6 @@ class PortiaToolRegistry(ToolRegistry):
         self.api_endpoint = config.must_get("portia_api_endpoint", str)
         self.tools = tools or self._load_tools()
 
-
     def _load_tools(self) -> dict[str, Tool]:
         """Load the tools from the API into the into the internal storage."""
         response = httpx.get(
@@ -416,6 +420,101 @@ class PortiaToolRegistry(ToolRegistry):
         )
 
 
+class McpToolRegistry(ToolRegistry):
+    """Provides access to tools within a Model Context Protocol (MCP) server.
+
+    See https://modelcontextprotocol.io/introduction for more information on MCP.
+    """
+
+    def __init__(self, mcp_client_config: McpClientConfig) -> None:
+        """Initialize the MCPToolRegistry with the given configuration."""
+        self.tools = {t.id: t for t in self._load_tools(mcp_client_config)}
+
+    def _load_tools(self, mcp_client_config: McpClientConfig) -> list[PortiaMcpTool]:
+        """Get a list of tools from an MCP server wrapped at Portia tools.
+
+        Args:
+            mcp_client_config: The configuration for the MCP client
+
+        Returns:
+            A list of Portia tools
+
+        """
+
+        async def async_inner() -> list[PortiaMcpTool]:
+            async with get_mcp_session(mcp_client_config) as session:
+                logger().debug("Fetching tools from MCP server")
+                tools = await session.list_tools()
+                logger().debug(f"Got {len(tools.tools)} tools from MCP server")
+                return [
+                    self._portia_tool_from_mcp_tool(tool, mcp_client_config) for tool in tools.tools
+                ]
+
+        return asyncio.run(async_inner())
+
+    def _portia_tool_from_mcp_tool(
+        self,
+        mcp_tool: mcp.Tool,
+        mcp_client_config: McpClientConfig,
+    ) -> PortiaMcpTool:
+        """Conversion of a remote MCP server tool to a Portia tool."""
+        tool_name_snake_case = re.sub(r"[^a-zA-Z0-9]+", "_", mcp_tool.name)
+
+        description = (
+            mcp_tool.description
+            if mcp_tool.description is not None
+            else f"{mcp_tool.name} tool from {mcp_client_config.server_name}"
+        )
+
+        return PortiaMcpTool(
+            id=f"mcp:{mcp_client_config.server_name}:{tool_name_snake_case}",
+            name=mcp_tool.name,
+            description=description,
+            args_schema=generate_pydantic_model_from_json_schema(
+                f"{tool_name_snake_case}_schema",
+                mcp_tool.inputSchema,
+            ),
+            output_schema=("str", "The response from the tool formatted as a JSON string"),
+            mcp_client_config=mcp_client_config,
+        )
+
+    def register_tool(self, tool: Tool) -> None:
+        """Register a new tool.
+
+        Args:
+            tool (Tool): The tool to be registered.
+
+        """
+        raise NotImplementedError("register_tool is not supported for MCPToolRegistry")
+
+    def get_tool(self, tool_id: str) -> Tool:
+        """Retrieve a tool's information.
+
+        Args:
+            tool_id (str): The ID of the tool to retrieve.
+
+        Returns:
+            Tool: The requested tool.
+
+        Raises:
+            ToolNotFoundError: If the tool with the given ID does not exist.
+
+        """
+        tool = self.tools.get(tool_id)
+        if not tool:
+            raise ToolNotFoundError(tool_id)
+        return tool
+
+    def get_tools(self) -> list[Tool]:
+        """Get all tools registered with the registry.
+
+        Returns:
+            list[Tool]: A list of all tools in the registry.
+
+        """
+        return list(self.tools.values())
+
+
 EXCLUDED_BY_DEFAULT_TOOL_REGEXS: frozenset[str] = frozenset(
     {
         # Exclude Outlook by default as it clashes with Gmail
@@ -481,8 +580,11 @@ def generate_pydantic_model_from_json_schema(
 
     # Define fields for the model
     fields = dict(
-        [_generate_field(key, value, required=key in required) for key, value in properties.items()
-    ])
+        [
+            _generate_field(key, value, required=key in required)
+            for key, value in properties.items()
+        ],
+    )
 
     # Create the Pydantic model dynamically
     return create_model(model_name, **fields)  # type: ignore  # noqa: PGH003 - We want to use default config
@@ -495,12 +597,13 @@ def _generate_field(
     required: bool,
 ) -> tuple[str, tuple[type | Any, Any]]:
     """Generate a Pydantic field from a JSON schema field."""
+    default_from_schema = field.get("default")
     return (
         field_name,
         (
             _map_pydantic_type(field_name, field),
             Field(
-                default=... if required else None,
+                default=... if required else default_from_schema,
                 description=field.get("description", ""),
             ),
         ),

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -689,7 +689,8 @@ def _map_single_pydantic_type(  # noqa: PLR0911
         case "null":
             if allow_nonetype:
                 return None
-            raise ValueError("Null type is not allowed")
+            logger().warning(f"Null type is not allowed for a non-union field: {field_name}")
+            return Any
         case _:
             logger().warning(f"Unsupported JSON schema type: {field.get('type')}: {field}")
             return Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ python-dotenv = "^1.0.1"
 pandas = "^2.2.3"
 pytest-mock = "^3.14.0"
 openpyxl = "^3.1.5"
+mcp = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pytest-cov = "^5.0.0"
 pyright = "^1.1.382"
 pytest-httpx = "^0.33.0"
 pytest-xdist = {extras = ["psutil"], version = "^3.6.1"}
+pytest-asyncio = "^0.25.3"
 
 [tool.ruff]
 line-length=100

--- a/tests/integration/mcp_server.py
+++ b/tests/integration/mcp_server.py
@@ -1,0 +1,33 @@
+"""Mock MCP server for testing."""
+from __future__ import annotations
+
+import sys
+from logging import getLogger
+
+from mcp.server import FastMCP
+
+logger = getLogger(__name__)
+
+
+server = FastMCP("server", port=11385, log_level="DEBUG")
+
+
+@server.tool()
+def add_one(input_number: float) -> str:
+    """Add one to the input.
+
+    Args:
+        input_number: The input to add one to.
+
+    Returns:
+        The input plus one.
+
+    """
+    return str(input_number + 1)
+
+if __name__ == "__main__":
+    server.run(
+        transport=sys.argv[1]  # type: ignore[arg-type]
+        if len(sys.argv) > 1 and sys.argv[1] in ["stdio", "sse"]
+        else "stdio",
+    )

--- a/tests/integration/mcp_server.py
+++ b/tests/integration/mcp_server.py
@@ -26,6 +26,7 @@ def add_one(input_number: float) -> str:
     return str(input_number + 1)
 
 if __name__ == "__main__":
+    logger.info("Starting MCP server with args: %s", sys.argv)
     server.run(
         transport=sys.argv[1]  # type: ignore[arg-type]
         if len(sys.argv) > 1 and sys.argv[1] in ["stdio", "sse"]

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -18,7 +18,7 @@ async def test_mcp_session_stdio() -> None:
         StdioMcpClientConfig(
             server_name="test_server",
             command="poetry",
-            args=["run", "python", str(SERVER_FILE_PATH), "stdio"],
+            args=["run", "python", str(SERVER_FILE_PATH.absolute()), "stdio"],
         ),
     ) as session:
         tools = await session.list_tools()
@@ -30,7 +30,7 @@ async def test_mcp_session_stdio() -> None:
 async def test_mcp_session_sse() -> None:
     """Test the MCP session with SSE."""
     process = await anyio.open_process(
-        ["poetry", "run", "python", str(SERVER_FILE_PATH), "sse"],
+        ["poetry", "run", "python", str(SERVER_FILE_PATH.absolute()), "sse"],
     )
     async with process, get_mcp_session(
         SseMcpClientConfig(

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -1,6 +1,9 @@
 """MCP Session Tests."""
 
+import socket
 import subprocess
+import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import mcp
@@ -9,6 +12,11 @@ import pytest
 from portia.mcp_session import SseMcpClientConfig, StdioMcpClientConfig, get_mcp_session
 
 SERVER_FILE_PATH = Path(__file__).parent / "mcp_server.py"
+
+def is_port_in_use(port: int) -> bool:
+    """Check if a port is in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("localhost", port)) == 0
 
 
 @pytest.mark.asyncio
@@ -26,24 +34,39 @@ async def test_mcp_session_stdio() -> None:
         assert len(tools.tools) == 1
 
 
+@pytest.fixture
+def sse_background_server() -> Iterator[None]:
+    """Start the MCP server in the background."""
+    process = subprocess.Popen(["poetry", "run", "python", str(SERVER_FILE_PATH.absolute()), "sse"])  # noqa: S607, S603
+    try:
+        # Wait for server to start
+        time.sleep(3)
+
+        # Check if process is still running
+        if process.poll() is not None:
+            raise Exception(f"Server process exited with code {process.poll()}")  # noqa: TRY002
+
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("sse_background_server")
 async def test_mcp_session_sse() -> None:
     """Test the MCP session with SSE."""
-    process = subprocess.Popen(  # noqa: ASYNC220, S602
-        ["poetry", "run", "python", str(SERVER_FILE_PATH.absolute()), "sse"],  # noqa: S607
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    with process:
-        async with get_mcp_session(
-            SseMcpClientConfig(
-                server_name="test_server",
-                url="http://localhost:11385/sse",
-                sse_read_timeout=5,
-                timeout=5,
-            ),
-        ) as session:
-            tools = await session.list_tools()
-            assert isinstance(tools, mcp.ListToolsResult)
-            assert len(tools.tools) == 1
+    async with get_mcp_session(
+        SseMcpClientConfig(
+            server_name="test_server",
+            url="http://localhost:11385/sse",
+            sse_read_timeout=5,
+            timeout=5,
+        ),
+    ) as session:
+        tools = await session.list_tools()
+        assert isinstance(tools, mcp.ListToolsResult)
+        assert len(tools.tools) == 1

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -39,7 +39,7 @@ async def test_mcp_session_sse() -> None:
         async with get_mcp_session(
             SseMcpClientConfig(
                 server_name="test_server",
-                url="http://127.0.0.1:11385/sse",
+                url="http://localhost:11385/sse",
                 sse_read_timeout=5,
                 timeout=5,
             ),

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -35,7 +35,7 @@ async def test_mcp_session_sse() -> None:
     async with process, get_mcp_session(
         SseMcpClientConfig(
             server_name="test_server",
-            url="http://localhost:11385/sse",
+            url="http://127.0.0.1:11385/sse",
             sse_read_timeout=5,
             timeout=5,
         ),

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -1,0 +1,45 @@
+"""MCP Session Tests."""
+
+from pathlib import Path
+
+import anyio
+import mcp
+import pytest
+
+from portia.mcp_session import SseMcpClientConfig, StdioMcpClientConfig, get_mcp_session
+
+SERVER_FILE_PATH = Path(__file__).parent / "mcp_server.py"
+
+
+@pytest.mark.asyncio
+async def test_mcp_session_stdio() -> None:
+    """Test the MCP session with stdio."""
+    async with get_mcp_session(
+        StdioMcpClientConfig(
+            server_name="test_server",
+            command="poetry",
+            args=["run", "python", str(SERVER_FILE_PATH), "stdio"],
+        ),
+    ) as session:
+        tools = await session.list_tools()
+        assert isinstance(tools, mcp.ListToolsResult)
+        assert len(tools.tools) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_session_sse() -> None:
+    """Test the MCP session with SSE."""
+    process = await anyio.open_process(
+        ["poetry", "run", "python", str(SERVER_FILE_PATH), "sse"],
+    )
+    async with process, get_mcp_session(
+        SseMcpClientConfig(
+            server_name="test_server",
+            url="http://localhost:11385/sse",
+            sse_read_timeout=5,
+            timeout=5,
+        ),
+    ) as session:
+        tools = await session.list_tools()
+        assert isinstance(tools, mcp.ListToolsResult)
+        assert len(tools.tools) == 1

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -3,8 +3,10 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import mcp
 import pytest
 from httpx import Response
+from mcp import ClientSession
 from pydantic import HttpUrl, SecretStr
 
 from portia.clarification import (
@@ -15,8 +17,15 @@ from portia.clarification import (
     ValueConfirmationClarification,
 )
 from portia.errors import InvalidToolDescriptionError, ToolHardError, ToolSoftError
-from portia.tool import PortiaRemoteTool
-from tests.utils import AdditionTool, ClarificationTool, ErrorTool, get_test_tool_context
+from portia.mcp_session import StdioMcpClientConfig
+from portia.tool import PortiaMcpTool, PortiaRemoteTool
+from tests.utils import (
+    AdditionTool,
+    ClarificationTool,
+    ErrorTool,
+    MockMcpSessionWrapper,
+    get_test_tool_context,
+)
 
 
 @pytest.fixture
@@ -583,3 +592,32 @@ def test_remote_tool_value_confirm_clarifications() -> None:
             },
             timeout=60,
         )
+
+
+def test_portia_mcp_tool_call() -> None:
+    """Test invoking a tool via MCP."""
+    mock_session = MagicMock(spec=ClientSession)
+    mock_session.call_tool.return_value = mcp.types.CallToolResult(
+        content=[mcp.types.TextContent(type="text", text="Hello, world!")],
+        isError=False,
+    )
+
+    tool = PortiaMcpTool(
+        id="mcp:mock_mcp:test_tool",
+        name="test_tool",
+        description="I am a tool",
+        output_schema=("str", "Tool output formatted as a JSON string"),
+        mcp_client_config=StdioMcpClientConfig(
+            server_name="mock_mcp", command="test", args=["test"],
+        ),
+    )
+    expected = (
+        '{"meta":null,"content":[{"type":"text","text":"Hello, world!","annotations":null}],'
+        '"isError":false}'
+    )
+
+    with patch(
+        "portia.tool.get_mcp_session", new=MockMcpSessionWrapper(mock_session).mock_mcp_session,
+    ):
+        tool_result = tool.run(get_test_tool_context(), a=1, b=2)
+        assert tool_result == expected

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -291,6 +291,12 @@ def test_mcp_tool_registry_get_tool(mcp_tool_registry: McpToolRegistry) -> None:
     assert issubclass(tool.args_schema, BaseModel)
 
 
+def test_mcp_tool_registry_get_tool_not_found(mcp_tool_registry: McpToolRegistry) -> None:
+    """Test getting a tool from the MCPToolRegistry that does not exist."""
+    with pytest.raises(ToolNotFoundError):
+        mcp_tool_registry.get_tool("mcp:mock_mcp:non_existent_tool")
+
+
 def test_mcp_tool_registry_register_tool(mcp_tool_registry: McpToolRegistry) -> None:
     """Test MCPToolRegistry.register_tool raises NotImplementedError."""
     with pytest.raises(NotImplementedError):

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -398,6 +398,12 @@ def test_generate_pydantic_model_from_json_schema_union_types() -> None:
                 "description": "Company number to search",
                 "title": "Company Number",
             },
+            "additional_company_numbers": {
+                "type": "array",
+                "items": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+                "description": "Additional company numbers to search",
+                "title": "Additional Company Numbers",
+            },
         },
         "required": ["company_number"],
     }
@@ -411,3 +417,9 @@ def test_generate_pydantic_model_from_json_schema_union_types() -> None:
     assert model.model_fields["company_number"].annotation == Union[str, int]
     assert model.model_fields["company_number"].default is PydanticUndefined
     assert model.model_fields["company_number"].description == "Company number to search"
+    assert model.model_fields["additional_company_numbers"].annotation == list[Union[str, int]]
+    assert model.model_fields["additional_company_numbers"].default is None
+    assert (
+        model.model_fields["additional_company_numbers"].description
+        == "Additional company numbers to search"
+    )

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -291,6 +291,12 @@ def test_mcp_tool_registry_get_tool(mcp_tool_registry: McpToolRegistry) -> None:
     assert issubclass(tool.args_schema, BaseModel)
 
 
+def test_mcp_tool_registry_register_tool(mcp_tool_registry: McpToolRegistry) -> None:
+    """Test MCPToolRegistry.register_tool raises NotImplementedError."""
+    with pytest.raises(NotImplementedError):
+        mcp_tool_registry.register_tool(MockTool(id=MOCK_TOOL_ID))
+
+
 def test_generate_pydantic_model_from_json_schema() -> None:
     """Test generating a Pydantic model from a JSON schema."""
     json_schema = {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Callable, override
 
 from pydantic import BaseModel, Field, SecretStr
@@ -18,7 +19,13 @@ from portia.tool import Tool, ToolRunContext
 from portia.tool_call import ToolCallRecord, ToolCallStatus
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from unittest.mock import MagicMock
+
+    from mcp import ClientSession
+
     from portia.execution_context import ExecutionContext
+    from portia.mcp_session import McpClientConfig
 
 
 def get_test_tool_context(
@@ -234,3 +241,16 @@ class TestClarificationHandler(ClarificationHandler):  # noqa: D101
     def reset(self) -> None:
         """Reset the received clarification."""
         self.received_clarification = None
+
+
+class MockMcpSessionWrapper:
+    """Wrapper for mocking out an MCP ClientSession for testing MCP integration."""
+
+    def __init__(self, session: MagicMock) -> None:
+        """Initialize the wrapper."""
+        self.session = session
+
+    @asynccontextmanager
+    async def mock_mcp_session(self, _: McpClientConfig) -> AsyncIterator[ClientSession]:
+        """Mock method to swap out with the mcp_session context manager."""
+        yield self.session


### PR DESCRIPTION
This PR adds a wrapper around the [MCP python SDK](https://github.com/modelcontextprotocol/python-sdk), enabling users to create a (portia) `ToolRegistry` for their application that calls out to an MCP server.

Example usage:

```python
tools = DefaultToolRegistry(config) + McpToolRegistry.from_stdio_connection(
    server_name="fetch",
    command="uvx",
    args=["mcp-server-fetch"],
)
    
portia = Portia(config=config, tools=tools)

plan = portia.run(
    "Fetch the current stories from BBC News, summarize them and then add them to the file 'bbc_news.txt'"
)
```

To do before merging

- [x] Clean up warnings coming from json-schema to pydantic model generation