### PR TITLE
Limit instructor version to be less than 1.7.5 (latest-but-one) due to broken import check

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1008,14 +1008,14 @@ files = [
 
 [[package]]
 name = "instructor"
-version = "1.7.5"
+version = "1.7.4"
 description = "structured outputs for llm"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "instructor-1.7.5-py3-none-any.whl", hash = "sha256:72bfd07a5a1437510661f6b6caac067d8948e6ef71bca11df030b0328e90a2a0"},
-    {file = "instructor-1.7.5.tar.gz", hash = "sha256:ec91ca0a4c772740f3f8f0b25e9f21d395375d0b5cc754f0adb66a49f418e6df"},
+    {file = "instructor-1.7.4-py3-none-any.whl", hash = "sha256:634c4fd7c05801baeac1eb6a6a9068240422fffa6e3dca3a51658dcb29ac068a"},
+    {file = "instructor-1.7.4.tar.gz", hash = "sha256:1919808f8ba007e58b0306688f26620347e09a86a922119263ca2ca944b60bca"},
 ]
 
 [package.dependencies]
@@ -1037,12 +1037,11 @@ bedrock = ["boto3 (>=1.34.0,<2.0.0)"]
 cerebras-cloud-sdk = ["cerebras-cloud-sdk (>=1.5.0,<2.0.0)"]
 cohere = ["cohere (>=5.1.8,<6.0.0)"]
 fireworks-ai = ["fireworks-ai (>=0.15.4,<1.0.0)"]
-google-genai = ["google-genai (>=1.5.0)", "jsonref (>=1.1.0,<2.0.0)"]
 google-generativeai = ["google-generativeai (>=0.8.2,<1.0.0)", "jsonref (>=1.1.0,<2.0.0)"]
 groq = ["groq (>=0.4.2,<0.14.0)"]
-mistral = ["mistralai (>=1.5.1,<2.0.0)"]
+mistral = ["mistralai (>=1.0.3,<2.0.0)"]
 perplexity = ["openai (>=1.52.0,<2.0.0)"]
-test-docs = ["diskcache (>=5.6.3,<6.0.0)", "fastapi (>=0.109.2,<0.116.0)", "litellm (>=1.35.31,<2.0.0)", "mistralai (>=1.5.1,<2.0.0)", "pandas (>=2.2.0,<3.0.0)", "pydantic-extra-types (>=2.6.0,<3.0.0)", "redis (>=5.0.1,<6.0.0)", "tabulate (>=0.9.0,<1.0.0)"]
+test-docs = ["diskcache (>=5.6.3,<6.0.0)", "fastapi (>=0.109.2,<0.116.0)", "litellm (>=1.35.31,<2.0.0)", "mistralai (>=1.0.3,<2.0.0)", "pandas (>=2.2.0,<3.0.0)", "pydantic-extra-types (>=2.6.0,<3.0.0)", "redis (>=5.0.1,<6.0.0)", "tabulate (>=0.9.0,<1.0.0)"]
 vertexai = ["google-cloud-aiplatform (>=1.53.0,<2.0.0)", "jsonref (>=1.1.0,<2.0.0)"]
 writer = ["writer-sdk (>=1.2.0,<2.0.0)"]
 
@@ -3552,4 +3551,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "188baf48ad7b4bd22f743fb070c4594bda7c9e5afc275699c3bfc48981982fd3"
+content-hash = "8ba843e301597d8271cb35c05f0d51967c4b2e3eb1d1ff7a14cafed8aa26f791"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 python = ">=3.11,<4.0"
 pydantic = "^2.10.3"
 jinja2 = "^3.1.4"
-instructor = ">=1.7.0,<1.7.6"
+instructor = ">=1.7.0,<1.7.5"
 anthropic = "^0.40.0"
 langchain-anthropic = "^0.3.0"
 langchain-core = "^0.3.25"


### PR DESCRIPTION


# Description
🤦 
It appears I was over-optimistic about rolling back - 1.7.5 is broken too, it appears 1.7.6 issue was an attempted bug fix

Author of release is fixing this now https://github.com/instructor-ai/instructor/issues/1416

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
