### PR TITLE
Limit testing workflow time to 10 minutes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   testing:
+    timeout-minutes: 10
     runs-on: ubuntu-latest-16core
     steps:
       - name: Checkout code

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -449,7 +449,7 @@ class McpToolRegistry(ToolRegistry):
         )
 
     @classmethod
-    def from_stdio_connection(  # noqa: PLR0913g
+    def from_stdio_connection(  # noqa: PLR0913
         cls,
         server_name: str,
         command: str,


### PR DESCRIPTION
During cost exploration, I found that part of the issue was a [workflow from the MCP branch](https://github.com/portiaAI/portia-sdk-python/actions/runs/13794105351) that took 6 hours 😬 !

The tests will normally take under 5 minutes if there is nothing wrong