### PR TITLE
[POR-1094] - Remove system context extensions

### DIFF
--- a/portia/execution_agents/context.py
+++ b/portia/execution_agents/context.py
@@ -26,24 +26,17 @@ if TYPE_CHECKING:
     from portia.plan_run import PlanRun
 
 
-def generate_main_system_context(system_context_extensions: list[str] | None = None) -> list[str]:
+def generate_main_system_context() -> list[str]:
     """Generate the main system context.
-
-    Args:
-        system_context_extensions (list[str] | None): Optional list of strings to extend
-                                                     the system context.
 
     Returns:
         list[str]: A list of strings representing the system context.
 
     """
-    system_context = [
+    return [
         "System Context:",
         f"Today's date is {datetime.now(UTC).strftime('%Y-%m-%d')}",
     ]
-    if system_context_extensions:
-        system_context.extend(system_context_extensions)
-    return system_context
 
 
 def generate_input_context(
@@ -200,12 +193,7 @@ def build_context(ctx: ExecutionContext, step: Step, plan_run: PlanRun) -> str:
     previous_outputs = plan_run.outputs.step_outputs
     clarifications = plan_run.outputs.clarifications
 
-    system_context_extension = (
-        ctx.execution_agent_system_context_extension
-        if ctx.execution_agent_system_context_extension
-        else plan_run.execution_context.execution_agent_system_context_extension
-    )
-    system_context = generate_main_system_context(system_context_extension)
+    system_context = generate_main_system_context()
 
     # exit early if no additional information
     if not inputs and not clarifications and not previous_outputs:

--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -593,8 +593,6 @@ class DefaultExecutionAgent(BaseExecutionAgent):
         if not self.tool:
             raise InvalidAgentError("Tool is required for DefaultExecutionAgent")
         context = self.get_system_context()
-        execution_context = get_execution_context()
-        execution_context.plan_run_context = context
         model = self.config.resolve_langchain_model(EXECUTION_MODEL_KEY)
 
         tools = [

--- a/portia/execution_context.py
+++ b/portia/execution_context.py
@@ -6,8 +6,8 @@ for each run execution, ensuring flexibility and context isolation, especially i
 multi-threaded or asynchronous applications.
 
 Key Features:
-- The `ExecutionContext` class encapsulates information such as user identification,
-  additional data, and system context extensions for planning and execution agents.
+- The `ExecutionContext` class encapsulates information such as user identification
+  and additional data for planning and execution agents.
 - The `execution_context` context manager allows for context isolation, ensuring
   that each task or thread has its own independent execution context.
 - The `get_execution_context` function allows retrieval of the current execution context.
@@ -43,10 +43,6 @@ class ExecutionContext(BaseModel):
         end_user_id (Optional[str]): The identifier of the user for whom the run is running.
             Used for authentication and debugging purposes.
         additional_data (dict[str, str]): Arbitrary additional data useful for debugging.
-        planning_agent_system_context_extension (Optional[list[str]]): Additional context for
-            planning_agents.
-        execution_agent_system_context_extension (Optional[list[str]]): Additional context for agent LLMs.
-        plan_run_context (Optional[str]): Additional context for the PlanRun.
 
     """  # noqa: E501
 
@@ -55,12 +51,6 @@ class ExecutionContext(BaseModel):
     end_user_id: str | None = None
 
     additional_data: dict[str, str] = Field(default={})
-
-    planning_agent_system_context_extension: list[str] | None = None
-
-    execution_agent_system_context_extension: list[str] | None = None
-
-    plan_run_context: str | None = Field(default=None, exclude=True)
 
 
 def empty_context() -> ExecutionContext:
@@ -73,9 +63,6 @@ def empty_context() -> ExecutionContext:
     return ExecutionContext(
         end_user_id=None,
         additional_data={},
-        planning_agent_system_context_extension=None,
-        execution_agent_system_context_extension=None,
-        plan_run_context=None,
     )
 
 
@@ -84,8 +71,6 @@ def execution_context(
     context: ExecutionContext | None = None,
     end_user_id: str | None = None,
     additional_data: dict[str, str] | None = None,
-    planning_agent_system_context_extension: list[str] | None = None,
-    agent_system_context_extension: list[str] | None = None,
 ) -> Generator[None, None, None]:
     """Set the execution context for the duration of the PlanRun.
 
@@ -102,10 +87,6 @@ def execution_context(
             the execution for specific users. Defaults to `None`.
         additional_data (Optional[Dict[str, str]]): Arbitrary additional data to associate
             with the context. Defaults to an empty dictionary.
-        planning_agent_system_context_extension (Optional[list[str]]): Additional context for
-            planning_agents. This should be concise to stay within the context window.
-        agent_system_context_extension (Optional[list[str]]): Additional context for agent
-            LLMs. This should also be concise.
 
     Yields:
         None: The block of code within the context manager executes with the specified context.
@@ -128,8 +109,6 @@ def execution_context(
         context = ExecutionContext(
             end_user_id=end_user_id,
             additional_data=additional_data or {},
-            planning_agent_system_context_extension=planning_agent_system_context_extension,
-            execution_agent_system_context_extension=agent_system_context_extension,
         )
     token = _execution_context.set(context)
     try:

--- a/portia/open_source_tools/image_understanding_tool.py
+++ b/portia/open_source_tools/image_understanding_tool.py
@@ -82,8 +82,6 @@ class ImageUnderstandingTool(Tool[str]):
             "plan run information and results of other tool calls. Use this to resolve any "
             "tasks"
         )
-        if ctx.execution_context.plan_run_context:
-            context += f"\nPlan run context: {ctx.execution_context.plan_run_context}"
         if self.tool_context:
             context += f"\nTool context: {self.tool_context}"
         content = (

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -70,8 +70,6 @@ class LLMTool(Tool[str]):
             "run information and results of other tool calls. Use this to resolve any "
             "tasks"
         )
-        if ctx.execution_context.plan_run_context:
-            context += f"\nRun context: {ctx.execution_context.plan_run_context}"
         if self.tool_context:
             context += f"\nTool context: {self.tool_context}"
         content = task if not len(context.split("\n")) > 1 else f"{context}\n\n{task}"

--- a/portia/planning_agents/base_planning_agent.py
+++ b/portia/planning_agents/base_planning_agent.py
@@ -18,7 +18,6 @@ from portia.plan import Plan, Step
 
 if TYPE_CHECKING:
     from portia.config import Config
-    from portia.execution_context import ExecutionContext
     from portia.tool import Tool
 
 logger = logging.getLogger(__name__)
@@ -48,7 +47,6 @@ class BasePlanningAgent(ABC):
     @abstractmethod
     def generate_steps_or_error(
         self,
-        ctx: ExecutionContext,
         query: str,
         tool_list: list[Tool],
         examples: list[Plan] | None = None,
@@ -59,7 +57,6 @@ class BasePlanningAgent(ABC):
         on the provided query and tools.
 
         Args:
-            ctx (ExecutionContext): The context for execution.
             query (str): The user query to generate a list of steps for.
             tool_list (list[Tool]): A list of tools available for the plan.
             examples (list[Plan] | None): Optional list of example plans to guide the PlanningAgent.

--- a/portia/planning_agents/context.py
+++ b/portia/planning_agents/context.py
@@ -16,11 +16,10 @@ if TYPE_CHECKING:
 def render_prompt_insert_defaults(
     query: str,
     tool_list: list[Tool],
-    system_context_extension: list[str] | None = None,
     examples: list[Plan] | None = None,
 ) -> str:
     """Render the prompt for the PlanningAgent with defaults inserted if not provided."""
-    system_context = default_query_system_context(system_context_extension)
+    system_context = default_query_system_context()
 
     if examples is None:
         examples = DEFAULT_EXAMPLE_PLANS
@@ -36,14 +35,9 @@ def render_prompt_insert_defaults(
     )
 
 
-def default_query_system_context(
-    system_context_extension: list[str] | None = None,
-) -> list[str]:
+def default_query_system_context() -> list[str]:
     """Return the default system context."""
-    base_context = [f"Today is {datetime.now(UTC).strftime('%Y-%m-%d')}"]
-    if system_context_extension:
-        base_context.extend(system_context_extension)
-    return base_context
+    return [f"Today is {datetime.now(UTC).strftime('%Y-%m-%d')}"]
 
 
 def get_tool_descriptions_for_tools(tool_list: list[Tool]) -> list[dict[str, str]]:

--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from portia.config import PLANNING_MODEL_KEY
-from portia.execution_context import ExecutionContext, get_execution_context
 from portia.model import Message
 from portia.open_source_tools.llm_tool import LLMTool
 from portia.planning_agents.base_planning_agent import BasePlanningAgent, StepsOrError
@@ -29,17 +28,14 @@ class DefaultPlanningAgent(BasePlanningAgent):
 
     def generate_steps_or_error(
         self,
-        ctx: ExecutionContext,
         query: str,
         tool_list: list[Tool],
         examples: list[Plan] | None = None,
     ) -> StepsOrError:
         """Generate a plan or error using an LLM from a query and a list of tools."""
-        ctx = get_execution_context()
         prompt = render_prompt_insert_defaults(
             query,
             tool_list,
-            ctx.planning_agent_system_context_extension,
             examples,
         )
         response = self.model.get_structured_response(

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -197,7 +197,6 @@ class Portia:
         logger().info(f"Running planning_agent for query - {query}")
         planning_agent = self._get_planning_agent()
         outcome = planning_agent.generate_steps_or_error(
-            ctx=get_execution_context(),
             query=query,
             tool_list=tools,
             examples=example_plans,
@@ -864,7 +863,6 @@ class Portia:
         tools = cloud_registry.match_tools(query)
         planning_agent = self._get_planning_agent()
         replan_outcome = planning_agent.generate_steps_or_error(
-            ctx=get_execution_context(),
             query=query,
             tool_list=tools,
             examples=example_plans,

--- a/tests/unit/execution_agents/test_base_execution_agent.py
+++ b/tests/unit/execution_agents/test_base_execution_agent.py
@@ -12,6 +12,7 @@ from pydantic import HttpUrl
 from portia.clarification import ActionClarification
 from portia.config import LLMModel
 from portia.execution_agents.base_execution_agent import BaseExecutionAgent, Output
+from portia.execution_agents.output import LocalOutput
 from portia.prefixed_uuid import PlanRunUUID
 from tests.utils import get_test_config, get_test_plan_run
 
@@ -68,5 +69,5 @@ def test_output_serialize() -> None:
     ]
 
     for tc in tcs:
-        output = Output(value=tc[0]).serialize_value(tc[0])
+        output = LocalOutput(value=tc[0]).serialize_value()
         assert output == tc[1]

--- a/tests/unit/execution_agents/test_base_execution_agent.py
+++ b/tests/unit/execution_agents/test_base_execution_agent.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
-from portia.execution_agents.base_execution_agent import BaseExecutionAgent
-from portia.execution_context import execution_context
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from openai import BaseModel
+from pydantic import HttpUrl
+
+from portia.clarification import ActionClarification
+from portia.config import LLMModel
+from portia.execution_agents.base_execution_agent import BaseExecutionAgent, Output
+from portia.prefixed_uuid import PlanRunUUID
 from tests.utils import get_test_config, get_test_plan_run
 
 
@@ -20,16 +29,44 @@ def test_base_agent_default_context() -> None:
     assert context is not None
 
 
-def test_base_agent_default_context_with_extensions() -> None:
-    """Test default context."""
-    plan, plan_run = get_test_plan_run()
-    agent = BaseExecutionAgent(
-        plan.steps[0],
-        plan_run,
-        get_test_config(),
-        None,
+def test_output_serialize() -> None:
+    """Test output serialize."""
+
+    class MyModel(BaseModel):
+        id: str
+
+    class NotAModel:
+        id: str
+
+        def __init__(self, id: str) -> None:  # noqa: A002
+            self.id = id
+
+    not_a_model = NotAModel(id="123")
+    now = datetime.now(tz=UTC)
+    clarification = ActionClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="",
+        action_url=HttpUrl("https://example.com"),
     )
-    with execution_context(agent_system_context_extension=["456"]):
-        context = agent.get_system_context()
-    assert context is not None
-    assert "456" in context
+
+    tcs: list[tuple[Any, Any]] = [
+        ("Hello World!", "Hello World!"),
+        (None, ""),
+        ({"hello": "world"}, json.dumps({"hello": "world"})),
+        ([{"hello": "world"}], json.dumps([{"hello": "world"}])),
+        (("hello", "world"), json.dumps(["hello", "world"])),
+        ({"hello"}, json.dumps(["hello"])),  # sets don't have ordering
+        (1, "1"),
+        (1.23, "1.23"),
+        (False, "false"),
+        (LLMModel.GPT_4_O, str(LLMModel.GPT_4_O.value)),
+        (MyModel(id="123"), MyModel(id="123").model_dump_json()),
+        (b"Hello World!", "Hello World!"),
+        (now, now.isoformat()),
+        (not_a_model, str(not_a_model)),
+        ([clarification], json.dumps([clarification.model_dump(mode="json")])),
+    ]
+
+    for tc in tcs:
+        output = Output(value=tc[0]).serialize_value(tc[0])
+        assert output == tc[1]

--- a/tests/unit/execution_agents/test_base_execution_agent.py
+++ b/tests/unit/execution_agents/test_base_execution_agent.py
@@ -11,7 +11,7 @@ from pydantic import HttpUrl
 
 from portia.clarification import ActionClarification
 from portia.config import LLMModel
-from portia.execution_agents.base_execution_agent import BaseExecutionAgent, Output
+from portia.execution_agents.base_execution_agent import BaseExecutionAgent
 from portia.execution_agents.output import LocalOutput
 from portia.prefixed_uuid import PlanRunUUID
 from tests.utils import get_test_config, get_test_plan_run

--- a/tests/unit/execution_agents/test_context.py
+++ b/tests/unit/execution_agents/test_context.py
@@ -8,7 +8,7 @@ from pydantic import HttpUrl
 from portia.clarification import ActionClarification, InputClarification
 from portia.execution_agents.context import build_context
 from portia.execution_agents.output import LocalOutput, Output
-from portia.execution_context import ExecutionContext
+from portia.execution_context import ExecutionContext, get_execution_context
 from portia.plan import Step, Variable
 from tests.utils import get_test_plan_run
 
@@ -84,20 +84,6 @@ def test_context_inputs_and_outputs(inputs: list[Variable], outputs: dict[str, O
             assert val in context
 
 
-def test_system_context() -> None:
-    """Test that the system context is set up correctly."""
-    (plan, plan_run) = get_test_plan_run()
-    context = build_context(
-        ExecutionContext(
-            execution_agent_system_context_extension=["system context 1", "system context 2"],
-        ),
-        plan.steps[0],
-        plan_run,
-    )
-    assert "system context 1" in context
-    assert "system context 2" in context
-
-
 def test_all_contexts(inputs: list[Variable], outputs: dict[str, Output]) -> None:
     """Test that the context is set up correctly with all contexts."""
     (plan, plan_run) = get_test_plan_run()
@@ -127,7 +113,6 @@ def test_all_contexts(inputs: list[Variable], outputs: dict[str, Output]) -> Non
     plan_run.outputs.clarifications = clarifications
     context = build_context(
         ExecutionContext(
-            execution_agent_system_context_extension=["system context 1", "system context 2"],
             end_user_id="123",
             additional_data={"email": "hello@world.com"},
         ),
@@ -167,9 +152,7 @@ end_user_id: 123
 context_key_name: email context_key_value: hello@world.com
 ----------
 System Context:
-Today's date is {datetime.now(UTC).strftime('%Y-%m-%d')}
-system context 1
-system context 2"""
+Today's date is {datetime.now(UTC).strftime('%Y-%m-%d')}"""
     )
 
 
@@ -198,9 +181,7 @@ def test_context_inputs_outputs_clarifications(
     plan_run.outputs.step_outputs = outputs
     plan_run.outputs.clarifications = clarifications
     context = build_context(
-        ExecutionContext(
-            execution_agent_system_context_extension=["system context 1", "system context 2"],
-        ),
+        get_execution_context(),
         plan.steps[0],
         plan_run,
     )

--- a/tests/unit/open_source_tools/test_image_understanding_tool.py
+++ b/tests/unit/open_source_tools/test_image_understanding_tool.py
@@ -113,8 +113,6 @@ def test_image_understanding_tool_run_with_context(
     mock_model.to_langchain.return_value.invoke.return_value = mock_response
     # Define task and context
     mock_image_understanding_tool.tool_context = "Context for task"
-    exec_context = mock_tool_run_context.execution_context
-    exec_context.plan_run_context = "Context from plan run context"
     schema_data = {
         "task": "What is the capital of France?",
         "image_url": "https://example.com/map.png",
@@ -129,6 +127,5 @@ def test_image_understanding_tool_run_with_context(
     assert isinstance(called_with[0], HumanMessage)
     assert isinstance(called_with[1], HumanMessage)
     assert mock_image_understanding_tool.tool_context in called_with[1].content[0]["text"]
-    assert exec_context.plan_run_context in called_with[1].content[0]["text"]
     # Assert the result is the expected response
     assert result == "Test response content"


### PR DESCRIPTION
# Description

Removes the ability to add system context extensions via execution context. This is the first step in removing execution context. 

Associated docs change: https://github.com/portiaAI/docs/pull/83/files

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [x] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [x] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
