### PR TITLE
Fix formatting issue when log message has '<>'

### DIFF
--- a/portia/logger.py
+++ b/portia/logger.py
@@ -96,14 +96,7 @@ class Formatter:
         """
         msg = record["message"]
         if isinstance(msg, str):
-            # doubles opening curly braces in a string { -> {{
-            msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
-            # doubles closing curly braces in a string } -> }}
-            msg = re.sub(r"(?<!\})\}(?!\})", "}}", msg)
-            # escapes < and > in a string
-            msg = msg.replace("<", "\\<").replace(">", "\\>")
-            msg = self._truncated_message_(msg)
-
+            msg = self._sanitize_message_(msg)
         function_color = self._get_function_color_(record)
 
         # Create the base format string
@@ -122,6 +115,18 @@ class Formatter:
 
         result += "\n"
         return result
+
+
+    def _sanitize_message_(self, msg: str) -> str:
+        """Sanitize a message to be used in a log record."""
+        # doubles opening curly braces in a string { -> {{
+        msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
+        # doubles closing curly braces in a string } -> }}
+        msg = re.sub(r"(?<!\})\}(?!\})", "}}", msg)
+        # escapes < and > in a string
+        msg = msg.replace("<", r"\<").replace(">", r"\>")
+
+        return self._truncated_message_(msg)
 
     def _get_function_color_(self, record: Any) -> str:  # noqa: ANN401
         """Get color based on function/module name. Default is white."""

--- a/portia/logger.py
+++ b/portia/logger.py
@@ -96,8 +96,12 @@ class Formatter:
         """
         msg = record["message"]
         if isinstance(msg, str):
+            # doubles opening curly braces in a string { -> {{
             msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
+            # doubles closing curly braces in a string } -> }}
             msg = re.sub(r"(?<!\})\}(?!\})", "}}", msg)
+            # escapes < and > in a string
+            msg = msg.replace("<", "\\<").replace(">", "\\>")
             msg = self._truncated_message_(msg)
 
         function_color = self._get_function_color_(record)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -45,6 +45,12 @@ def test_logger_formatter_get_function_color(record: dict, expected_color: str) 
     logger_formatter = Formatter()
     assert logger_formatter._get_function_color_(record) == expected_color
 
+def test_logger_sanitize_message() -> None:
+    """Test the logger sanitize_message method."""
+    logger_formatter = Formatter()
+    assert logger_formatter._sanitize_message_("<test>") == r"\<test\>"
+    assert logger_formatter._sanitize_message_("test") == "test"
+    assert logger_formatter._sanitize_message_("{test} {{test}}") == "{{test}} {{test}}"
 
 def test_logger_manager_initialization() -> None:
     """Test initialization of LoggerManager with default logger."""

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -49,8 +49,15 @@ def test_logger_sanitize_message() -> None:
     """Test the logger sanitize_message method."""
     logger_formatter = Formatter()
     assert logger_formatter._sanitize_message_("<test>") == r"\<test\>"
-    assert logger_formatter._sanitize_message_("test") == "test"
     assert logger_formatter._sanitize_message_("{test} {{test}}") == "{{test}} {{test}}"
+    assert logger_formatter._sanitize_message_('{"test": "<test>"}') == '{{"test": "\\<test\\>"}}'
+
+    # a long message gets truncated correctly
+    long_message = "test\n" * 100
+    truncated_message = logger_formatter._sanitize_message_(long_message)
+    assert len(truncated_message.split("\n"))  == logger_formatter.max_lines
+    assert truncated_message.endswith("test\n")
+    assert truncated_message.startswith("test\n")
 
 def test_logger_manager_initialization() -> None:
     """Test initialization of LoggerManager with default logger."""


### PR DESCRIPTION
we will see error like 
```
ValueError: Tag "<repository_name>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)
```
if the log message has `<>` in it

Tested with query `star all of the repos belonging to <PortiaAI>`