### PR TITLE
Add Notion to excluded by default tools

### DIFF
--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -420,6 +420,8 @@ EXCLUDED_BY_DEFAULT_TOOL_REGEXS: frozenset[str] = frozenset(
     {
         # Exclude Outlook by default as it clashes with Gmail
         "portia:microsoft:outlook:*",
+        # Exclude Notion by default as it requires explicit setup
+        "portia:notion:*",
     },
 )
 


### PR DESCRIPTION
This PR adds Notion to the list of tools that are excluded by default in the tool registry. This ensures that Notion tools are not automatically enabled without explicit setup, as they require OAuth configuration.