### PR TITLE
Refactor ToolRegistry to simplify code. Add model field to LLMTool, Image tool and browser tool

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -273,8 +273,6 @@ class LogLevel(Enum):
 PLANNING_MODEL_KEY = "planning_model_name"
 EXECUTION_MODEL_KEY = "execution_model_name"
 INTROSPECTION_MODEL_KEY = "introspection_model_name"
-LLM_TOOL_MODEL_KEY = "llm_tool_model_name"
-IMAGE_TOOL_MODEL_KEY = "image_tool_model_name"
 SUMMARISER_MODEL_KEY = "summariser_model_name"
 DEFAULT_MODEL_KEY = "default_model_name"
 PLANNING_DEFAULT_MODEL_KEY = "planning_default_model_name"
@@ -454,14 +452,14 @@ class Config(BaseModel):
             return self.models.get(PLANNING_MODEL_KEY, self.models[PLANNING_DEFAULT_MODEL_KEY])
         return self.models.get(usage, self.models[DEFAULT_MODEL_KEY])
 
-    def resolve_model(self, usage: str) -> GenerativeModel:
+    def resolve_model(self, usage: str = DEFAULT_MODEL_KEY) -> GenerativeModel:
         """Resolve a model from the config."""
         if usage in self.custom_models:
             return self.custom_models[usage]
         model = self.model(usage)
         return self._construct_model(model)
 
-    def resolve_langchain_model(self, usage: str) -> LangChainGenerativeModel:
+    def resolve_langchain_model(self, usage: str = DEFAULT_MODEL_KEY) -> LangChainGenerativeModel:
         """Resolve a LangChain model from the config."""
         model = self.resolve_model(usage)
         if isinstance(model, LangChainGenerativeModel):
@@ -715,8 +713,6 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
         PLANNING_MODEL_KEY,
         INTROSPECTION_MODEL_KEY,
         EXECUTION_MODEL_KEY,
-        LLM_TOOL_MODEL_KEY,
-        IMAGE_TOOL_MODEL_KEY,
         SUMMARISER_MODEL_KEY,
     ]:
         model_name = kwargs.pop(model_usage, llm_model_name)

--- a/portia/open_source_tools/image_understanding_tool.py
+++ b/portia/open_source_tools/image_understanding_tool.py
@@ -10,8 +10,8 @@ from typing import Any, Self
 from langchain.schema import HumanMessage
 from pydantic import BaseModel, Field, model_validator
 
-from portia.config import IMAGE_TOOL_MODEL_KEY
 from portia.errors import ToolHardError
+from portia.model import LangChainGenerativeModel  # noqa: TC001 - used in Pydantic Schema
 from portia.tool import Tool, ToolRunContext
 
 
@@ -63,9 +63,16 @@ class ImageUnderstandingTool(Tool[str]):
         """
     tool_context: str = ""
 
+    model: LangChainGenerativeModel | None = Field(
+        default=None,
+        exclude=True,
+        description="The model to use for the ImageUnderstandingTool. If not provided, "
+        "the model will be resolved from the config.",
+    )
+
     def run(self, ctx: ToolRunContext, **kwargs: Any) -> str:
         """Run the ImageTool."""
-        model = ctx.config.resolve_langchain_model(IMAGE_TOOL_MODEL_KEY)
+        model = self.model or ctx.config.resolve_langchain_model()
 
         tool_schema = ImageUnderstandingToolSchema(**kwargs)
 

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -6,8 +6,7 @@ from typing import ClassVar
 
 from pydantic import BaseModel, Field
 
-from portia.config import LLM_TOOL_MODEL_KEY
-from portia.model import Message
+from portia.model import GenerativeModel, Message
 from portia.tool import Tool, ToolRunContext
 
 
@@ -54,9 +53,16 @@ class LLMTool(Tool[str]):
         """
     tool_context: str = ""
 
+    model: GenerativeModel | None = Field(
+        default=None,
+        exclude=True,
+        description="The model to use for the LLMTool. If not provided, "
+        "the model will be resolved from the config.",
+    )
+
     def run(self, ctx: ToolRunContext, task: str) -> str:
         """Run the LLMTool."""
-        model = ctx.config.resolve_model(LLM_TOOL_MODEL_KEY)
+        model = self.model or ctx.config.resolve_model()
 
         # Define system and user messages
         context = (

--- a/portia/open_source_tools/registry.py
+++ b/portia/open_source_tools/registry.py
@@ -10,17 +10,17 @@ from portia.open_source_tools.local_file_writer_tool import FileWriterTool
 from portia.open_source_tools.search_tool import SearchTool
 from portia.open_source_tools.weather import WeatherTool
 from portia.tool_registry import (
-    InMemoryToolRegistry,
+    ToolRegistry,
 )
 
 logger = logging.getLogger(__name__)
 
-example_tool_registry = InMemoryToolRegistry.from_local_tools(
+example_tool_registry = ToolRegistry(
     [CalculatorTool(), WeatherTool(), SearchTool()],
 )
 
 
-open_source_tool_registry = InMemoryToolRegistry.from_local_tools(
+open_source_tool_registry = ToolRegistry(
     [
         CalculatorTool(),
         WeatherTool(),

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -107,7 +107,7 @@ class Tool(BaseModel, Generic[SERIALIZABLE_TYPE_VAR]):
 
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     id: str = Field(description="ID of the tool")
     name: str = Field(description="Name of the tool")

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -23,7 +23,7 @@ from portia.open_source_tools.registry import example_tool_registry
 from portia.plan import Plan, PlanContext, Step, Variable
 from portia.plan_run import PlanRunState
 from portia.portia import ExecutionHooks, Portia
-from portia.tool_registry import InMemoryToolRegistry
+from portia.tool_registry import ToolRegistry
 from tests.utils import AdditionTool, ClarificationTool, ErrorTool, TestClarificationHandler
 
 if TYPE_CHECKING:
@@ -76,7 +76,7 @@ def test_portia_run_query(
     addition_tool = AdditionTool()
     addition_tool.should_summarize = True
 
-    tool_registry = InMemoryToolRegistry.from_local_tools([addition_tool])
+    tool_registry = ToolRegistry([addition_tool])
     portia = Portia(config=config, tools=tool_registry)
     query = "Add 1 + 2"
 
@@ -102,7 +102,7 @@ def test_portia_generate_plan(
         storage_class=StorageClass.MEMORY,
     )
 
-    tool_registry = InMemoryToolRegistry.from_local_tools([AdditionTool()])
+    tool_registry = ToolRegistry([AdditionTool()])
     portia = Portia(config=config, tools=tool_registry)
     query = "Add 1 + 2"
 
@@ -130,7 +130,7 @@ def test_portia_run_query_with_clarifications(
     )
 
     test_clarification_handler = TestClarificationHandler()
-    tool_registry = InMemoryToolRegistry.from_local_tools([ClarificationTool()])
+    tool_registry = ToolRegistry([ClarificationTool()])
     portia = Portia(
         config=config,
         tools=tool_registry,
@@ -169,7 +169,7 @@ def test_portia_run_query_with_clarifications_no_handler() -> None:
         storage_class=StorageClass.MEMORY,
     )
 
-    tool_registry = InMemoryToolRegistry.from_local_tools([ClarificationTool()])
+    tool_registry = ToolRegistry([ClarificationTool()])
     portia = Portia(config=config, tools=tool_registry)
     clarification_step = Step(
         tool_id="clarification_tool",
@@ -214,7 +214,7 @@ def test_portia_run_query_with_hard_error(
         execution_agent_type=agent,
         storage_class=StorageClass.MEMORY,
     )
-    tool_registry = InMemoryToolRegistry.from_local_tools([ErrorTool()])
+    tool_registry = ToolRegistry([ErrorTool()])
     portia = Portia(config=config, tools=tool_registry)
     clarification_step = Step(
         tool_id="error_tool",
@@ -260,7 +260,7 @@ def test_portia_run_query_with_soft_error(
         def run(self, _: ToolRunContext, a: int, b: int) -> int:  # noqa: ARG002
             raise ToolSoftError("Server Timeout")
 
-    tool_registry = InMemoryToolRegistry.from_local_tools([MyAdditionTool()])
+    tool_registry = ToolRegistry([MyAdditionTool()])
     portia = Portia(config=config, tools=tool_registry)
     clarification_step = Step(
         tool_id="add_tool",
@@ -314,7 +314,7 @@ def test_portia_run_query_with_multiple_clarifications(
 
     test_clarification_handler = TestClarificationHandler()
     test_clarification_handler.clarification_response = 456
-    tool_registry = InMemoryToolRegistry.from_local_tools([MyAdditionTool()])
+    tool_registry = ToolRegistry([MyAdditionTool()])
     portia = Portia(
         config=config,
         tools=tool_registry,
@@ -407,7 +407,7 @@ def test_portia_run_query_with_multiple_async_clarifications(
     test_clarification_handler = ActionClarificationHandler()
     portia = Portia(
         config=config,
-        tools=InMemoryToolRegistry.from_local_tools([MyAdditionTool()]),
+        tools=ToolRegistry([MyAdditionTool()]),
         execution_hooks=ExecutionHooks(clarification_handler=test_clarification_handler),
     )
 

--- a/tests/integration/test_runner_context.py
+++ b/tests/integration/test_runner_context.py
@@ -8,7 +8,7 @@ from portia.plan import Plan, PlanContext, Step
 from portia.plan_run import PlanRun, PlanRunState
 from portia.portia import Portia
 from portia.tool import Tool, ToolRunContext
-from portia.tool_registry import InMemoryToolRegistry
+from portia.tool_registry import ToolRegistry
 
 
 class ExecutionContextTrackerTool(Tool):
@@ -52,7 +52,7 @@ def get_test_plan_run() -> tuple[Plan, PlanRun]:
 def test_portia_no_execution_context_new() -> None:
     """Test running a query."""
     tool = ExecutionContextTrackerTool()
-    tool_registry = InMemoryToolRegistry.from_local_tools([tool])
+    tool_registry = ToolRegistry([tool])
     portia = Portia(tools=tool_registry, config=default_config(storage_class=StorageClass.MEMORY))
     (plan, plan_run) = get_test_plan_run()
     portia.storage.save_plan(plan)
@@ -66,7 +66,7 @@ def test_portia_no_execution_context_new() -> None:
 def test_portia_no_execution_context_existing() -> None:
     """Test running a query."""
     tool = ExecutionContextTrackerTool()
-    tool_registry = InMemoryToolRegistry.from_local_tools([tool])
+    tool_registry = ToolRegistry([tool])
     portia = Portia(tools=tool_registry, config=default_config(storage_class=StorageClass.MEMORY))
     (plan, plan_run) = get_test_plan_run()
     plan_run.execution_context = ExecutionContext(end_user_id="123")
@@ -82,7 +82,7 @@ def test_portia_no_execution_context_existing() -> None:
 def test_portia_with_execution_context_new() -> None:
     """Test running a query."""
     tool = ExecutionContextTrackerTool()
-    tool_registry = InMemoryToolRegistry.from_local_tools([tool])
+    tool_registry = ToolRegistry([tool])
     portia = Portia(tools=tool_registry, config=default_config(storage_class=StorageClass.MEMORY))
     (plan, plan_run) = get_test_plan_run()
     portia.storage.save_plan(plan)
@@ -99,7 +99,7 @@ def test_portia_with_execution_context_new() -> None:
 def test_portia_with_execution_context_existing() -> None:
     """Test running a query."""
     tool = ExecutionContextTrackerTool()
-    tool_registry = InMemoryToolRegistry.from_local_tools([tool])
+    tool_registry = ToolRegistry([tool])
     portia = Portia(tools=tool_registry, config=default_config(storage_class=StorageClass.MEMORY))
     (plan, plan_run) = get_test_plan_run()
     plan_run.execution_context = ExecutionContext()

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -36,7 +36,7 @@ from portia.plan_run import PlanRun, PlanRunOutputs, PlanRunState, PlanRunUUID, 
 from portia.planning_agents.base_planning_agent import StepsOrError
 from portia.portia import ExecutionHooks, Portia
 from portia.tool import Tool, ToolRunContext
-from portia.tool_registry import InMemoryToolRegistry
+from portia.tool_registry import ToolRegistry
 from tests.utils import (
     AdditionTool,
     ClarificationTool,
@@ -67,7 +67,7 @@ def portia(planning_model: MagicMock, default_model: MagicMock) -> Portia:
             DEFAULT_MODEL_KEY: default_model,
         },
     )
-    tool_registry = InMemoryToolRegistry.from_local_tools([AdditionTool(), ClarificationTool()])
+    tool_registry = ToolRegistry([AdditionTool(), ClarificationTool()])
     return Portia(config=config, tools=tool_registry)
 
 
@@ -83,7 +83,7 @@ def portia_with_agent_memory(planning_model: MagicMock, default_model: MagicMock
             DEFAULT_MODEL_KEY: default_model,
         },
     )
-    tool_registry = InMemoryToolRegistry.from_local_tools([AdditionTool(), ClarificationTool()])
+    tool_registry = ToolRegistry([AdditionTool(), ClarificationTool()])
     return Portia(config=config, tools=tool_registry)
 
 
@@ -171,7 +171,7 @@ def test_portia_run_query_disk_storage(planning_model: MagicMock) -> None:
                 PLANNING_MODEL_KEY: planning_model,
             },
         )
-        tool_registry = InMemoryToolRegistry.from_local_tools([AdditionTool(), ClarificationTool()])
+        tool_registry = ToolRegistry([AdditionTool(), ClarificationTool()])
         portia = Portia(config=config, tools=tool_registry)
 
         planning_model.get_structured_response.return_value = StepsOrError(steps=[], error=None)
@@ -351,7 +351,7 @@ def test_portia_wait_for_ready_tool(portia: Portia) -> None:
             mock_call_count.count += 1
             return mock_call_count.count == 3
 
-    portia.tool_registry = InMemoryToolRegistry.from_local_tools([ReadyTool()])
+    portia.tool_registry = ToolRegistry([ReadyTool()])
     step0 = Step(
         task="Do something",
         inputs=[],

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -12,193 +12,159 @@ from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
 from portia.errors import DuplicateToolError, ToolNotFoundError
-from portia.tool import Tool
 from portia.tool_registry import (
-    AggregatedToolRegistry,
     InMemoryToolRegistry,
     McpToolRegistry,
+    PortiaToolRegistry,
     ToolRegistry,
     generate_pydantic_model_from_json_schema,
 )
-from tests.utils import AdditionTool, MockMcpSessionWrapper, MockTool, get_test_tool_context
+from tests.utils import MockMcpSessionWrapper, MockTool, get_test_tool_context
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from pytest_mock import MockerFixture
 
-    from portia.tool import Tool
-
 
 MOCK_TOOL_ID = "mock_tool"
 OTHER_MOCK_TOOL_ID = "other_mock_tool"
 
 
-def test_registry_base_classes() -> None:
-    """Test registry raises."""
-
-    class MyRegistry(ToolRegistry):
-        """Override to test base."""
-
-        def get_tools(self) -> list[Tool]:
-            return super().get_tools()  # type: ignore  # noqa: PGH003
-
-        def get_tool(self, tool_id: str) -> Tool:
-            return super().get_tool(tool_id)  # type: ignore  # noqa: PGH003
-
-        def register_tool(self, tool: Tool) -> None:
-            return super().register_tool(tool)  # type: ignore  # noqa: PGH003
-
-        def match_tools(
-            self,
-            query: str | None = None,
-            tool_ids: list[str] | None = None,
-        ) -> list[Tool]:
-            return super().match_tools(query, tool_ids)
-
-    registry = MyRegistry()
-
-    with pytest.raises(NotImplementedError):
-        registry.get_tools()
-
-    with pytest.raises(NotImplementedError):
-        registry.get_tool("1")
-
-    with pytest.raises(NotImplementedError):
-        registry.register_tool(AdditionTool())
-
-    with pytest.raises(NotImplementedError):
-        registry.match_tools("match")
-
-    agg_registry = AggregatedToolRegistry(registries=[registry])
-    with pytest.raises(NotImplementedError):
-        agg_registry.register_tool(AdditionTool())
-
-
-def test_local_tool_registry_register_tool() -> None:
-    """Test registering tools in the InMemoryToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry()
-    local_tool_registry.register_tool(MockTool(id=MOCK_TOOL_ID))
-    tool1 = local_tool_registry.get_tool(MOCK_TOOL_ID)
+def test_tool_registry_register_tool() -> None:
+    """Test registering tools in the ToolRegistry."""
+    tool_registry = ToolRegistry()
+    tool_registry.with_tool(MockTool(id=MOCK_TOOL_ID))
+    tool1 = tool_registry.get_tool(MOCK_TOOL_ID)
     assert tool1.id == MOCK_TOOL_ID
 
     with pytest.raises(ToolNotFoundError):
-        local_tool_registry.get_tool("tool3")
+        tool_registry.get_tool("tool3")
 
     with pytest.raises(DuplicateToolError):
-        local_tool_registry.register_tool(MockTool(id=MOCK_TOOL_ID))
+        tool_registry.with_tool(MockTool(id=MOCK_TOOL_ID))
+
+    tool_registry.replace_tool(
+        MockTool(
+            id=MOCK_TOOL_ID,
+            name="New Mock Tool",
+        ),
+    )
+    tool2 = tool_registry.get_tool(MOCK_TOOL_ID)
+    assert tool2.id == MOCK_TOOL_ID
+    assert tool2.name == "New Mock Tool"
 
 
-def test_local_tool_registry_get_and_plan_run() -> None:
+def test_tool_registry_get_and_plan_run() -> None:
     """Test getting and running tools in the InMemoryToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry()
-    local_tool_registry.register_tool(MockTool(id=MOCK_TOOL_ID))
-    tool1 = local_tool_registry.get_tool(MOCK_TOOL_ID)
+    tool_registry = ToolRegistry()
+    tool_registry.with_tool(MockTool(id=MOCK_TOOL_ID))
+    tool1 = tool_registry.get_tool(MOCK_TOOL_ID)
     ctx = get_test_tool_context()
     tool1.run(ctx)
 
 
-def test_local_tool_registry_get_tools() -> None:
+def test_tool_registry_get_tools() -> None:
     """Test the get_tools method of InMemoryToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools(
+    tool_registry = ToolRegistry(
         [MockTool(id=MOCK_TOOL_ID), MockTool(id=OTHER_MOCK_TOOL_ID)],
     )
-    tools = local_tool_registry.get_tools()
+    tools = tool_registry.get_tools()
     assert len(tools) == 2
     assert any(tool.id == MOCK_TOOL_ID for tool in tools)
     assert any(tool.id == OTHER_MOCK_TOOL_ID for tool in tools)
 
 
-def test_local_tool_registry_match_tools() -> None:
+def test_tool_registry_match_tools() -> None:
     """Test matching tools in the InMemoryToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools(
+    tool_registry = ToolRegistry(
         [MockTool(id=MOCK_TOOL_ID), MockTool(id=OTHER_MOCK_TOOL_ID)],
     )
 
     # Test matching specific tool ID
-    matched_tools = local_tool_registry.match_tools(tool_ids=[MOCK_TOOL_ID])
+    matched_tools = tool_registry.match_tools(tool_ids=[MOCK_TOOL_ID])
     assert len(matched_tools) == 1
     assert matched_tools[0].id == MOCK_TOOL_ID
 
     # Test matching multiple tool IDs
-    matched_tools = local_tool_registry.match_tools(
+    matched_tools = tool_registry.match_tools(
         tool_ids=[MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID],
     )
     assert len(matched_tools) == 2
     assert {tool.id for tool in matched_tools} == {MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID}
 
     # Test matching non-existent tool ID
-    matched_tools = local_tool_registry.match_tools(tool_ids=["non_existent_tool"])
+    matched_tools = tool_registry.match_tools(tool_ids=["non_existent_tool"])
     assert len(matched_tools) == 0
 
     # Test with no tool_ids (should return all tools)
-    matched_tools = local_tool_registry.match_tools()
+    matched_tools = tool_registry.match_tools()
     assert len(matched_tools) == 2
     assert {tool.id for tool in matched_tools} == {MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID}
 
 
-def test_aggregated_tool_registry_duplicate_tool() -> None:
-    """Test searching across multiple registries in AggregatedToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
-    other_tool_registry = InMemoryToolRegistry.from_local_tools(
+def test_combined_tool_registry_duplicate_tool() -> None:
+    """Test searching across multiple registries in ToolRegistry."""
+    tool_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
+    other_tool_registry = ToolRegistry(
         [MockTool(id=MOCK_TOOL_ID)],
     )
-    aggregated_tool_registry = local_tool_registry + other_tool_registry
+    combined_tool_registry = tool_registry + other_tool_registry
 
-    tool1 = aggregated_tool_registry.get_tool(MOCK_TOOL_ID)
+    tool1 = combined_tool_registry.get_tool(MOCK_TOOL_ID)
     assert tool1.id == MOCK_TOOL_ID
 
 
-def test_aggregated_tool_registry_get_tool() -> None:
-    """Test searching across multiple registries in AggregatedToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
-    other_tool_registry = InMemoryToolRegistry.from_local_tools(
+def test_combined_tool_registry_get_tool() -> None:
+    """Test searching across multiple registries in ToolRegistry."""
+    tool_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
+    other_tool_registry = ToolRegistry(
         [MockTool(id=OTHER_MOCK_TOOL_ID)],
     )
-    aggregated_tool_registry = local_tool_registry + other_tool_registry
+    combined_tool_registry = tool_registry + other_tool_registry
 
-    tool1 = aggregated_tool_registry.get_tool(MOCK_TOOL_ID)
+    tool1 = combined_tool_registry.get_tool(MOCK_TOOL_ID)
     assert tool1.id == MOCK_TOOL_ID
 
     with pytest.raises(ToolNotFoundError):
-        aggregated_tool_registry.get_tool("tool_not_found")
+        combined_tool_registry.get_tool("tool_not_found")
 
 
-def test_aggregated_tool_registry_get_tools() -> None:
-    """Test getting all tools from an AggregatedToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
-    other_tool_registry = InMemoryToolRegistry.from_local_tools(
+def test_combined_tool_registry_get_tools() -> None:
+    """Test getting all tools from an ToolRegistry."""
+    tool_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
+    other_tool_registry = ToolRegistry(
         [MockTool(id=OTHER_MOCK_TOOL_ID)],
     )
-    aggregated_tool_registry = local_tool_registry + other_tool_registry
+    combined_tool_registry = tool_registry + other_tool_registry
 
-    tools = aggregated_tool_registry.get_tools()
+    tools = combined_tool_registry.get_tools()
     assert len(tools) == 2
     assert any(tool.id == MOCK_TOOL_ID for tool in tools)
 
 
-def test_aggregated_tool_registry_match_tools() -> None:
-    """Test matching tools across multiple registries in AggregatedToolRegistry."""
-    local_tool_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
-    other_tool_registry = InMemoryToolRegistry.from_local_tools(
+def test_combined_tool_registry_match_tools() -> None:
+    """Test matching tools across multiple registries in ToolRegistry."""
+    tool_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
+    other_tool_registry = ToolRegistry(
         [MockTool(id=OTHER_MOCK_TOOL_ID)],
     )
-    aggregated_tool_registry = local_tool_registry + other_tool_registry
+    combined_tool_registry = tool_registry + other_tool_registry
 
     # Test matching specific tool IDs
-    matched_tools = aggregated_tool_registry.match_tools(tool_ids=[MOCK_TOOL_ID])
+    matched_tools = combined_tool_registry.match_tools(tool_ids=[MOCK_TOOL_ID])
     assert len(matched_tools) == 1
     assert matched_tools[0].id == MOCK_TOOL_ID
 
     # Test matching multiple tool IDs
-    matched_tools = aggregated_tool_registry.match_tools(
+    matched_tools = combined_tool_registry.match_tools(
         tool_ids=[MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID],
     )
     assert len(matched_tools) == 2
     assert {tool.id for tool in matched_tools} == {MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID}
 
     # Test matching non-existent tool IDs
-    matched_tools = aggregated_tool_registry.match_tools(tool_ids=["non_existent_tool"])
+    matched_tools = combined_tool_registry.match_tools(tool_ids=["non_existent_tool"])
     assert len(matched_tools) == 0
 
 
@@ -209,34 +175,57 @@ def test_tool_registry_add_operators(mocker: MockerFixture) -> None:
     mocker.patch("portia.tool_registry.logger", return_value=mock_logger)
 
     # Create registries and tools
-    registry1 = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
-    registry2 = InMemoryToolRegistry.from_local_tools([MockTool(id=OTHER_MOCK_TOOL_ID)])
+    registry1 = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
+    registry2 = ToolRegistry([MockTool(id=OTHER_MOCK_TOOL_ID)])
     tool_list = [MockTool(id="tool3")]
 
     # Test registry + registry
     combined = registry1 + registry2
-    assert isinstance(combined, AggregatedToolRegistry)
+    assert isinstance(combined, ToolRegistry)
     assert len(combined.get_tools()) == 2
     assert {tool.id for tool in combined.get_tools()} == {MOCK_TOOL_ID, OTHER_MOCK_TOOL_ID}
 
     # Test registry + list
     combined = registry1 + tool_list  # type: ignore reportOperatorIssue
-    assert isinstance(combined, AggregatedToolRegistry)
+    assert isinstance(combined, ToolRegistry)
     assert len(combined.get_tools()) == 2
     assert {tool.id for tool in combined.get_tools()} == {MOCK_TOOL_ID, "tool3"}
 
     # Test list + registry (radd)
     combined = tool_list + registry1  # type: ignore reportOperatorIssue
-    assert isinstance(combined, AggregatedToolRegistry)
+    assert isinstance(combined, ToolRegistry)
     assert len(combined.get_tools()) == 2
     assert {tool.id for tool in combined.get_tools()} == {MOCK_TOOL_ID, "tool3"}
 
     # Test warning on duplicate tools
-    duplicate_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
+    duplicate_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID)])
     combined = registry1 + duplicate_registry
     mock_logger.warning.assert_called_once_with(
         f"Duplicate tool ID found: {MOCK_TOOL_ID}. Unintended behavior may occur.",
     )
+
+
+def test_in_memory_tool_registry_from_local_tools() -> None:
+    """Test creating an InMemoryToolRegistry from a list of local tools."""
+    tool_registry = InMemoryToolRegistry.from_local_tools([MockTool(id=MOCK_TOOL_ID)])
+    assert isinstance(tool_registry, InMemoryToolRegistry)
+    assert len(tool_registry.get_tools()) == 1
+    assert tool_registry.get_tool(MOCK_TOOL_ID).id == MOCK_TOOL_ID
+
+
+def test_tool_registry_filter_tools() -> None:
+    """Test filtering tools in a ToolRegistry."""
+    tool_registry = ToolRegistry([MockTool(id=MOCK_TOOL_ID), MockTool(id=OTHER_MOCK_TOOL_ID)])
+    filtered_registry = tool_registry.filter_tools(lambda tool: tool.id == MOCK_TOOL_ID)
+    filtered_tools = filtered_registry.get_tools()
+    assert len(filtered_tools) == 1
+    assert filtered_tools[0].id == MOCK_TOOL_ID
+
+
+def test_portia_tool_registry_missing_required_args() -> None:
+    """Test that PortiaToolRegistry raises an error if required args are missing."""
+    with pytest.raises(ValueError, match="Either config, client or tools must be provided"):
+        PortiaToolRegistry()
 
 
 @pytest.fixture
@@ -306,18 +295,6 @@ def test_mcp_tool_registry_get_tool(mcp_tool_registry: McpToolRegistry) -> None:
     assert tool.name == "test_tool"
     assert tool.description == "I am a tool"
     assert issubclass(tool.args_schema, BaseModel)
-
-
-def test_mcp_tool_registry_get_tool_not_found(mcp_tool_registry: McpToolRegistry) -> None:
-    """Test getting a tool from the MCPToolRegistry that does not exist."""
-    with pytest.raises(ToolNotFoundError):
-        mcp_tool_registry.get_tool("mcp:mock_mcp:non_existent_tool")
-
-
-def test_mcp_tool_registry_register_tool(mcp_tool_registry: McpToolRegistry) -> None:
-    """Test MCPToolRegistry.register_tool raises NotImplementedError."""
-    with pytest.raises(NotImplementedError):
-        mcp_tool_registry.register_tool(MockTool(id=MOCK_TOOL_ID))
 
 
 def test_generate_pydantic_model_from_json_schema() -> None:

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -12,6 +12,9 @@ from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
 from portia.errors import DuplicateToolError, ToolNotFoundError
+from portia.model import GenerativeModel
+from portia.open_source_tools.llm_tool import LLMTool
+from portia.open_source_tools.registry import open_source_tool_registry
 from portia.tool_registry import (
     InMemoryToolRegistry,
     McpToolRegistry,
@@ -226,6 +229,21 @@ def test_portia_tool_registry_missing_required_args() -> None:
     """Test that PortiaToolRegistry raises an error if required args are missing."""
     with pytest.raises(ValueError, match="Either config, client or tools must be provided"):
         PortiaToolRegistry()
+
+
+def test_tool_registry_reconfigure_llm_tool() -> None:
+    """Test replacing the LLMTool with a new LLMTool."""
+    registry = ToolRegistry(open_source_tool_registry.get_tools())
+    llm_tool = registry.get_tool("llm_tool")
+
+    assert llm_tool is not None
+    assert getattr(llm_tool, "model", None) is None
+
+    registry.replace_tool(LLMTool(model=MagicMock(spec=GenerativeModel)))
+
+    llm_tool = registry.get_tool("llm_tool")
+    assert llm_tool is not None
+    assert getattr(llm_tool, "model", None) is not None
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Step 1 of simplifying config: Allow user to provide `GenerativeModel` to `LLMTool`, `ImageUnderstandingTool` and `BrowserTool`

Simplified ToolRegistry based on observation that the only real difference between different implementations is the instantiation, the rest is the same.

Ticket Link: [POR-1143](https://linear.app/portialabs/issue/POR-1143/simplify-config)

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
