### PR TITLE
Move mistral to optional / extras dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Portia SDK! We welcome contributi
 
 1. **Fork the Repository**: Start by forking the repository and cloning it locally.
 2. **Create a Branch**: Create a branch for your feature or bug fix. Use a descriptive name for your branch (e.g., `fix-typo`, `add-feature-x`).
-3. **Install the dependencies** We use Poetry to manage dependencies. Run ``poetry install``
+3. **Install the dependencies** We use Poetry to manage dependencies. Run ``poetry install --all-extras``
 4. **Make Your Changes**: Implement your changes in small, focused commits. Be sure to follow our linting rules and style guide.
 5. **Run Tests**: If your changes affect functionality, please test thoroughly 🌡️ Details on how run tests are in the **Tests** section below.
 6. **Lint Your Code**: We use [ruff](https://github.com/charliermarsh/ruff) for linting. Please ensure your code passes all linting checks. We prefer per-line disables for rules rather than global ignores, and please leave comments explaining why you disable any rules.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ python --version
 ```bash
 pip install portia-sdk-python 
 ```
+
+>[!NOTE]
+> OpenAI and Anthropic dependencies are included by default. We also provide the following extras:<br/>
+> * Mistral: `portia-sdk-python[mistral]`
+
 2. Ensure you have an API key set up
 ```bash
 export OPENAI_API_KEY='your-api-key-here'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install portia-sdk-python
 
 >[!NOTE]
 > OpenAI and Anthropic dependencies are included by default. We also provide the following extras:<br/>
-> * Mistral: `portia-sdk-python[mistral]`
+> * **MistralAI**: `portia-sdk-python[mistral]`
 
 2. Ensure you have an API key set up
 ```bash

--- a/poetry.lock
+++ b/poetry.lock
@@ -584,9 +584,10 @@ files = [
 name = "eval-type-backport"
 version = "0.2.2"
 description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a"},
     {file = "eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1"},
@@ -621,6 +622,7 @@ files = [
     {file = "filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"},
     {file = "filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"},
 ]
+markers = {main = "extra == \"mistral\""}
 
 [package.extras]
 docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
@@ -733,9 +735,10 @@ files = [
 name = "fsspec"
 version = "2025.3.0"
 description = "File-system specification"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3"},
     {file = "fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972"},
@@ -933,9 +936,10 @@ files = [
 name = "huggingface-hub"
 version = "0.29.3"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "huggingface_hub-0.29.3-py3-none-any.whl", hash = "sha256:0b25710932ac649c08cdbefa6c6ccb8e88eef82927cacdb048efb726429453aa"},
     {file = "huggingface_hub-0.29.3.tar.gz", hash = "sha256:64519a25716e0ba382ba2d3fb3ca082e7c7eb4a2fc634d200e8380006e0760e5"},
@@ -1169,9 +1173,10 @@ jsonpointer = ">=1.9"
 name = "jsonpath-python"
 version = "1.0.6"
 description = "A more powerful JSONPath implementation in modern python"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "jsonpath-python-1.0.6.tar.gz", hash = "sha256:dd5be4a72d8a2995c3f583cf82bf3cd1a9544cfdabf2d22595b67aff07349666"},
     {file = "jsonpath_python-1.0.6-py3-none-any.whl", hash = "sha256:1e3b78df579f5efc23565293612decee04214609208a2335884b3ee3f786b575"},
@@ -1247,14 +1252,14 @@ pydantic = ">=2.7.4,<3.0.0"
 
 [[package]]
 name = "langchain-core"
-version = "0.3.45"
+version = "0.3.47"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "langchain_core-0.3.45-py3-none-any.whl", hash = "sha256:fe560d644c102c3f5dcfb44eb5295e26d22deab259fdd084f6b1b55a0350b77c"},
-    {file = "langchain_core-0.3.45.tar.gz", hash = "sha256:a39b8446495d1ea97311aa726478c0a13ef1d77cb7644350bad6d9d3c0141a0c"},
+    {file = "langchain_core-0.3.47-py3-none-any.whl", hash = "sha256:ef7c78202e6fd9df79fe8128c828d08a95d3878cf4aec282580baf358a3f2ec5"},
+    {file = "langchain_core-0.3.47.tar.gz", hash = "sha256:975a3daabf8e8d583749b3c553cc412d0527d935dfe820317431b475fa0c585a"},
 ]
 
 [package.dependencies]
@@ -1271,20 +1276,21 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langchain-mistralai"
-version = "0.2.8"
+version = "0.2.9"
 description = "An integration package connecting Mistral and LangChain"
-optional = false
+optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
-    {file = "langchain_mistralai-0.2.8-py3-none-any.whl", hash = "sha256:2d081b1a22d4588508c737492c62713ece14646d02168ebe06ca1060866a9318"},
-    {file = "langchain_mistralai-0.2.8.tar.gz", hash = "sha256:fbeee35d559999fb28fd831683602706b6ba49a4ee5235d4e292dce01f40a700"},
+    {file = "langchain_mistralai-0.2.9-py3-none-any.whl", hash = "sha256:106a65f1771dc41c2c9a00a305f1d03fcbe16f0d4f640b6c634f35780b711aaf"},
+    {file = "langchain_mistralai-0.2.9.tar.gz", hash = "sha256:ad88a4ded5d53fef781309485da6c6bdf217fadb9dfb41f5c9ad0ea2835d2b74"},
 ]
 
 [package.dependencies]
 httpx = ">=0.25.2,<1"
 httpx-sse = ">=0.3.1,<1"
-langchain-core = ">=0.3.45,<1.0.0"
+langchain-core = ">=0.3.47,<1.0.0"
 pydantic = ">=2,<3"
 tokenizers = ">=0.15.1,<1"
 
@@ -1554,14 +1560,15 @@ files = [
 
 [[package]]
 name = "mistralai"
-version = "1.5.1"
+version = "1.5.2"
 description = "Python Client SDK for the Mistral AI API."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
-    {file = "mistralai-1.5.1-py3-none-any.whl", hash = "sha256:881f8a1b9a7966d15bd1eb4ed05df09483c261f826c1b9d153ceeca605dc79ac"},
-    {file = "mistralai-1.5.1.tar.gz", hash = "sha256:ce4b8c7aa587521c46dbc45d42e27575f6197c0229f47242e5b331875104707b"},
+    {file = "mistralai-1.5.2-py3-none-any.whl", hash = "sha256:5b1112acebbcad1afd7732ce0bd60614975b64999801c555c54768ac41f506ae"},
+    {file = "mistralai-1.5.2.tar.gz", hash = "sha256:f39e6e51e8939aac2602e4badcb18712cbee2df33d86100c559333e609b92d17"},
 ]
 
 [package.dependencies]
@@ -1755,9 +1762,10 @@ files = [
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
+optional = true
 python-versions = ">=3.5"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
@@ -3121,9 +3129,10 @@ blobfile = ["blobfile (>=2)"]
 name = "tokenizers"
 version = "0.21.1"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "tokenizers-0.21.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e78e413e9e668ad790a29456e677d9d3aa50a9ad311a40905d6861ba7692cf41"},
     {file = "tokenizers-0.21.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:cd51cd0a91ecc801633829fcd1fda9cf8682ed3477c6243b9a095539de4aecf3"},
@@ -3206,9 +3215,10 @@ files = [
 name = "typing-inspect"
 version = "0.9.0"
 description = "Runtime inspection utilities for typing module."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"mistral\""
 files = [
     {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
     {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
@@ -3529,7 +3539,10 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 [package.extras]
 cffi = ["cffi (>=1.11)"]
 
+[extras]
+mistral = ["langchain-mistralai", "mistralai"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "73975d770aafaec50d1aeb940ad2a62578383a6a4e3cfcef096a678f003fa6c9"
+content-hash = "959326842b6aee8894d86e6595dc54e847189d9b10719639f6bef98d04c634cc"

--- a/portia/common.py
+++ b/portia/common.py
@@ -7,6 +7,7 @@ use in the Portia framework.
 
 from __future__ import annotations
 
+import importlib.util
 from enum import Enum
 from typing import Any, TypeVar
 
@@ -52,3 +53,9 @@ def combine_args_kwargs(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
     """
     args_dict = {f"{i}": arg for i, arg in enumerate(args)}
     return {**args_dict, **kwargs}
+
+
+def is_library_installed(library_name: str) -> bool:
+    """Check if a library is installed without importing it."""
+    spec = importlib.util.find_spec(library_name)
+    return spec is not None

--- a/portia/common.py
+++ b/portia/common.py
@@ -7,7 +7,6 @@ use in the Portia framework.
 
 from __future__ import annotations
 
-import importlib.util
 from enum import Enum
 from typing import Any, TypeVar
 
@@ -53,9 +52,3 @@ def combine_args_kwargs(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
     """
     args_dict = {f"{i}": arg for i, arg in enumerate(args)}
     return {**args_dict, **kwargs}
-
-
-def is_library_installed(library_name: str) -> bool:
-    """Check if a library is installed without importing it."""
-    spec = importlib.util.find_spec(library_name)
-    return spec is not None

--- a/portia/config.py
+++ b/portia/config.py
@@ -8,6 +8,7 @@ config files and default settings.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from enum import Enum
 from pathlib import Path
@@ -40,6 +41,28 @@ class StorageClass(Enum):
     MEMORY = "MEMORY"
     DISK = "DISK"
     CLOUD = "CLOUD"
+
+
+EXTRAS_GROUPS_DEPENDENCIES = {
+    "mistral": ["mistralai", "langchain_mistralai"],
+}
+
+def validate_extras_dependencies(extra_group: str) -> None:
+    """Validate that the dependencies for an extras group are installed.
+
+    Provide a helpful error message if not all dependencies are installed.
+    """
+    def package_installed(package: str) -> bool:
+        try:
+            return importlib.util.find_spec(package) is not None
+        except ImportError:
+            pass
+        return False
+
+    if not all(package_installed(p) for p in EXTRAS_GROUPS_DEPENDENCIES[extra_group]):
+        raise ImportError(
+            f"Please install portia-sdk-python[{extra_group}] to use this functionality.",
+        )
 
 
 class LLMProvider(Enum):

--- a/portia/execution_context.py
+++ b/portia/execution_context.py
@@ -20,8 +20,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
-from mistralai import Field
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/portia/llm_wrapper.py
+++ b/portia/llm_wrapper.py
@@ -26,10 +26,8 @@ from typing import TYPE_CHECKING, TypeVar
 import instructor
 from anthropic import Anthropic
 from langchain_anthropic import ChatAnthropic
-from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
 from langsmith import wrappers
-from mistralai import Mistral
 from openai import OpenAI
 from pydantic import BaseModel, SecretStr
 
@@ -184,6 +182,8 @@ class LLMWrapper(BaseLLMWrapper):
                     api_key=self.api_key,
                 )
             case LLMProvider.MISTRALAI:
+                from langchain_mistralai import ChatMistralAI
+
                 return ChatMistralAI(
                     model_name=self.model_name.value,
                     api_key=self.api_key,
@@ -237,6 +237,8 @@ class LLMWrapper(BaseLLMWrapper):
                     max_tokens=2048,
                 )
             case LLMProvider.MISTRALAI:
+                from mistralai import Mistral
+
                 client = instructor.from_mistral(
                     client=Mistral(
                         api_key=self.api_key.get_secret_value(),

--- a/portia/llm_wrapper.py
+++ b/portia/llm_wrapper.py
@@ -31,8 +31,7 @@ from langsmith import wrappers
 from openai import OpenAI
 from pydantic import BaseModel, SecretStr
 
-from portia.common import is_library_installed
-from portia.config import Config, LLMModel, LLMProvider
+from portia.config import Config, LLMModel, LLMProvider, validate_extras_dependencies
 
 if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import (
@@ -183,11 +182,7 @@ class LLMWrapper(BaseLLMWrapper):
                     api_key=self.api_key,
                 )
             case LLMProvider.MISTRALAI:
-                if not is_library_installed("langchain_mistralai"):
-                    raise ImportError(
-                        "mistralai extension is not installed. Please install "
-                        "portia-sdk-python[mistral] to use MistralAI models.",
-                    )
+                validate_extras_dependencies("mistral")
                 from langchain_mistralai import ChatMistralAI
 
                 return ChatMistralAI(
@@ -243,11 +238,7 @@ class LLMWrapper(BaseLLMWrapper):
                     max_tokens=2048,
                 )
             case LLMProvider.MISTRALAI:
-                if not is_library_installed("mistralai"):
-                    raise ImportError(
-                        "mistralai extension is not installed. Please install "
-                        "portia-sdk-python[mistral] to use MistralAI models.",
-                    )
+                validate_extras_dependencies("mistral")
                 from mistralai import Mistral
 
                 client = instructor.from_mistral(

--- a/portia/llm_wrapper.py
+++ b/portia/llm_wrapper.py
@@ -31,6 +31,7 @@ from langsmith import wrappers
 from openai import OpenAI
 from pydantic import BaseModel, SecretStr
 
+from portia.common import is_library_installed
 from portia.config import Config, LLMModel, LLMProvider
 
 if TYPE_CHECKING:
@@ -182,6 +183,11 @@ class LLMWrapper(BaseLLMWrapper):
                     api_key=self.api_key,
                 )
             case LLMProvider.MISTRALAI:
+                if not is_library_installed("langchain_mistralai"):
+                    raise ImportError(
+                        "mistralai extension is not installed. Please install "
+                        "portia-sdk-python[mistral] to use MistralAI models.",
+                    )
                 from langchain_mistralai import ChatMistralAI
 
                 return ChatMistralAI(
@@ -237,6 +243,11 @@ class LLMWrapper(BaseLLMWrapper):
                     max_tokens=2048,
                 )
             case LLMProvider.MISTRALAI:
+                if not is_library_installed("mistralai"):
+                    raise ImportError(
+                        "mistralai extension is not installed. Please install "
+                        "portia-sdk-python[mistral] to use MistralAI models.",
+                    )
                 from mistralai import Mistral
 
                 client = instructor.from_mistral(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ instructor = "^1.7.7"
 anthropic = ">=0.41.0"
 langchain-anthropic = "^0.3.0"
 langchain-core = "^0.3.25"
-langchain-mistralai = "^0.2.3"
+langchain-mistralai = {version = "^0.2.3", optional = true}
 langchain-openai = "^0.3"
-mistralai = "^1.2.5"
+mistralai = {version = "^1.2.5", optional = true}
 langchain = "^0.3.17"
 langgraph = "^0.2.59"
 click = "^8.1.7"
@@ -48,6 +48,9 @@ pyright = "^1.1.382"
 pytest-httpx = "^0.33.0"
 pytest-xdist = {extras = ["psutil"], version = "^3.6.1"}
 pytest-asyncio = "^0.25.3"
+
+[tool.poetry.extras]
+mistral = ["langchain-mistralai", "mistralai"]
 
 [tool.ruff]
 line-length=100

--- a/tests/unit/planning_agents/test_default_planning_agent.py
+++ b/tests/unit/planning_agents/test_default_planning_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -46,13 +47,16 @@ def test_generate_steps_or_error_success(planning_agent: DefaultPlanningAgent) -
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    result = planning_agent.generate_steps_or_error(
-        ctx=get_execution_context(),
-        query=query,
-        tool_list=[],
-    )
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        result = planning_agent.generate_steps_or_error(
+            ctx=get_execution_context(),
+            query=query,
+            tool_list=[],
+        )
 
     assert result.steps == []
     assert result.error is None
@@ -88,13 +92,16 @@ def test_generate_steps_or_error_failure(planning_agent: DefaultPlanningAgent) -
         steps=[],
         error="Unable to generate a plan",
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    result = planning_agent.generate_steps_or_error(
-        ctx=get_execution_context(),
-        query=query,
-        tool_list=[],
-    )
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        result = planning_agent.generate_steps_or_error(
+            ctx=get_execution_context(),
+            query=query,
+            tool_list=[],
+        )
 
     assert result.error == "Unable to generate a plan"
 
@@ -185,13 +192,16 @@ def test_generate_steps_or_error_invalid_tool_id(planning_agent: DefaultPlanning
         ],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    result = planning_agent.generate_steps_or_error(
-        ctx=get_execution_context(),
-        query=query,
-        tool_list=[AdditionTool()],
-    )
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        result = planning_agent.generate_steps_or_error(
+            ctx=get_execution_context(),
+            query=query,
+            tool_list=[AdditionTool()],
+        )
 
     assert result.error == "Missing tools no_tool_1, no_tool_2 from the provided tool_list"
     assert result.steps == mock_response.steps
@@ -219,13 +229,16 @@ def test_generate_steps_assigns_llm_tool_id(planning_agent: DefaultPlanningAgent
         ],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    result = planning_agent.generate_steps_or_error(
-        ctx=get_execution_context(),
-        query=query,
-        tool_list=[AdditionTool()],
-    )
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        result = planning_agent.generate_steps_or_error(
+            ctx=get_execution_context(),
+            query=query,
+            tool_list=[AdditionTool()],
+        )
 
     assert all(step.tool_id == LLMTool.LLM_TOOL_ID for step in result.steps)
     assert len(result.steps) == 2

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,7 @@ from pydantic import SecretStr
 
 from portia.config import (
     EXECUTION_MODEL_KEY,
+    EXTRAS_GROUPS_DEPENDENCIES,
     PLANNING_MODEL_KEY,
     Config,
     ExecutionAgentType,
@@ -16,6 +17,7 @@ from portia.config import (
     LogLevel,
     PlanningAgentType,
     StorageClass,
+    validate_extras_dependencies,
 )
 from portia.errors import ConfigNotFoundError, InvalidConfigError
 
@@ -228,3 +230,10 @@ def test_all_models_have_provider(model: LLMModel) -> None:
 def test_all_providers_have_associated_model(provider: LLMProvider) -> None:
     """Test all providers have an associated model."""
     assert provider.associated_models() is not None
+
+def test_validate_extras_dependencies_catches_import_errors() -> None:
+    """Test function doesn't raise on non-existing top level package."""
+    EXTRAS_GROUPS_DEPENDENCIES["fake-extras-package"] = ["fake_package.bar"]
+    with pytest.raises(ImportError) as e:
+        validate_extras_dependencies("fake-extras-package")
+    assert "portia-sdk-python[fake-extras-package]" in str(e.value)

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -51,7 +51,7 @@ def test_base_classes() -> None:
 def mock_import_check(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Mock the import check."""
     monkeypatch.setenv("MISTRAL_API_KEY", "test123")
-    with patch("portia.llm_wrapper.is_library_installed", return_value=False):
+    with patch("importlib.util.find_spec", return_value=None):
         yield
 
 

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -87,4 +87,5 @@ def test_error_if_extension_not_installed_to_instructor(
         Config.from_default(llm_provider=provider),
     )
 
-    llm_wrapper.to_instructor(response_model=DummyModel, messages=[])
+    with pytest.raises(ImportError):
+        llm_wrapper.to_langchain()

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -87,5 +87,4 @@ def test_error_if_extension_not_installed_to_instructor(
         Config.from_default(llm_provider=provider),
     )
 
-    with pytest.raises(ImportError):
-        llm_wrapper.to_instructor(response_model=DummyModel, messages=[])
+    llm_wrapper.to_instructor(response_model=DummyModel, messages=[])

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -75,5 +75,4 @@ def test_error_if_extension_not_installed(
     with pytest.raises(ImportError):
         llm_wrapper.to_langchain()
 
-    with pytest.raises(ImportError):
-        llm_wrapper.to_instructor(response_model=DummyModel, messages=[])
+    llm_wrapper.to_instructor(response_model=DummyModel, messages=[])

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -75,4 +75,5 @@ def test_error_if_extension_not_installed(
     with pytest.raises(ImportError):
         llm_wrapper.to_langchain()
 
-    llm_wrapper.to_instructor(response_model=DummyModel, messages=[])
+    with pytest.raises(ImportError):
+        llm_wrapper.to_instructor(response_model=DummyModel, messages=[])

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -47,33 +47,28 @@ def test_base_classes() -> None:
         wrapper.to_langchain()
 
 
-@pytest.fixture
-def mock_import_check(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Mock the import check."""
-    monkeypatch.setenv("MISTRAL_API_KEY", "test123")
-    with patch("importlib.util.find_spec", return_value=None):
-        yield
-
-
 class DummyModel(BaseModel):
     """Dummy model for testing."""
 
     name: str
 
 
-@pytest.mark.usefixtures("mock_import_check")
 @pytest.mark.parametrize("provider", [LLMProvider.MISTRALAI])
 def test_error_if_extension_not_installed_to_langchain(
     provider: LLMProvider,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that an error is raised in to_langchain if the extension is not installed."""
-    llm_wrapper = LLMWrapper.for_usage(
-        EXECUTION_MODEL_KEY,
-        Config.from_default(llm_provider=provider),
-    )
 
-    with pytest.raises(ImportError):
-        llm_wrapper.to_langchain()
+    monkeypatch.setenv("MISTRAL_API_KEY", "test123")
+    with patch("importlib.util.find_spec", return_value=None):
+        llm_wrapper = LLMWrapper.for_usage(
+            EXECUTION_MODEL_KEY,
+            Config.from_default(llm_provider=provider),
+        )
+
+        with pytest.raises(ImportError):
+            llm_wrapper.to_langchain()
 
 
 @pytest.mark.parametrize("provider", [LLMProvider.MISTRALAI])
@@ -82,6 +77,7 @@ def test_error_if_extension_not_installed_to_instructor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that an error is raised in to_instructor if the extension is not installed."""
+
     monkeypatch.setenv("MISTRAL_API_KEY", "test123")
     with patch("importlib.util.find_spec", return_value=None):
         llm_wrapper = LLMWrapper.for_usage(

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import BaseModel, SecretStr
 
-from portia.config import EXECUTION_MODEL_KEY, Config, LLMModel, LLMProvider
+from portia.config import EXECUTION_MODEL_KEY, Config, LLMProvider
 from portia.llm_wrapper import BaseLLMWrapper, LLMWrapper, T
 from portia.planning_agents.base_planning_agent import StepsOrError
 

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -13,7 +13,6 @@ from portia.llm_wrapper import BaseLLMWrapper, LLMWrapper, T
 from portia.planning_agents.base_planning_agent import StepsOrError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
 
     from langchain_core.language_models.chat_models import BaseChatModel
     from openai.types.chat import ChatCompletionMessageParam
@@ -59,7 +58,6 @@ def test_error_if_extension_not_installed_to_langchain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that an error is raised in to_langchain if the extension is not installed."""
-
     monkeypatch.setenv("MISTRAL_API_KEY", "test123")
     with patch("importlib.util.find_spec", return_value=None):
         llm_wrapper = LLMWrapper.for_usage(
@@ -77,7 +75,6 @@ def test_error_if_extension_not_installed_to_instructor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that an error is raised in to_instructor if the extension is not installed."""
-
     monkeypatch.setenv("MISTRAL_API_KEY", "test123")
     with patch("importlib.util.find_spec", return_value=None):
         llm_wrapper = LLMWrapper.for_usage(

--- a/tests/unit/test_llm_wrapper.py
+++ b/tests/unit/test_llm_wrapper.py
@@ -63,7 +63,7 @@ class DummyModel(BaseModel):
 
 @pytest.mark.usefixtures("mock_import_check")
 @pytest.mark.parametrize("provider", [LLMProvider.MISTRALAI])
-def test_error_if_extension_not_installed(
+def test_error_if_extension_not_installed_to_langchain(
     provider: LLMProvider,
 ) -> None:
     """Test that an error is raised if the extension is not installed."""
@@ -74,6 +74,18 @@ def test_error_if_extension_not_installed(
 
     with pytest.raises(ImportError):
         llm_wrapper.to_langchain()
+
+
+@pytest.mark.usefixtures("mock_import_check")
+@pytest.mark.parametrize("provider", [LLMProvider.MISTRALAI])
+def test_error_if_extension_not_installed_to_instructor(
+    provider: LLMProvider,
+) -> None:
+    """Test that an error is raised if the extension is not installed."""
+    llm_wrapper = LLMWrapper.for_usage(
+        EXECUTION_MODEL_KEY,
+        Config.from_default(llm_provider=provider),
+    )
 
     with pytest.raises(ImportError):
         llm_wrapper.to_instructor(response_model=DummyModel, messages=[])

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -5,7 +5,7 @@ import threading
 import time
 from pathlib import Path
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import HttpUrl, SecretStr
@@ -93,9 +93,8 @@ def test_portia_run_query(portia: Portia) -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with patch.object(LLMWrapper, "to_instructor", new=MagicMock(return_value=mock_response)):
+        plan_run = portia.run(query)
 
     assert plan_run.state == PlanRunState.COMPLETE
 
@@ -109,9 +108,8 @@ def test_portia_run_query_tool_list() -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with patch.object(LLMWrapper, "to_instructor", new=MagicMock(return_value=mock_response)):
+        plan_run = portia.run(query)
 
     assert plan_run.state == PlanRunState.COMPLETE
 
@@ -129,9 +127,12 @@ def test_portia_run_query_disk_storage() -> None:
         portia = Portia(config=config, tools=tool_registry)
 
         mock_response = StepsOrError(steps=[], error=None)
-        LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-        plan_run = portia.run(query)
+        with mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_response),
+        ):
+            plan_run = portia.run(query)
 
         assert plan_run.state == PlanRunState.COMPLETE
         # Use Path to check for the files
@@ -147,9 +148,12 @@ def test_portia_generate_plan(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan = portia.plan(query)
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan = portia.plan(query)
 
     assert plan.plan_context.query == query
 
@@ -159,9 +163,11 @@ def test_portia_generate_plan_error(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error="could not plan")
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    with pytest.raises(PlanError):
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ), pytest.raises(PlanError):
         portia.plan(query)
 
 
@@ -170,9 +176,12 @@ def test_portia_generate_plan_with_tools(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan = portia.plan(query, tools=["add_tool"])
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan = portia.plan(query, tools=["add_tool"])
 
     assert plan.plan_context.query == query
     assert plan.plan_context.tool_ids == ["add_tool"]
@@ -183,9 +192,12 @@ def test_portia_resume(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan = portia.plan(query)
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan = portia.plan(query)
     plan_run = portia.create_plan_run(plan)
     plan_run = portia.resume(plan_run)
 
@@ -198,9 +210,8 @@ def test_portia_resume_after_interruption(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with patch.object(LLMWrapper, "to_instructor", new=MagicMock(return_value=mock_response)):
+        plan_run = portia.run(query)
 
     # Simulate run being in progress
     plan_run.state = PlanRunState.IN_PROGRESS
@@ -221,9 +232,12 @@ def test_portia_resume_edge_cases(portia: Portia) -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan = portia.plan(query)
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan = portia.plan(query)
     plan_run = portia.create_plan_run(plan)
 
     # Simulate run being in progress
@@ -243,9 +257,8 @@ def test_portia_run_invalid_state(portia: Portia) -> None:
     query = "example query"
 
     mock_response = StepsOrError(steps=[], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with patch.object(LLMWrapper, "to_instructor", new=MagicMock(return_value=mock_response)):
+        plan_run = portia.run(query)
 
     # Set invalid state
     plan_run.state = PlanRunState.COMPLETE
@@ -262,9 +275,8 @@ def test_portia_wait_for_ready(portia: Portia) -> None:
         steps=[Step(task="Example task", inputs=[], output="$output")],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with patch.object(LLMWrapper, "to_instructor", new=MagicMock(return_value=mock_response)):
+        plan_run = portia.run(query)
 
     plan_run.state = PlanRunState.FAILED
     with pytest.raises(InvalidPlanRunStateError):
@@ -388,9 +400,12 @@ def test_get_clarifications_and_get_run_called_once(portia: Portia) -> None:
         steps=[Step(task="Example task", inputs=[], output="$output")],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run(query)
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan_run = portia.run(query)
 
     # Set the run state to NEED_CLARIFICATION to ensure it goes through the wait logic
     plan_run.state = PlanRunState.NEED_CLARIFICATION
@@ -438,7 +453,6 @@ def test_portia_run_query_with_summary(portia: Portia) -> None:
         steps=[weather_step, activities_step],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_plan)
 
     # Mock agent responses
     weather_output = Output(value="Sunny and warm")
@@ -452,6 +466,11 @@ def test_portia_run_query_with_summary(portia: Portia) -> None:
     mock_summarizer_agent.create_summary.side_effect = [expected_summary]
 
     with (
+        mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_plan),
+        ),
         mock.patch(
             "portia.portia.FinalOutputSummarizer",
             return_value=mock_summarizer_agent,
@@ -643,9 +662,12 @@ def test_portia_run_plan(portia: Portia) -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan = portia.plan(query)
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan = portia.plan(query)
 
     # Mock the create_plan_run and resume methods
     with (
@@ -684,11 +706,15 @@ def test_portia_handle_clarification() -> None:
         ],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_plan)
     mock_step_agent = mock.MagicMock()
     mock_summarizer_agent = mock.MagicMock()
     mock_summarizer_agent.create_summary.side_effect = "I caught the clarification"
     with (
+        mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_plan),
+        ),
         mock.patch(
             "portia.portia.FinalOutputSummarizer",
             return_value=mock_summarizer_agent,
@@ -725,9 +751,12 @@ def test_portia_error_clarification(portia: Portia) -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run("test query")
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan_run = portia.run("test query")
 
     portia.error_clarification(
         ValueConfirmationClarification(
@@ -746,9 +775,12 @@ def test_portia_error_clarification_with_plan_run(portia: Portia) -> None:
         steps=[],
         error=None,
     )
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
-
-    plan_run = portia.run("test query")
+    with mock.patch.object(
+        LLMWrapper,
+        "to_instructor",
+        new=MagicMock(return_value=mock_response),
+    ):
+        plan_run = portia.run("test query")
 
     portia.error_clarification(
         ValueConfirmationClarification(
@@ -768,7 +800,6 @@ def test_portia_run_with_introspection_skip(portia: Portia) -> None:
     step1 = Step(task="Step 1", inputs=[], output="$step1_result", condition="some_condition")
     step2 = Step(task="Step 2", inputs=[], output="$step2_result")
     mock_response = StepsOrError(steps=[step1, step2], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
 
     # Mock introspection agent to return SKIP for first step
     mock_introspection = MagicMock()
@@ -781,8 +812,15 @@ def test_portia_run_with_introspection_skip(portia: Portia) -> None:
     mock_step_agent = MagicMock()
     mock_step_agent.execute_sync.return_value = Output(value="Step 2 result")
 
-    with mock.patch.object(portia, "_get_introspection_agent", return_value=mock_introspection), \
-         mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent):
+    with (
+        mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_response),
+        ),
+        mock.patch.object(portia, "_get_introspection_agent", return_value=mock_introspection),
+        mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent),
+    ):
         plan_run = portia.run("Test query with skipped step")
 
         # Verify result
@@ -805,7 +843,6 @@ def test_portia_run_with_introspection_stop(portia: Portia) -> None:
     step2 = Step(task="Step 2", inputs=[], output="$step2_result", condition="some_condition")
     step3 = Step(task="Step 3", inputs=[], output="$step3_result")
     mock_response = StepsOrError(steps=[step1, step2, step3], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
 
     # Mock step agent for first step
     mock_step_agent = MagicMock()
@@ -840,8 +877,15 @@ def test_portia_run_with_introspection_stop(portia: Portia) -> None:
             reason="Condition met",
         ))
 
-    with mock.patch.object(portia, "_handle_introspection_outcome", custom_handle_introspection), \
-         mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent):
+    with (
+        mock.patch.object(portia, "_handle_introspection_outcome", custom_handle_introspection),
+        mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent),
+        mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_response),
+        ),
+    ):
 
         # Run the test
         plan_run = portia.run("Test query with stopped execution")
@@ -863,7 +907,6 @@ def test_portia_run_with_introspection_fail(portia: Portia) -> None:
     step1 = Step(task="Step 1", inputs=[], output="$step1_result")
     step2 = Step(task="Step 2", inputs=[], output="$step2_result", condition="some_condition")
     mock_response = StepsOrError(steps=[step1, step2], error=None)
-    LLMWrapper.to_instructor = MagicMock(return_value=mock_response)
 
     # Mock step agent for first step
     mock_step_agent = MagicMock()
@@ -897,8 +940,15 @@ def test_portia_run_with_introspection_fail(portia: Portia) -> None:
             reason="Condition met",
         ))
 
-    with mock.patch.object(portia, "_handle_introspection_outcome", custom_handle_introspection), \
-         mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent):
+    with (
+        mock.patch.object(portia, "_handle_introspection_outcome", custom_handle_introspection),
+        mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent),
+        mock.patch.object(
+            LLMWrapper,
+            "to_instructor",
+            new=MagicMock(return_value=mock_response),
+        ),
+    ):
 
         # Run the test
         plan_run = portia.run("Test query with failed execution")


### PR DESCRIPTION
# Description

OpenAI and Anthropic are left as "default" for now - thoughts?

Added a guard for imports to direct people to install if they try to use Mistral without the extra dep

Usage: 
`poetry install portia-sdk-python[mistral]`

For local development:
`poetry install --all-extras`


Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
