### PR TITLE
[POR-1003] Custom agents

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -170,6 +170,7 @@ class ExecutionAgentType(Enum):
 
     ONE_SHOT = "ONE_SHOT"
     DEFAULT = "DEFAULT"
+    CUSTOM = "CUSTOM"
 
 
 class PlanningAgentType(Enum):
@@ -181,6 +182,7 @@ class PlanningAgentType(Enum):
     """
 
     DEFAULT = "DEFAULT"
+    CUSTOM = "CUSTOM"
 
 
 class LogLevel(Enum):
@@ -418,7 +420,23 @@ class Config(BaseModel):
     @classmethod
     def parse_planning_agent_type(cls, value: str | PlanningAgentType) -> PlanningAgentType:
         """Parse planning_agent_type to enum if string provided."""
-        return parse_str_to_enum(value, PlanningAgentType)
+        planning_agent_type = parse_str_to_enum(value, PlanningAgentType)
+        if planning_agent_type == PlanningAgentType.CUSTOM and not cls.custom_planning_agent:
+            raise InvalidConfigError(
+                "planning_agent_type",
+                "Custom planning agent not set",
+            )
+        return planning_agent_type
+
+    custom_planning_agent: type[BasePlanningAgent] | None = Field(
+        default=None,
+        description="A custom planning agent to use.",
+    )
+
+    custom_execution_agent: type[BaseExecutionAgent] | None = Field(
+        default=None,
+        description="A custom execution agent to use.",
+    )
 
     @model_validator(mode="after")
     def check_config(self) -> Self:

--- a/portia/config.py
+++ b/portia/config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Self, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from pydantic import (
     BaseModel,
@@ -23,6 +23,15 @@ from pydantic import (
 )
 
 from portia.errors import ConfigNotFoundError, InvalidConfigError
+
+if TYPE_CHECKING:
+    from portia.execution_agents.base_execution_agent import BaseExecutionAgent
+    from portia.planning_agents.base_planning_agent import BasePlanningAgent
+else:
+    # Placeholder types for runtime
+    BaseExecutionAgent = Any
+    BasePlanningAgent = Any
+
 
 T = TypeVar("T")
 
@@ -275,7 +284,10 @@ class Config(BaseModel):
 
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
 
     # Portia Cloud Options
     portia_api_endpoint: str = Field(
@@ -313,6 +325,11 @@ class Config(BaseModel):
     models: dict[str, LLMModel] = Field(
         default={},
         description="A dictionary of configured LLM models for each usage.",
+    )
+
+    agents: dict[str, BaseExecutionAgent | BasePlanningAgent] = Field(
+        default_factory=dict,
+        description="A dictionary of configured agents for each usage.",
     )
 
     @model_validator(mode="after")

--- a/portia/config.py
+++ b/portia/config.py
@@ -314,7 +314,7 @@ class Config(BaseModel):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        populate_by_name=True,
+        extra="ignore",
     )
 
     # Portia Cloud Options

--- a/portia/config.py
+++ b/portia/config.py
@@ -56,11 +56,13 @@ EXTRAS_GROUPS_DEPENDENCIES = {
     "mistral": ["mistralai", "langchain_mistralai"],
 }
 
+
 def validate_extras_dependencies(extra_group: str) -> None:
     """Validate that the dependencies for an extras group are installed.
 
     Provide a helpful error message if not all dependencies are installed.
     """
+
     def package_installed(package: str) -> bool:
         try:
             return importlib.util.find_spec(package) is not None
@@ -353,11 +355,6 @@ class Config(BaseModel):
         description="A dictionary of configured LLM models for each usage.",
     )
 
-    agents: dict[str, BaseExecutionAgent | BasePlanningAgent] = Field(
-        default_factory=dict,
-        description="A dictionary of configured agents for each usage.",
-    )
-
     @model_validator(mode="after")
     def add_default_models(self) -> Self:
         """Add default models if not provided."""
@@ -432,7 +429,13 @@ class Config(BaseModel):
     @classmethod
     def parse_execution_agent_type(cls, value: str | ExecutionAgentType) -> ExecutionAgentType:
         """Parse execution_agent_type to enum if string provided."""
-        return parse_str_to_enum(value, ExecutionAgentType)
+        execution_agent_type = parse_str_to_enum(value, ExecutionAgentType)
+        if execution_agent_type == ExecutionAgentType.CUSTOM and not cls.custom_execution_agent:
+            raise InvalidConfigError(
+                "execution_agent_type",
+                "Custom execution agent not set",
+            )
+        return execution_agent_type
 
     # PlanningAgent Options
     planning_agent_type: PlanningAgentType = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ line-length=100
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+  "COM812",  # Disables checks for detecting missing trailing commas as it conflicts with ISC001 (implicit string concatenation).
   "D203",    # Disables checks for having a blank line before a class docstring. We instead have no-blank-line-before-class (D211) enabled.
   "D213",    # Disables checks for multi-line docstrings not starting on the first line. We instead have multi-line-summary-first-line (D212) enabled.
   "EM101",   # Disables checks for missing exception message arguments. We prefer single-line exception statements for simplicity and terseness.


### PR DESCRIPTION
# Description

In order to have our own planning agents that we are testing and refining, we need to be able to use these in the SDK without forking the code. We should probably also extend the concept to execution agents.

Replaces https://github.com/portiaAI/portia-sdk-python/pull/223

Re the discussion on the other PR about having this as a separate method on the config class -- I think that creates another way to do config like actions so I'd rather not do that unless the reason for it is strong. At the moment we don't have a requirement for serialisable config so I'm not sure if it would be the right tradeoff but happy to discuss further.
@TomSPortia @Nathanjp91 -- plz review directionally (hence the draft PR)

## Type of change

(select all that apply)

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Changelog

### Added
- 0.1.8 Allow for custom execution and planning agents without forking of code
