### PR TITLE
Allow additinal fields for Step in Prod

### DIFF
--- a/portia/plan.py
+++ b/portia/plan.py
@@ -172,7 +172,7 @@ class Step(BaseModel):
 
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     task: str = Field(
         description="The task that needs to be completed by this step",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portia-sdk-python"
-version = "0.1.6"
+version = "0.1.7"
 description = "Portia Labs Python SDK for building agentic workflows."
 authors = ["Hello <hello@portialabs.ai>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Because the current pre-release (alpha) SDK have a breaking change, we need to hot fix allow first in production. Then, do our normal release process.

### Steps:
 1- Allowing additional fields to be saved for production SDK.
 2- Consume this new release (0.1.7) in backend in Prod.
 3- Carry on with normal release for current pre-release promotion to prod.


Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
