### PR TITLE
Fixing final output with conditionals

### DIFF
--- a/portia/execution_agents/utils/final_output_summarizer.py
+++ b/portia/execution_agents/utils/final_output_summarizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from portia.config import SUMMARISER_MODEL_KEY
+from portia.introspection_agents.introspection_agent import PreStepIntrospectionOutcome
 from portia.llm_wrapper import LLMWrapper
 
 if TYPE_CHECKING:
@@ -56,8 +57,17 @@ class FinalOutputSummarizer:
         outputs = plan_run.outputs.step_outputs
         for step in plan.steps:
             if step.output in outputs:
+                output_value = (
+                    outputs[step.output].summary
+                    if outputs[step.output].value in (
+                        PreStepIntrospectionOutcome.SKIP,
+                        PreStepIntrospectionOutcome.STOP,
+                        PreStepIntrospectionOutcome.FAIL,
+                    )
+                    else outputs[step.output].value
+                )
                 context.append(f"Task: {step.task}")
-                context.append(f"Output: {outputs[step.output].value}")
+                context.append(f"Output: {output_value}")
                 context.append("----------")
         return "\n".join(context)
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -509,7 +509,12 @@ class Portia:
             f"Plan Run State is updated to {plan_run.state!s}.{dashboard_message}",
         )
 
-        last_executed_step_output = None
+        # If there are no steps, return the plan run as complete
+        if not plan.steps:
+            self._set_plan_run_state(plan_run, PlanRunState.COMPLETE)
+            return plan_run
+
+        last_executed_step_output = self._get_last_executed_step_output(plan, plan_run)
         introspection_agent = self._get_introspection_agent()
         for index in range(plan_run.current_step_index, len(plan.steps)):
             step = plan.steps[index]
@@ -595,6 +600,29 @@ class Portia:
             )
         return plan_run
 
+    def _get_last_executed_step_output(self, plan: Plan, plan_run: PlanRun) -> Output | None:
+        """Get the output of the last executed step.
+
+        Args:
+            plan (Plan): The plan containing steps.
+            plan_run (PlanRun): The plan run to get the output from.
+
+        Returns:
+            Output | None: The output of the last executed step.
+
+        """
+        return next(
+            (
+                plan_run.outputs.step_outputs[step.output]
+                for i in range(plan_run.current_step_index, -1, -1)
+                if i < len(plan.steps)
+                and (step := plan.steps[i]).output in plan_run.outputs.step_outputs
+                and (step_output := plan_run.outputs.step_outputs[step.output])
+                and step_output.value != PreStepIntrospectionOutcome.SKIP
+            ),
+            None,
+        )
+
     def _handle_introspection_outcome(
         self,
         introspection_agent: BaseIntrospectionAgent,
@@ -639,18 +667,21 @@ class Portia:
             f"Reason: {pre_step_outcome.reason}",
         )
 
+        if pre_step_outcome.outcome != PreStepIntrospectionOutcome.FAIL:
+            logger().debug(*log_message)
+        else:
+            logger().error(*log_message)
+
         match pre_step_outcome.outcome:
             case PreStepIntrospectionOutcome.SKIP:
-                logger().debug(*log_message)
                 plan_run.outputs.step_outputs[step.output] = Output(
-                    value="SKIPPED",
+                    value=PreStepIntrospectionOutcome.SKIP,
                     summary=pre_step_outcome.reason,
                 )
                 self.storage.save_plan_run(plan_run)
             case PreStepIntrospectionOutcome.STOP:
-                logger().debug(*log_message)
                 plan_run.outputs.step_outputs[step.output] = Output(
-                    value="STOPPED",
+                    value=PreStepIntrospectionOutcome.STOP,
                     summary=pre_step_outcome.reason,
                 )
                 if last_executed_step_output:
@@ -662,9 +693,8 @@ class Portia:
                 self._set_plan_run_state(plan_run, PlanRunState.COMPLETE)
                 self.storage.save_plan_run(plan_run)
             case PreStepIntrospectionOutcome.FAIL:
-                logger().error(*log_message)
                 failed_output = Output(
-                    value="FAILED",
+                    value=PreStepIntrospectionOutcome.FAIL,
                     summary=pre_step_outcome.reason,
                 )
                 plan_run.outputs.step_outputs[step.output] = failed_output

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -662,10 +662,10 @@ class Portia:
             f"Reason: {pre_step_outcome.reason}",
         )
 
-        if pre_step_outcome.outcome != PreStepIntrospectionOutcome.FAIL:
-            logger().debug(*log_message)
-        else:
+        if pre_step_outcome.outcome == PreStepIntrospectionOutcome.FAIL:
             logger().error(*log_message)
+        else:
+            logger().debug(*log_message)
 
         match pre_step_outcome.outcome:
             case PreStepIntrospectionOutcome.SKIP:

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -509,11 +509,6 @@ class Portia:
             f"Plan Run State is updated to {plan_run.state!s}.{dashboard_message}",
         )
 
-        # If there are no steps, return the plan run as complete
-        if not plan.steps:
-            self._set_plan_run_state(plan_run, PlanRunState.COMPLETE)
-            return plan_run
-
         last_executed_step_output = self._get_last_executed_step_output(plan, plan_run)
         introspection_agent = self._get_introspection_agent()
         for index in range(plan_run.current_step_index, len(plan.steps)):

--- a/tests/unit/execution_agents/utils/test_final_output_summarizer.py
+++ b/tests/unit/execution_agents/utils/test_final_output_summarizer.py
@@ -145,7 +145,6 @@ def test_build_tasks_and_outputs_context() -> None:
     )
 
 
-
 def test_build_tasks_and_outputs_context_empty() -> None:
     """Test that the tasks and outputs context handles empty steps and outputs."""
     (plan, plan_run) = get_test_plan_run()
@@ -203,12 +202,11 @@ def test_build_tasks_and_outputs_context_partial_outputs() -> None:
     )
 
 
-def test_build_tasks_and_outputs_context_with_special_outcomes() -> None:
-    """Test that the context builder correctly uses summary for special outcomes."""
+def test_build_tasks_and_outputs_context_with_conditional_outcomes() -> None:
+    """Test that the context builder correctly uses summary for conditional outcomes."""
     (plan, plan_run) = get_test_plan_run()
 
-    # Set up test data with special outcomes
-    plan.plan_context.query = "Test query with special outcomes"
+    plan.plan_context.query = "Test query with conditional outcomes"
     plan.steps = [
         Step(
             task="Regular task",
@@ -228,7 +226,6 @@ def test_build_tasks_and_outputs_context_with_special_outcomes() -> None:
         ),
     ]
 
-    # Provide outputs with special values and summaries
     plan_run.outputs.step_outputs = {
         "$regular_output": Output(value="Regular result", summary="Not used"),
         "$failed_output": Output(
@@ -251,9 +248,8 @@ def test_build_tasks_and_outputs_context_with_special_outcomes() -> None:
         plan_run=plan_run,
     )
 
-    # Verify that regular values are used directly, but summaries are used for special outcomes
     assert context == (
-        "Query: Test query with special outcomes\n"
+        "Query: Test query with conditional outcomes\n"
         "----------\n"
         "Task: Regular task\n"
         "Output: Regular result\n"

--- a/tests/unit/execution_agents/utils/test_final_output_summarizer.py
+++ b/tests/unit/execution_agents/utils/test_final_output_summarizer.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from portia.execution_agents.base_execution_agent import Output
 from portia.execution_agents.utils.final_output_summarizer import FinalOutputSummarizer
+from portia.introspection_agents.introspection_agent import PreStepIntrospectionOutcome
 from portia.plan import Step
 from tests.utils import get_test_config, get_test_plan_run
 
@@ -144,6 +145,7 @@ def test_build_tasks_and_outputs_context() -> None:
     )
 
 
+
 def test_build_tasks_and_outputs_context_empty() -> None:
     """Test that the tasks and outputs context handles empty steps and outputs."""
     (plan, plan_run) = get_test_plan_run()
@@ -197,5 +199,72 @@ def test_build_tasks_and_outputs_context_partial_outputs() -> None:
         "----------\n"
         "Task: Get weather in London\n"
         "Output: Sunny and warm\n"
+        "----------"
+    )
+
+
+def test_build_tasks_and_outputs_context_with_special_outcomes() -> None:
+    """Test that the context builder correctly uses summary for special outcomes."""
+    (plan, plan_run) = get_test_plan_run()
+
+    # Set up test data with special outcomes
+    plan.plan_context.query = "Test query with special outcomes"
+    plan.steps = [
+        Step(
+            task="Regular task",
+            output="$regular_output",
+        ),
+        Step(
+            task="Failed task",
+            output="$failed_output",
+        ),
+        Step(
+            task="Skipped task",
+            output="$skipped_output",
+        ),
+        Step(
+            task="Stopped task",
+            output="$stopped_output",
+        ),
+    ]
+
+    # Provide outputs with special values and summaries
+    plan_run.outputs.step_outputs = {
+        "$regular_output": Output(value="Regular result", summary="Not used"),
+        "$failed_output": Output(
+            value=PreStepIntrospectionOutcome.FAIL,
+            summary="This task failed due to an error",
+        ),
+        "$skipped_output": Output(
+            value=PreStepIntrospectionOutcome.SKIP,
+            summary="This task was skipped as it was unnecessary",
+        ),
+        "$stopped_output": Output(
+            value=PreStepIntrospectionOutcome.STOP,
+            summary="The plan execution was stopped early",
+        ),
+    }
+
+    summarizer = FinalOutputSummarizer(config=get_test_config())
+    context = summarizer._build_tasks_and_outputs_context(  # noqa: SLF001
+        plan=plan,
+        plan_run=plan_run,
+    )
+
+    # Verify that regular values are used directly, but summaries are used for special outcomes
+    assert context == (
+        "Query: Test query with special outcomes\n"
+        "----------\n"
+        "Task: Regular task\n"
+        "Output: Regular result\n"
+        "----------\n"
+        "Task: Failed task\n"
+        "Output: This task failed due to an error\n"
+        "----------\n"
+        "Task: Skipped task\n"
+        "Output: This task was skipped as it was unnecessary\n"
+        "----------\n"
+        "Task: Stopped task\n"
+        "Output: The plan execution was stopped early\n"
         "----------"
     )

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -1128,7 +1128,7 @@ def test_portia_resume_with_skipped_steps(portia: Portia) -> None:
     mock_introspection = MagicMock()
     def mock_introspection_outcome(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
         plan_run = kwargs.get("plan_run")
-        if plan_run.current_step_index in (2, 3):  # Skip both step3 and step4
+        if plan_run.current_step_index in (2, 3): # pyright: ignore[reportOptionalMemberAccess] # Skip both step3 and step4
             return PreStepIntrospection(
                 outcome=PreStepIntrospectionOutcome.SKIP,
                 reason="Condition is false",

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -788,7 +788,10 @@ def test_portia_run_with_introspection_skip(portia: Portia) -> None:
         # Verify result
         assert plan_run.state == PlanRunState.COMPLETE
         assert "$step1_result" in plan_run.outputs.step_outputs
-        assert plan_run.outputs.step_outputs["$step1_result"].value == "SKIPPED"
+        assert (
+            plan_run.outputs.step_outputs["$step1_result"].value
+            == PreStepIntrospectionOutcome.SKIP
+        )
         assert "$step2_result" in plan_run.outputs.step_outputs
         assert plan_run.outputs.step_outputs["$step2_result"].value == "Step 2 result"
         assert plan_run.outputs.final_output is not None
@@ -819,7 +822,7 @@ def test_portia_run_with_introspection_stop(portia: Portia) -> None:
 
         if plan_run.current_step_index == 1:
             plan_run.outputs.step_outputs["$step2_result"] = Output(
-                value="STOPPED",
+                value=PreStepIntrospectionOutcome.STOP,
                 summary="Remaining steps cannot be executed",
             )
             plan_run.outputs.final_output = Output(
@@ -846,7 +849,10 @@ def test_portia_run_with_introspection_stop(portia: Portia) -> None:
         # Verify result based on our simulated outcomes
         assert plan_run.state == PlanRunState.COMPLETE
         assert "$step2_result" in plan_run.outputs.step_outputs
-        assert plan_run.outputs.step_outputs["$step2_result"].value == "STOPPED"
+        assert (
+            plan_run.outputs.step_outputs["$step2_result"].value
+            == PreStepIntrospectionOutcome.STOP
+        )
         assert plan_run.outputs.final_output is not None
         assert plan_run.outputs.final_output.summary == "Execution stopped early"
 
@@ -874,7 +880,10 @@ def test_portia_run_with_introspection_fail(portia: Portia) -> None:
         # If this is step 1, simulate a FAIL outcome
         if plan_run.current_step_index == 1:
             # Modify the plan_run to look like it failed
-            failed_output = Output(value="FAILED", summary="Missing required data")
+            failed_output = Output(
+                value=PreStepIntrospectionOutcome.FAIL,
+                summary="Missing required data",
+            )
             plan_run.outputs.step_outputs["$step2_result"] = failed_output
             plan_run.outputs.final_output = failed_output
             plan_run.state = PlanRunState.FAILED
@@ -897,9 +906,12 @@ def test_portia_run_with_introspection_fail(portia: Portia) -> None:
         # Verify the expected outcome
         assert plan_run.state == PlanRunState.FAILED
         assert "$step2_result" in plan_run.outputs.step_outputs
-        assert plan_run.outputs.step_outputs["$step2_result"].value == "FAILED"
+        assert (
+            plan_run.outputs.step_outputs["$step2_result"].value
+            == PreStepIntrospectionOutcome.FAIL
+        )
         assert plan_run.outputs.final_output is not None
-        assert plan_run.outputs.final_output.value == "FAILED"
+        assert plan_run.outputs.final_output.value == PreStepIntrospectionOutcome.FAIL
         assert plan_run.outputs.final_output.summary == "Missing required data"
 
 
@@ -941,7 +953,10 @@ def test_handle_introspection_outcome_stop(portia: Portia) -> None:
         assert outcome.reason == "Stopping execution"
 
         # Verify plan_run was updated correctly
-        assert updated_plan_run.outputs.step_outputs["$test_output"].value == "STOPPED"
+        assert (
+            updated_plan_run.outputs.step_outputs["$test_output"].value
+            == PreStepIntrospectionOutcome.STOP
+        )
         assert updated_plan_run.outputs.step_outputs["$test_output"].summary == "Stopping execution"
         assert updated_plan_run.outputs.final_output == mock_final_output
         assert updated_plan_run.state == PlanRunState.COMPLETE
@@ -982,10 +997,13 @@ def test_handle_introspection_outcome_fail(portia: Portia) -> None:
     assert outcome.reason == "Execution failed"
 
     # Verify plan_run was updated correctly
-    assert updated_plan_run.outputs.step_outputs["$test_output"].value == "FAILED"
+    assert (
+        updated_plan_run.outputs.step_outputs["$test_output"].value
+        == PreStepIntrospectionOutcome.FAIL
+    )
     assert updated_plan_run.outputs.step_outputs["$test_output"].summary == "Execution failed"
     assert updated_plan_run.outputs.final_output is not None
-    assert updated_plan_run.outputs.final_output.value == "FAILED"
+    assert updated_plan_run.outputs.final_output.value == PreStepIntrospectionOutcome.FAIL
     assert updated_plan_run.outputs.final_output.summary is not None
     assert updated_plan_run.outputs.final_output.summary == "Execution failed"
     assert updated_plan_run.state == PlanRunState.FAILED
@@ -1026,7 +1044,10 @@ def test_handle_introspection_outcome_skip(portia: Portia) -> None:
     assert outcome.reason == "Skipping step"
 
     # Verify plan_run was updated correctly
-    assert updated_plan_run.outputs.step_outputs["$test_output"].value == "SKIPPED"
+    assert (
+        updated_plan_run.outputs.step_outputs["$test_output"].value
+        == PreStepIntrospectionOutcome.SKIP
+    )
     assert updated_plan_run.outputs.step_outputs["$test_output"].summary == "Skipping step"
     assert updated_plan_run.state == PlanRunState.IN_PROGRESS  # State should remain IN_PROGRESS
 
@@ -1068,3 +1089,87 @@ def test_handle_introspection_outcome_no_condition(portia: Portia) -> None:
     assert "$test_output" not in updated_plan_run.outputs.step_outputs
     assert updated_plan_run.state == PlanRunState.IN_PROGRESS
 
+
+def test_portia_resume_with_skipped_steps(portia: Portia) -> None:
+    """Test resuming a plan run with skipped steps and verifying final output.
+
+    This test verifies:
+    1. Resuming from a middle index works correctly
+    2. Steps marked as SKIPPED are properly skipped during execution
+    3. The final output is correctly computed from the last non-SKIPPED step
+    """
+    # Create a plan with multiple steps
+    step1 = Step(task="Step 1", inputs=[], output="$step1_result")
+    step2 = Step(task="Step 2", inputs=[], output="$step2_result", condition="true")
+    step3 = Step(task="Step 3", inputs=[], output="$step3_result", condition="false")
+    step4 = Step(task="Step 4", inputs=[], output="$step4_result", condition="false")
+    plan = Plan(
+        plan_context=PlanContext(query="Test query with skips", tool_ids=[]),
+        steps=[step1, step2, step3, step4],
+    )
+
+    # Create a plan run that's partially completed (step1 is done)
+    plan_run = PlanRun(
+        plan_id=plan.id,
+        current_step_index=1,  # Resume from step 2
+        state=PlanRunState.IN_PROGRESS,
+        outputs=PlanRunOutputs(
+            step_outputs={
+                "$step1_result": Output(value="Step 1 result", summary="Summary of step 1"),
+            },
+        ),
+    )
+
+    # Mock the storage to return our plan
+    portia.storage.save_plan(plan)
+    portia.storage.save_plan_run(plan_run)
+
+    # Mock introspection agent to SKIP steps 3 and 4
+    mock_introspection = MagicMock()
+    def mock_introspection_outcome(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        plan_run = kwargs.get("plan_run")
+        if plan_run.current_step_index in (2, 3):  # Skip both step3 and step4
+            return PreStepIntrospection(
+                outcome=PreStepIntrospectionOutcome.SKIP,
+                reason="Condition is false",
+            )
+        return PreStepIntrospection(
+            outcome=PreStepIntrospectionOutcome.CONTINUE,
+            reason="Continue execution",
+        )
+    mock_introspection.pre_step_introspection.side_effect = mock_introspection_outcome
+
+    # Mock step agent to return expected output for step 2 only (steps 3 and 4 will be skipped)
+    mock_step_agent = MagicMock()
+    mock_step_agent.execute_sync.return_value = Output(
+        value="Step 2 result",
+        summary="Summary of step 2",
+    )
+
+    # Mock the final output summarizer
+    expected_summary = "Combined summary of steps 1 and 2"
+    mock_summarizer = MagicMock()
+    mock_summarizer.create_summary.return_value = expected_summary
+
+    with mock.patch.object(portia, "_get_introspection_agent", return_value=mock_introspection), \
+         mock.patch.object(portia, "_get_agent_for_step", return_value=mock_step_agent), \
+         mock.patch("portia.portia.FinalOutputSummarizer", return_value=mock_summarizer):
+
+        result_plan_run = portia.resume(plan_run)
+
+        assert result_plan_run.state == PlanRunState.COMPLETE
+
+        assert result_plan_run.outputs.step_outputs["$step1_result"].value == "Step 1 result"
+        assert result_plan_run.outputs.step_outputs["$step2_result"].value == "Step 2 result"
+        assert (
+            result_plan_run.outputs.step_outputs["$step3_result"].value
+            == PreStepIntrospectionOutcome.SKIP
+        )
+        assert (
+            result_plan_run.outputs.step_outputs["$step4_result"].value
+            == PreStepIntrospectionOutcome.SKIP
+        )
+        assert result_plan_run.outputs.final_output is not None
+        assert result_plan_run.outputs.final_output.value == "Step 2 result"
+        assert result_plan_run.outputs.final_output.summary == expected_summary
+        assert result_plan_run.current_step_index == 3


### PR DESCRIPTION
# Description

- This is fix to final output for conditional cases for resuming cases (or after resolving clarifications), where currently we initialise the `last_executed_step_output` with None. Instead, we should properly, retrieve it back from the PlanRun object.
-  Add the summary instead of value for final step summarizer, so it can provide more comprehensive summary of what has decisions that had been done in the plan run. 

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
