### PR TITLE
[POR-960] Move to a global client to limit in-flight requests

### DIFF
--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -1,0 +1,27 @@
+"""Core client for interacting with portia cloud."""
+
+import httpx
+
+from portia.config import Config
+
+
+class PortiaCloudClient:
+    """Base HTTP client for interacting with portia cloud."""
+
+    _client = None
+
+    @classmethod
+    def get_client(cls, config: Config) -> httpx.Client:
+        """Return the client using a singleton pattern to help manage limits across the SDK."""
+        if cls._client is None:
+            api_key = config.must_get_api_key("portia_api_key").get_secret_value()
+            cls._client = httpx.Client(
+                base_url=config.must_get("portia_api_endpoint", str),
+                headers={
+                    "Authorization": f"Api-Key {api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=httpx.Timeout(60),
+                limits=httpx.Limits(max_connections=10),
+            )
+        return cls._client

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -540,7 +540,6 @@ class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
         else:
             try:
                 output = self.parse_response(ctx, response.json())
-                print(output)
             except (ValidationError, KeyError) as e:
                 logger().error(f"Error parsing response from Portia Cloud: {e}")
                 raise ToolHardError(e) from e

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -540,6 +540,7 @@ class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
         else:
             try:
                 output = self.parse_response(ctx, response.json())
+                print(output)
             except (ValidationError, KeyError) as e:
                 logger().error(f"Error parsing response from Portia Cloud: {e}")
                 raise ToolHardError(e) from e

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -345,19 +345,14 @@ class PortiaToolRegistry(ToolRegistry):
               If not provided, all tools will be loaded from the Portia API.
 
         """
-        self.api_key = config.must_get_api_key("portia_api_key")
         self.config = config
-        self.api_endpoint = config.must_get("portia_api_endpoint", str)
+        self.client = PortiaCloudClient().get_client(config)
         self.tools = tools or self._load_tools()
 
     def _load_tools(self) -> dict[str, Tool]:
         """Load the tools from the API into the into the internal storage."""
-        response = (
-            PortiaCloudClient()
-            .get_client(self.config)
-            .get(
-                url="/api/v0/tools/descriptions/",
-            )
+        response = self.client.get(
+            url="/api/v0/tools/descriptions/",
         )
         response.raise_for_status()
         tools = {}
@@ -376,7 +371,7 @@ class PortiaToolRegistry(ToolRegistry):
                     raw_tool["description"]["output_description"],
                 ),
                 # pass API info
-                config=self.config,
+                client=self.client,
             )
             tools[raw_tool["tool_id"]] = tool
         return tools

--- a/tests/integration/test_portia_cloud.py
+++ b/tests/integration/test_portia_cloud.py
@@ -3,9 +3,9 @@
 import uuid
 
 import pytest
-from pydantic import SecretStr
 
 from portia.clarification import ActionClarification
+from portia.cloud import PortiaCloudClient
 from portia.config import Config, StorageClass
 from portia.errors import ToolNotFoundError
 from portia.execution_context import execution_context
@@ -52,7 +52,7 @@ def test_run_tool_error() -> None:
 
     tool = registry.get_tool("portia:tavily::search")
     assert isinstance(tool, PortiaRemoteTool)
-    tool.api_key = SecretStr("123")
+    tool.client = PortiaCloudClient().get_client(config)
     ctx = get_test_tool_context()
     with pytest.raises(ToolHardError):
         tool.run(ctx)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -155,7 +155,7 @@ def test_portia_cloud_storage() -> None:
             storage.get_plan(plan.id)
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plans/{plan.id}/",
+            url=f"/api/v0/plans/{plan.id}/",
         )
 
     with (
@@ -166,7 +166,7 @@ def test_portia_cloud_storage() -> None:
             storage.save_plan_run(plan_run)
 
         mock_put.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/{plan_run.id}/",
+            url=f"/api/v0/plan-runs/{plan_run.id}/",
             json={
                 "current_step_index": plan_run.current_step_index,
                 "state": plan_run.state,
@@ -184,7 +184,7 @@ def test_portia_cloud_storage() -> None:
             storage.get_plan_run(plan_run.id)
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/{plan_run.id}/",
+            url=f"/api/v0/plan-runs/{plan_run.id}/",
         )
 
     with (
@@ -195,7 +195,7 @@ def test_portia_cloud_storage() -> None:
             storage.get_plan_runs()
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/?",
+            url="/api/v0/plan-runs/?",
         )
 
     with (
@@ -206,7 +206,7 @@ def test_portia_cloud_storage() -> None:
             storage.save_tool_call(tool_call)
 
         mock_post.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/tool-calls/",
+            url="/api/v0/tool-calls/",
             json={
                 "plan_run_id": str(tool_call.plan_run_id),
                 "tool_name": tool_call.tool_name,
@@ -265,7 +265,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.get_plan(plan.id)
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plans/{plan.id}/",
+            url=f"/api/v0/plans/{plan.id}/",
         )
 
     with (
@@ -277,7 +277,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.save_plan_run(plan_run)
 
         mock_put.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/{plan_run.id}/",
+            url=f"/api/v0/plan-runs/{plan_run.id}/",
             json={
                 "current_step_index": plan_run.current_step_index,
                 "state": plan_run.state,
@@ -296,7 +296,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.get_plan_run(plan_run.id)
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/{plan_run.id}/",
+            url=f"/api/v0/plan-runs/{plan_run.id}/",
         )
 
     with (
@@ -308,7 +308,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.get_plan_runs()
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/?",
+            url="/api/v0/plan-runs/?",
         )
 
     with (
@@ -320,7 +320,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.get_plan_runs(run_state=PlanRunState.COMPLETE, page=10)
 
         mock_get.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plan-runs/?page=10&run_state=COMPLETE",
+            url="/api/v0/plan-runs/?page=10&run_state=COMPLETE",
         )
 
     with (
@@ -332,7 +332,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.save_tool_call(tool_call)
 
         mock_post.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/tool-calls/",
+            url="/api/v0/tool-calls/",
             json={
                 "plan_run_id": str(tool_call.plan_run_id),
                 "tool_name": tool_call.tool_name,

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -138,7 +138,7 @@ def test_portia_cloud_storage() -> None:
             storage.save_plan(plan)
 
         mock_post.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plans/",
+            url="/api/v0/plans/",
             json={
                 "id": str(plan.id),
                 "steps": [],
@@ -248,7 +248,7 @@ def test_portia_cloud_storage_errors() -> None:
             storage.save_plan(plan)
 
         mock_post.assert_called_once_with(
-            url=f"{config.portia_api_endpoint}/api/v0/plans/",
+            url="/api/v0/plans/",
             json={
                 "id": str(plan.id),
                 "steps": [],

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -183,8 +183,7 @@ def test_remote_tool_bad_response() -> None:
     """Test remote soft errors come back to soft errors."""
     mock_client = MagicMock(spec=httpx.Client)
     mock_response = MagicMock()
-    mock_response.raise_for_status.side_effect = Exception()
-    mock_response.json.return_value = {"output": {"value": "An error occurred."}}
+    mock_response.json.return_value = {"ot": {"value": "An error occurred."}}
     mock_client.post.return_value = mock_response
 
     tool = PortiaRemoteTool(
@@ -218,12 +217,15 @@ def test_remote_tool_hard_error() -> None:
     """Test remote hard errors come back to hard errors."""
     mock_client = MagicMock(spec=httpx.Client)
     mock_response = MagicMock()
-    mock_response.raise_for_status.side_effect = Exception()
-    mock_response.json.return_value = {"output": {"value": "An error occurred."}}
+    mock_response.json.return_value = {"output": {"value": "ToolHardError: An error occurred."}}
     mock_client.post.return_value = mock_response
 
     tool = PortiaRemoteTool(
-        id="test", name="test", description="", output_schema=("", ""), client=mock_client,
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
     )
 
     ctx = get_test_tool_context()

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -7,7 +7,7 @@ import mcp
 import pytest
 from httpx import Response
 from mcp import ClientSession
-from pydantic import BaseModel, HttpUrl, SecretStr
+from pydantic import BaseModel, HttpUrl
 
 from portia.clarification import (
     ActionClarification,
@@ -24,6 +24,7 @@ from tests.utils import (
     ClarificationTool,
     ErrorTool,
     MockMcpSessionWrapper,
+    get_test_config,
     get_test_tool_context,
 )
 
@@ -126,8 +127,7 @@ def test_remote_tool_hard_error_from_server() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
         ctx = get_test_tool_context()
         with pytest.raises(ToolHardError):
@@ -169,8 +169,7 @@ def test_remote_tool_soft_error() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -212,8 +211,7 @@ def test_remote_tool_bad_response() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -256,8 +254,7 @@ def test_remote_tool_hard_error() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -299,8 +296,7 @@ def test_remote_tool_ready() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
         ctx = get_test_tool_context()
         assert tool.ready(ctx)
@@ -342,8 +338,7 @@ def test_remote_tool_ready_error() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -395,8 +390,7 @@ def test_remote_tool_action_clarifications() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
         ctx = get_test_tool_context()
         output = tool.run(ctx)
@@ -451,8 +445,7 @@ def test_remote_tool_input_clarifications() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -508,8 +501,7 @@ def test_remote_tool_mc_clarifications() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -565,8 +557,7 @@ def test_remote_tool_value_confirm_clarifications() -> None:
             name="test",
             description="",
             output_schema=("", ""),
-            api_key=SecretStr(""),
-            api_endpoint="https://example.com",
+            config=get_test_config(),
         )
 
         ctx = get_test_tool_context()
@@ -613,7 +604,9 @@ def test_portia_mcp_tool_call() -> None:
         output_schema=("str", "Tool output formatted as a JSON string"),
         args_schema=TestArgSchema,
         mcp_client_config=StdioMcpClientConfig(
-            server_name="mock_mcp", command="test", args=["test"],
+            server_name="mock_mcp",
+            command="test",
+            args=["test"],
         ),
     )
     expected = (
@@ -622,7 +615,8 @@ def test_portia_mcp_tool_call() -> None:
     )
 
     with patch(
-        "portia.tool.get_mcp_session", new=MockMcpSessionWrapper(mock_session).mock_mcp_session,
+        "portia.tool.get_mcp_session",
+        new=MockMcpSessionWrapper(mock_session).mock_mcp_session,
     ):
         tool_result = tool.run(get_test_tool_context(), a=1, b=2)
         assert tool_result == expected
@@ -647,11 +641,17 @@ def test_portia_mcp_tool_call_with_error() -> None:
         output_schema=("str", "Tool output formatted as a JSON string"),
         args_schema=TestArgSchema,
         mcp_client_config=StdioMcpClientConfig(
-            server_name="mock_mcp", command="test", args=["test"],
+            server_name="mock_mcp",
+            command="test",
+            args=["test"],
         ),
     )
 
-    with patch(
-        "portia.tool.get_mcp_session", new=MockMcpSessionWrapper(mock_session).mock_mcp_session,
-    ), pytest.raises(ToolHardError):
+    with (
+        patch(
+            "portia.tool.get_mcp_session",
+            new=MockMcpSessionWrapper(mock_session).mock_mcp_session,
+        ),
+        pytest.raises(ToolHardError),
+    ):
         tool.run(get_test_tool_context(), a=1, b=2)

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -3,9 +3,9 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import mcp
 import pytest
-from httpx import Response
 from mcp import ClientSession
 from pydantic import BaseModel, HttpUrl
 
@@ -24,7 +24,6 @@ from tests.utils import (
     ClarificationTool,
     ErrorTool,
     MockMcpSessionWrapper,
-    get_test_config,
     get_test_tool_context,
 )
 
@@ -112,262 +111,209 @@ def test_tool_serialization() -> None:
 
 def test_remote_tool_hard_error_from_server() -> None:
     """Test http errors come back to hard errors."""
+    mock_client = MagicMock(spec=httpx.Client)
     mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock(
-        side_effect=Exception(),
-    )
-    mock_response.json = MagicMock(
-        return_value={"output": {"value": "An error occurred."}},
-    )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
-        ctx = get_test_tool_context()
-        with pytest.raises(ToolHardError):
-            tool.run(ctx)
+    mock_response.raise_for_status.side_effect = Exception()
+    mock_response.json.return_value = {"output": {"value": "An error occurred."}}
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    mock_client.post.return_value = mock_response
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
+    ctx = get_test_tool_context()
+    with pytest.raises(ToolHardError):
+        tool.run(ctx)
+
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_soft_error() -> None:
     """Test remote soft errors come back to soft errors."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={"output": {"value": "ToolSoftError: An error occurred."}},
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
+    mock_client.post.return_value = mock_response
 
-        ctx = get_test_tool_context()
-        with pytest.raises(ToolSoftError):
-            tool.run(ctx)
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    ctx = get_test_tool_context()
+    with pytest.raises(ToolSoftError):
+        tool.run(ctx)
+
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_bad_response() -> None:
     """Test remote soft errors come back to soft errors."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json = MagicMock(
-        return_value={"not_output": {"value": "ToolSoftError: An error occurred."}},
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = Exception()
+    mock_response.json.return_value = {"output": {"value": "An error occurred."}}
+    mock_client.post.return_value = mock_response
+
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
 
-        ctx = get_test_tool_context()
-        with pytest.raises(ToolHardError):
-            tool.run(ctx)
+    ctx = get_test_tool_context()
+    with pytest.raises(ToolHardError):
+        tool.run(ctx)
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_hard_error() -> None:
     """Test remote hard errors come back to hard errors."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json = MagicMock(
-        return_value={"output": {"value": "ToolHardError: An error occurred."}},
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = Exception()
+    mock_response.json.return_value = {"output": {"value": "An error occurred."}}
+    mock_client.post.return_value = mock_response
+
+    tool = PortiaRemoteTool(
+        id="test", name="test", description="", output_schema=("", ""), client=mock_client,
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
 
-        ctx = get_test_tool_context()
-        with pytest.raises(ToolHardError):
-            tool.run(ctx)
+    ctx = get_test_tool_context()
+    with pytest.raises(ToolHardError):
+        tool.run(ctx)
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_ready() -> None:
     """Test remote tool ready."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={"success": "true"},
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
-        ctx = get_test_tool_context()
-        assert tool.ready(ctx)
+    mock_client.post.return_value = mock_response
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
+    ctx = get_test_tool_context()
+    assert tool.ready(ctx)
 
-        content = {
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    content = {
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/ready/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/ready/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_ready_error() -> None:
     """Test remote tool ready."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = False
-    mock_response.raise_for_status = MagicMock(
-        side_effect=Exception(),
-    )
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = Exception()
     mock_response.json = MagicMock(
         return_value={"success": "true"},
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
+    mock_client.post.return_value = mock_response
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
 
-        ctx = get_test_tool_context()
-        assert not tool.ready(ctx)
+    ctx = get_test_tool_context()
+    assert not tool.ready(ctx)
 
-        content = {
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    content = {
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/ready/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/ready/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_action_clarifications() -> None:
     """Test action clarifications."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={
             "output": {
@@ -382,47 +328,40 @@ def test_remote_tool_action_clarifications() -> None:
             },
         },
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
-        ctx = get_test_tool_context()
-        output = tool.run(ctx)
-        assert output is not None
-        assert isinstance(output, ActionClarification)
-        assert output.action_url == HttpUrl("https://example.com")
+    mock_client.post.return_value = mock_response
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
+    ctx = get_test_tool_context()
+    output = tool.run(ctx)
+    assert output is not None
+    assert isinstance(output, ActionClarification)
+    assert output.action_url == HttpUrl("https://example.com")
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_input_clarifications() -> None:
     """Test Input clarifications."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={
             "output": {
@@ -437,47 +376,40 @@ def test_remote_tool_input_clarifications() -> None:
             },
         },
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
+    mock_client.post.return_value = mock_response
 
-        ctx = get_test_tool_context()
-        output = tool.run(ctx)
-        assert output is not None
-        assert isinstance(output, InputClarification)
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    ctx = get_test_tool_context()
+    output = tool.run(ctx)
+    assert output is not None
+    assert isinstance(output, InputClarification)
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_mc_clarifications() -> None:
     """Test Multi Choice clarifications."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={
             "output": {
@@ -493,48 +425,41 @@ def test_remote_tool_mc_clarifications() -> None:
             },
         },
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
+    mock_client.post.return_value = mock_response
 
-        ctx = get_test_tool_context()
-        output = tool.run(ctx)
-        assert output is not None
-        assert isinstance(output, MultipleChoiceClarification)
-        assert output.options == [1]
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    ctx = get_test_tool_context()
+    output = tool.run(ctx)
+    assert output is not None
+    assert isinstance(output, MultipleChoiceClarification)
+    assert output.options == [1]
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_remote_tool_value_confirm_clarifications() -> None:
     """Test value confirm clarifications."""
-    mock_response = MagicMock(spec=Response)
-    mock_response.is_success = True
-    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock()
     mock_response.json = MagicMock(
         return_value={
             "output": {
@@ -549,40 +474,34 @@ def test_remote_tool_value_confirm_clarifications() -> None:
             },
         },
     )
-    with (
-        patch("httpx.post", return_value=mock_response) as mock_post,
-    ):
-        tool = PortiaRemoteTool(
-            id="test",
-            name="test",
-            description="",
-            output_schema=("", ""),
-            config=get_test_config(),
-        )
+    mock_client.post.return_value = mock_response
 
-        ctx = get_test_tool_context()
-        output = tool.run(ctx)
-        assert output is not None
-        assert isinstance(output, ValueConfirmationClarification)
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=mock_client,
+    )
 
-        content = {
-            "arguments": {},
-            "execution_context": {
-                "end_user_id": ctx.execution_context.end_user_id or "",
-                "plan_run_id": str(ctx.plan_run_id),
-                "additional_data": ctx.execution_context.additional_data or {},
-            },
-        }
+    ctx = get_test_tool_context()
+    output = tool.run(ctx)
+    assert output is not None
+    assert isinstance(output, ValueConfirmationClarification)
 
-        mock_post.assert_called_once_with(
-            url="https://example.com/api/v0/tools/test/run/",
-            content=json.dumps(content),
-            headers={
-                "Authorization": "Api-Key ",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+    content = {
+        "arguments": {},
+        "execution_context": {
+            "end_user_id": ctx.execution_context.end_user_id or "",
+            "plan_run_id": str(ctx.plan_run_id),
+            "additional_data": ctx.execution_context.additional_data or {},
+        },
+    }
+
+    mock_client.post.assert_called_once_with(
+        url="/api/v0/tools/test/run/",
+        content=json.dumps(content),
+    )
 
 
 def test_portia_mcp_tool_call() -> None:


### PR DESCRIPTION
By using a single HTTPX client for all cloud operations we can limit on the SDK side concurrent requests. This fixes the concurrency issues we are having.