### PR TITLE
Plan with cloud tools on error

### DIFF
--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -11,14 +11,15 @@ class PortiaCloudClient:
     _client = None
 
     @classmethod
-    def get_client(cls, config: Config, allow_unauthenticated: bool = False) -> httpx.Client:
+    def get_client(cls, config: Config, *, allow_unauthenticated: bool = False) -> httpx.Client:
         """Return the client using a singleton pattern to help manage limits across the SDK."""
         if cls._client is None:
             headers = {
                 "Content-Type": "application/json",
             }
             if config.portia_api_key is not None or allow_unauthenticated is False:
-                headers["Authorization"] = f"Api-Key {config.must_get_api_key('portia_api_key').get_secret_value()}"
+                api_key = config.must_get_api_key("portia_api_key").get_secret_value()
+                headers["Authorization"] = f"Api-Key {api_key}"
             cls._client = httpx.Client(
                 base_url=config.must_get("portia_api_endpoint", str),
                 headers=headers,

--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -17,7 +17,7 @@ class PortiaCloudClient:
             headers = {
                 "Content-Type": "application/json",
             }
-            if config.portia_api_key is not None or allow_unauthenticated is False:
+            if config.portia_api_key or allow_unauthenticated is False:
                 api_key = config.must_get_api_key("portia_api_key").get_secret_value()
                 headers["Authorization"] = f"Api-Key {api_key}"
             cls._client = httpx.Client(

--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -11,19 +11,24 @@ class PortiaCloudClient:
     _client = None
 
     @classmethod
-    def get_client(cls, config: Config, *, allow_unauthenticated: bool = False) -> httpx.Client:
+    def get_client(cls, config: Config) -> httpx.Client:
         """Return the client using a singleton pattern to help manage limits across the SDK."""
         if cls._client is None:
-            headers = {
-                "Content-Type": "application/json",
-            }
-            if config.portia_api_key or allow_unauthenticated is False:
-                api_key = config.must_get_api_key("portia_api_key").get_secret_value()
-                headers["Authorization"] = f"Api-Key {api_key}"
-            cls._client = httpx.Client(
-                base_url=config.must_get("portia_api_endpoint", str),
-                headers=headers,
-                timeout=httpx.Timeout(60),
-                limits=httpx.Limits(max_connections=10),
-            )
+            cls._client = cls.new_client(config, allow_unauthenticated=False)
         return cls._client
+
+    @classmethod
+    def new_client(cls, config: Config, *, allow_unauthenticated: bool = False) -> httpx.Client:
+        """Create a new httpx client."""
+        headers = {
+                "Content-Type": "application/json",
+        }
+        if config.portia_api_key or allow_unauthenticated is False:
+            api_key = config.must_get_api_key("portia_api_key").get_secret_value()
+            headers["Authorization"] = f"Api-Key {api_key}"
+        return httpx.Client(
+            base_url=config.must_get("portia_api_endpoint", str),
+            headers=headers,
+            timeout=httpx.Timeout(60),
+            limits=httpx.Limits(max_connections=10),
+        )

--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -19,7 +19,13 @@ class PortiaCloudClient:
 
     @classmethod
     def new_client(cls, config: Config, *, allow_unauthenticated: bool = False) -> httpx.Client:
-        """Create a new httpx client."""
+        """Create a new httpx client.
+
+        Args:
+            config (Config): The Portia Configuration instance, containing the API key and endpoint.
+            allow_unauthenticated (bool): Whether to allow creation of an unauthenticated client.
+
+        """
         headers = {
                 "Content-Type": "application/json",
         }

--- a/portia/cloud.py
+++ b/portia/cloud.py
@@ -11,16 +11,17 @@ class PortiaCloudClient:
     _client = None
 
     @classmethod
-    def get_client(cls, config: Config) -> httpx.Client:
+    def get_client(cls, config: Config, allow_unauthenticated: bool = False) -> httpx.Client:
         """Return the client using a singleton pattern to help manage limits across the SDK."""
         if cls._client is None:
-            api_key = config.must_get_api_key("portia_api_key").get_secret_value()
+            headers = {
+                "Content-Type": "application/json",
+            }
+            if config.portia_api_key is not None or allow_unauthenticated is False:
+                headers["Authorization"] = f"Api-Key {config.must_get_api_key('portia_api_key').get_secret_value()}"
             cls._client = httpx.Client(
                 base_url=config.must_get("portia_api_endpoint", str),
-                headers={
-                    "Authorization": f"Api-Key {api_key}",
-                    "Content-Type": "application/json",
-                },
+                headers=headers,
                 timeout=httpx.Timeout(60),
                 limits=httpx.Limits(max_connections=10),
             )

--- a/portia/config.py
+++ b/portia/config.py
@@ -287,7 +287,7 @@ class Config(BaseModel):
         description="The URL for the Portia Cloud Dashboard",
     )
     portia_api_key: SecretStr | None = Field(
-        default_factory=lambda: SecretStr(os.getenv("PORTIA_API_KEY") or ""),
+        default_factory=lambda: SecretStr(os.environ["PORTIA_API_KEY"]) if "PORTIA_API_KEY" in os.environ else None,
         description="The API Key for the Portia Cloud API available from the dashboard at https://app.portialabs.ai",
     )
 

--- a/portia/config.py
+++ b/portia/config.py
@@ -287,7 +287,11 @@ class Config(BaseModel):
         description="The URL for the Portia Cloud Dashboard",
     )
     portia_api_key: SecretStr | None = Field(
-        default_factory=lambda: SecretStr(os.environ["PORTIA_API_KEY"]) if "PORTIA_API_KEY" in os.environ else None,
+        default_factory=lambda: (
+            SecretStr(os.environ["PORTIA_API_KEY"])
+            if "PORTIA_API_KEY" in os.environ
+            else None
+        ),
         description="The API Key for the Portia Cloud API available from the dashboard at https://app.portialabs.ai",
     )
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -709,22 +709,18 @@ class Portia:
         example_plans: list[Plan] | None = None,
     ) -> None:
         """Generate a plan using Portia cloud tools for users who's plans fail without them."""
-        try: # This steps is optional and if it fails we don't want to exit with an error
-            cloud_registry = (
-                self.tool_registry
-                + PortiaToolRegistry.with_default_tool_filter(self.config)
-            )
-            tools = cloud_registry.match_tools(query)
-            planning_agent = self._get_planning_agent()
-            replan_outcome = planning_agent.generate_steps_or_error(
-                ctx=get_execution_context(),
-                query=query,
-                tool_list=tools,
-                examples=example_plans,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger().debug(f"Error generating plan with Portia cloud tools: {e}")
-            return
+        cloud_registry = (
+            self.tool_registry
+            + PortiaToolRegistry.with_default_tool_filter(self.config)
+        )
+        tools = cloud_registry.match_tools(query)
+        planning_agent = self._get_planning_agent()
+        replan_outcome = planning_agent.generate_steps_or_error(
+            ctx=get_execution_context(),
+            query=query,
+            tool_list=tools,
+            examples=example_plans,
+        )
         if not replan_outcome.error:
             tools_used = ", ".join([str(step.tool_id) for step in replan_outcome.steps])
             logger().error(

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -841,7 +841,7 @@ class Portia:
         """Generate a plan using Portia cloud tools for users who's plans fail without them."""
         cloud_registry = (
             self.tool_registry
-            + PortiaToolRegistry.with_default_tool_filter(self.config)
+            + PortiaToolRegistry.with_unauthenticated_client(self.config)
         )
         tools = cloud_registry.match_tools(query)
         planning_agent = self._get_planning_agent()

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -331,6 +331,7 @@ class PortiaToolRegistry(ToolRegistry):
 
     This class interacts with the Portia API to retrieve and manage tools.
     """
+
     EXCLUDED_BY_DEFAULT_TOOL_REGEXS: frozenset[str] = frozenset(
         {
             # Exclude Outlook by default as it clashes with Gmail
@@ -356,12 +357,16 @@ class PortiaToolRegistry(ToolRegistry):
         self.tools = tools or self._load_tools()
 
     @classmethod
-    def with_default_tool_filter(cls, config: Config) -> PortiaToolRegistry:
+    def with_default_tool_filter(cls, config: Config) -> ToolRegistry:
         """Create a PortiaToolRegistry with a default tool filter."""
         def default_tool_filter(tool: Tool) -> bool:
             """Filter to get the default set of tools offered by Portia cloud."""
-            return not any(re.match(regex, tool.id) for regex in cls.EXCLUDED_BY_DEFAULT_TOOL_REGEXS)
-        return cls(config, tools=None).filter_tools(default_tool_filter)
+            return not any(
+                re.match(regex, tool.id)
+                for regex
+                in cls.EXCLUDED_BY_DEFAULT_TOOL_REGEXS
+            )
+        return PortiaToolRegistry(config).filter_tools(default_tool_filter)
 
     def _load_tools(self) -> dict[str, Tool]:
         """Load the tools from the API into the into the internal storage."""

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -353,7 +353,7 @@ class PortiaToolRegistry(ToolRegistry):
 
         """
         self.config = config
-        self.client = PortiaCloudClient().get_client(config, allow_unauthenticated=True)
+        self.client = PortiaCloudClient().get_client(config)
         self.tools = tools or self._load_tools()
 
     @classmethod
@@ -367,6 +367,14 @@ class PortiaToolRegistry(ToolRegistry):
                 in cls.EXCLUDED_BY_DEFAULT_TOOL_REGEXS
             )
         return PortiaToolRegistry(config).filter_tools(default_tool_filter)
+
+    @classmethod
+    def with_unauthenticated_client(cls, config: Config) -> ToolRegistry:
+        """Create a PortiaToolRegistry with an unauthenticated client."""
+        registry = PortiaToolRegistry.with_default_tool_filter(config)
+        if isinstance(registry, PortiaToolRegistry):
+            registry.client = PortiaCloudClient.new_client(config, allow_unauthenticated=True)
+        return registry
 
     def _load_tools(self) -> dict[str, Tool]:
         """Load the tools from the API into the into the internal storage."""

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -11,7 +11,7 @@ from pydantic import HttpUrl
 from portia.clarification import ActionClarification, Clarification, InputClarification
 from portia.clarification_handler import ClarificationHandler
 from portia.config import Config, ExecutionAgentType, LLMModel, LLMProvider, LogLevel, StorageClass
-from portia.errors import ToolSoftError
+from portia.errors import PlanError, ToolSoftError
 from portia.open_source_tools.registry import example_tool_registry
 from portia.plan import Plan, PlanContext, Step, Variable
 from portia.plan_run import PlanRunState
@@ -525,3 +525,15 @@ def test_portia_run_query_with_example_registry() -> None:
 
     plan_run = portia.run(query)
     assert plan_run.state == PlanRunState.COMPLETE
+
+
+def test_portia_run_query_requiring_cloud_tools_not_authenticated() -> None:
+    """Test that running a query requiring cloud tools fails but points user to sign up."""
+    config = Config.from_default(portia_api_key=None, storage_class=StorageClass.MEMORY)
+
+    portia = Portia(config=config)
+    query = "Send an email to John Doe"
+
+    with pytest.raises(PlanError) as e:
+        portia.plan(query)
+    assert "PORTIA_API_KEY is required to use Portia cloud tools." in str(e.value)


### PR DESCRIPTION
# Description

Based on user feedback

If you haven't got an API key set then the planner can fail when building more than a trivial plan because the tools available are limited.

This PR introduces a log message that only gets triggered if:
- the user has no API key
- the Plan generation fails
- the replan with Portia cloud tools does not fail

[Ticket Link](https://linear.app/portialabs/issue/POR-829)

## Type of change

(select all that apply)

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [x] Documentation update

## Screenshots

```python
from portia import Portia, Config

portia = Portia(config=Config(portia_api_endpoint="https://api.porita.dev"))
portia.run("Send an email to example@example.com about farm yard animals")
```

Results in 
<img width="994" alt="image" src="https://github.com/user-attachments/assets/ca5b1100-fda4-43d7-8a84-5fba48339d25" />


## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
