### PR TITLE
fix for double planning

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -289,7 +289,7 @@ def run(
             if not click.confirm("Do you want to execute the plan?"):
                 return
 
-        plan_run = portia.run(query)
+        plan_run = portia.run_plan(plan)
         click.echo(plan_run.model_dump_json(indent=4))
 
 


### PR DESCRIPTION
# Description
CLI double plans atm, leading to issues with the stated plan and input/output/tool matching. 

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
