### PR TITLE
Fixed the step summarizer to include tool's description in context

### DIFF
--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -647,7 +647,7 @@ class DefaultExecutionAgent(BaseExecutionAgent):
             )
 
         graph.add_node(AgentNode.TOOLS, tool_node)
-        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm, self.tool).invoke)
+        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm, self.tool, self.step).invoke)
         graph.add_conditional_edges(
             AgentNode.TOOLS,
             lambda state: next_state_after_tool_call(state, self.tool),

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -197,7 +197,7 @@ class OneShotAgent(BaseExecutionAgent):
             OneShotToolCallingModel(llm, context, tools, self).invoke,
         )
         graph.add_node(AgentNode.TOOLS, tool_node)
-        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm).invoke)
+        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm, self.tool).invoke)
         graph.add_edge(START, AgentNode.TOOL_AGENT)
 
         # Use execution manager for state transitions

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -197,7 +197,7 @@ class OneShotAgent(BaseExecutionAgent):
             OneShotToolCallingModel(llm, context, tools, self).invoke,
         )
         graph.add_node(AgentNode.TOOLS, tool_node)
-        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm, self.tool).invoke)
+        graph.add_node(AgentNode.SUMMARIZER, StepSummarizer(llm, self.tool, self.step).invoke)
         graph.add_edge(START, AgentNode.TOOL_AGENT)
 
         # Use execution manager for state transitions

--- a/portia/execution_agents/utils/step_summarizer.py
+++ b/portia/execution_agents/utils/step_summarizer.py
@@ -15,10 +15,11 @@ from langgraph.graph import MessagesState  # noqa: TC002
 from portia.execution_agents.base_execution_agent import Output
 from portia.logger import logger
 from portia.planning_agents.context import get_tool_descriptions_for_tools
-from portia.tool import Tool
 
 if TYPE_CHECKING:
     from langchain.chat_models.base import BaseChatModel
+
+    from portia.tool import Tool
 
 
 class StepSummarizer:

--- a/portia/execution_agents/utils/step_summarizer.py
+++ b/portia/execution_agents/utils/step_summarizer.py
@@ -32,6 +32,7 @@ class StepSummarizer:
         summarizer_prompt (ChatPromptTemplate): The prompt template used to generate the summary.
         llm (BaseChatModel): The language model used for summarization.
         summary_max_length (int): The maximum length of the summary.
+        step (Step): The step that produced the output.
 
     """
 

--- a/portia/execution_agents/utils/step_summarizer.py
+++ b/portia/execution_agents/utils/step_summarizer.py
@@ -14,12 +14,12 @@ from langgraph.graph import MessagesState  # noqa: TC002
 
 from portia.execution_agents.base_execution_agent import Output
 from portia.logger import logger
-from portia.plan import Step
 from portia.planning_agents.context import get_tool_descriptions_for_tools
 
 if TYPE_CHECKING:
     from langchain.chat_models.base import BaseChatModel
 
+    from portia.plan import Step
     from portia.tool import Tool
 
 
@@ -68,6 +68,7 @@ class StepSummarizer:
         Args:
             llm (BaseChatModel): The language model used for summarization.
             tool (Tool): The tool used for summarization.
+            step (Step): The step that produced the output.
             summary_max_length (int): The maximum length of the summary. Default is 500 characters.
 
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ runtime-evaluated-base-classes = [
   "pydantic.BaseModel", # Tells ruff that BaseModel instances need to be evaluated at runtime.
 ]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true  # Allows **kwargs: Any in type signatures.
 
 [build-system]

--- a/tests/unit/execution_agents/utils/test_step_summarizer.py
+++ b/tests/unit/execution_agents/utils/test_step_summarizer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 from portia.execution_agents.base_execution_agent import Output
 from portia.execution_agents.utils.step_summarizer import StepSummarizer
-from tests.utils import get_test_llm_wrapper
+from tests.utils import AdditionTool, get_test_llm_wrapper
 
 
 class MockInvoker:
@@ -59,6 +59,7 @@ class MockInvoker:
 def test_summarizer_model_normal_output(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the summarizer model with valid tool message."""
     summary = AIMessage(content="Short summary")
+    tool = AdditionTool()
     mock_invoker = MockInvoker(response=summary)
     monkeypatch.setattr(ChatOpenAI, "invoke", mock_invoker.invoke)
     monkeypatch.setattr(ChatOpenAI, "with_structured_output", mock_invoker.with_structured_output)
@@ -66,12 +67,13 @@ def test_summarizer_model_normal_output(monkeypatch: pytest.MonkeyPatch) -> None
     tool_message = ToolMessage(
         content="Tool output content",
         tool_call_id="123",
-        name="test_tool",
+        name=tool.name,
         artifact=Output(value="Tool output value"),
     )
 
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
+        tool=tool,
     )
     result = summarizer_model.invoke({"messages": [tool_message]})
 
@@ -97,6 +99,7 @@ def test_summarizer_model_non_tool_message(monkeypatch: pytest.MonkeyPatch) -> N
 
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
+        tool=AdditionTool(),
     )
     result = summarizer_model.invoke({"messages": [ai_message]})
 
@@ -112,6 +115,7 @@ def test_summarizer_model_no_messages(monkeypatch: pytest.MonkeyPatch) -> None:
 
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
+        tool=AdditionTool(),
     )
     result = summarizer_model.invoke({"messages": []})
 
@@ -141,7 +145,10 @@ def test_summarizer_model_error_handling(monkeypatch: pytest.MonkeyPatch) -> Non
         artifact=Output(value="Tool output value"),
     )
 
-    summarizer_model = StepSummarizer(llm=get_test_llm_wrapper().to_langchain())
+    summarizer_model = StepSummarizer(
+        llm=get_test_llm_wrapper().to_langchain(),
+        tool=AdditionTool(),
+    )
     result = summarizer_model.invoke({"messages": [tool_message]})
 
     # Should return original message without summaries when error occurs

--- a/tests/unit/execution_agents/utils/test_step_summarizer.py
+++ b/tests/unit/execution_agents/utils/test_step_summarizer.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 from langchain_openai import ChatOpenAI
 
+from portia.plan import Step
+
 if TYPE_CHECKING:
     import pytest
     from pydantic import BaseModel
@@ -74,6 +76,7 @@ def test_summarizer_model_normal_output(monkeypatch: pytest.MonkeyPatch) -> None
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
         tool=tool,
+        step=Step(task="Test task", output="$output"),
     )
     result = summarizer_model.invoke({"messages": [tool_message]})
 
@@ -100,6 +103,7 @@ def test_summarizer_model_non_tool_message(monkeypatch: pytest.MonkeyPatch) -> N
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
         tool=AdditionTool(),
+        step=Step(task="Test task", output="$output"),
     )
     result = summarizer_model.invoke({"messages": [ai_message]})
 
@@ -116,6 +120,7 @@ def test_summarizer_model_no_messages(monkeypatch: pytest.MonkeyPatch) -> None:
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
         tool=AdditionTool(),
+        step=Step(task="Test task", output="$output"),
     )
     result = summarizer_model.invoke({"messages": []})
 
@@ -148,6 +153,7 @@ def test_summarizer_model_error_handling(monkeypatch: pytest.MonkeyPatch) -> Non
     summarizer_model = StepSummarizer(
         llm=get_test_llm_wrapper().to_langchain(),
         tool=AdditionTool(),
+        step=Step(task="Test task", output="$output"),
     )
     result = summarizer_model.invoke({"messages": [tool_message]})
 


### PR DESCRIPTION
# Description

- This is to fix the step summary to be more accurate the nature of the output of the tools. E.g. for google tools check availability tool is mistakenly assumes the output is an event created.
- The fix is to include the tool's description (and output schema..etc), when summarising the output. This also helps the introspection takes more accurate decisions based on output of steps.


Ticket Link: https://linear.app/portialabs/issue/POR-1089/summarizer-producing-bad-output-for-google-calendar-tool

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Check Availability Summary

**Before**:
```
"value": "[{\"start\": \"2025-04-01T00:00:00+0000\", \"end\": \"2025-04-03T00:00:00+0000\"}]",
"summary": "Event scheduled from April 1 to April 3, 2025."
```
**After**:
```
"value": "[{\"start\": \"2025-04-01T00:00:00+0000\", \"end\": \"2025-04-03T00:00:00+0000\"}]",
"summary": "The user is available from April 1, 2025, to April 3, 2025."
```

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
