### PR TITLE
[POR-1019] Add browserbase support to browser tool

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -216,7 +216,7 @@ description = "Function decoration for backoff and retry"
 optional = true
 python-versions = ">=3.7,<4.0"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
     {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
@@ -229,7 +229,7 @@ description = "Screen-scraping library"
 optional = true
 python-versions = ">=3.7.0"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"},
     {file = "beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b"},
@@ -253,7 +253,7 @@ description = "Make websites accessible for AI agents"
 optional = true
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "browser_use-0.1.40-py3-none-any.whl", hash = "sha256:8deb6846bec00819bf150808357406e7847204c383351147c1f3d261c1904fb9"},
     {file = "browser_use-0.1.40.tar.gz", hash = "sha256:ddafcda30a9f9fe0f63612af5bf19a0ec03454d2774f54543eee70eef7ab369f"},
@@ -275,6 +275,27 @@ setuptools = ">=75.8.0"
 
 [package.extras]
 dev = ["build (>=1.2.2)", "fastapi (>=0.115.8)", "hatch (>=1.13.0)", "inngest (>=0.4.19)", "langchain (>=0.3.18)", "langchain-aws (>=0.2.11)", "langchain-fireworks (>=0.2.6)", "langchain-google-genai (==2.0.8)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24.0)", "tokencost (>=0.1.16)", "uvicorn (>=0.34.0)"]
+
+[[package]]
+name = "browserbase"
+version = "1.2.0"
+description = "The official Python library for the Browserbase API"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"tools-browser-browserbase\""
+files = [
+    {file = "browserbase-1.2.0-py3-none-any.whl", hash = "sha256:0b8d9429dea58f787b42b0109306f7a193770b78a24329ed13f50864debdf959"},
+    {file = "browserbase-1.2.0.tar.gz", hash = "sha256:44a1dbf2562893a8f9447c3d6de6fe72d3ae30fe743a5c2c52439928d0464a7b"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.10,<5"
 
 [[package]]
 name = "cachetools"
@@ -1032,7 +1053,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\" or extra == \"tools-browser-local\""
+markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\" or extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -1672,7 +1693,7 @@ description = "An integration package connecting Ollama and LangChain"
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "langchain_ollama-0.2.2-py3-none-any.whl", hash = "sha256:8a1ee72dbb6ea3b3ace1d9dd317e472d667a8ed491328550da59f4893a6796f8"},
     {file = "langchain_ollama-0.2.2.tar.gz", hash = "sha256:2d9bcb06ffdbe43c7c6906c46e710d36d33b6b99cd4975cbf54060f13e51c875"},
@@ -1843,7 +1864,7 @@ description = "Convert HTML to markdown."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "markdownify-0.14.1-py3-none-any.whl", hash = "sha256:4c46a6c0c12c6005ddcd49b45a5a890398b002ef51380cd319db62df5e09bc2a"},
     {file = "markdownify-0.14.1.tar.gz", hash = "sha256:a62a7a216947ed0b8dafb95b99b2ef4a0edd1e18d5653c656f68f03db2bfb2f1"},
@@ -1994,7 +2015,7 @@ description = "An implementation of time.monotonic() for Python 2 & < 3.3"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "monotonic-1.6-py2.py3-none-any.whl", hash = "sha256:68687e19a14f11f26d140dd5c86f3dba4bf5df58003000ed467e0e2a69bca96c"},
     {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
@@ -2273,7 +2294,7 @@ description = "The official Python client for Ollama."
 optional = true
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "ollama-0.4.7-py3-none-any.whl", hash = "sha256:85505663cca67a83707be5fb3aeff0ea72e67846cea5985529d8eca4366564a1"},
     {file = "ollama-0.4.7.tar.gz", hash = "sha256:891dcbe54f55397d82d289c459de0ea897e103b86a3f1fad0fdb1895922a75ff"},
@@ -2535,7 +2556,7 @@ description = "A high-level API to automate web browsers"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "playwright-1.51.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bcaaa3d5d73bda659bfb9ff2a288b51e85a91bd89eda86eaf8186550973e416a"},
     {file = "playwright-1.51.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e0ae6eb44297b24738e1a6d9c580ca4243b4e21b7e65cf936a71492c08dd0d4"},
@@ -2573,7 +2594,7 @@ description = "Integrate PostHog into any python application."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "posthog-3.21.0-py2.py3-none-any.whl", hash = "sha256:1e07626bb5219369dd36826881fa61711713e8175d3557db4657e64ecb351467"},
     {file = "posthog-3.21.0.tar.gz", hash = "sha256:62e339789f6f018b6a892357f5703d1f1e63c97aee75061b3dc97c5e5c6a5304"},
@@ -2989,7 +3010,7 @@ description = "A rough port of Node.js's EventEmitter to Python with a few trick
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "pyee-12.1.1-py3-none-any.whl", hash = "sha256:18a19c650556bb6b32b406d7f017c8f513aceed1ef7ca618fb65de7bd2d347ef"},
     {file = "pyee-12.1.1.tar.gz", hash = "sha256:bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3"},
@@ -3503,7 +3524,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "setuptools-78.0.2-py3-none-any.whl", hash = "sha256:4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d"},
     {file = "setuptools-78.0.2.tar.gz", hash = "sha256:137525e6afb9022f019d6e884a319017f9bf879a0d8783985d32cbc8683cab93"},
@@ -3561,7 +3582,7 @@ description = "A modern CSS selector implementation for Beautiful Soup."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\""
 files = [
     {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
     {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
@@ -4196,9 +4217,10 @@ cffi = ["cffi (>=1.11)"]
 all = ["google-generativeai", "langchain-google-genai", "langchain-mistralai", "mistralai"]
 google = ["google-generativeai", "langchain-google-genai"]
 mistral = ["langchain-mistralai", "mistralai"]
+tools-browser-browserbase = ["browser-use", "browserbase", "playwright"]
 tools-browser-local = ["browser-use", "playwright"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f3c9e311b994370d5733eac8bc96fea6ecdc9b4b8d388ea01668d69aa5ef2f7c"
+content-hash = "b0c984ecffb89761a3f01b0e3e66dfdbdab0078aad5588638ee2d3692c32ac56"

--- a/portia/_unstable/browser_tool.py
+++ b/portia/_unstable/browser_tool.py
@@ -11,14 +11,19 @@ import json
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from browser_use import Agent, Browser, BrowserConfig, Controller
+from browserbase import Browserbase
 from pydantic import BaseModel, Field, HttpUrl
 
 from portia.clarification import ActionClarification
 from portia.config import LLM_TOOL_MODEL_KEY
 from portia.errors import ToolHardError
 from portia.tool import Tool, ToolRunContext
+
+if TYPE_CHECKING:
+    from browserbase.types import SessionCreateResponse
 
 logger = logging.getLogger(__name__)
 
@@ -179,113 +184,29 @@ class BrowserTool(Tool[str]):
         )
 
 
-"""Browserbase authenticated tools."""
+class BrowserToolNonLocal(Tool[str]):
+    """General purpose browser tool. Customizable to user requirements."""
 
-from __future__ import annotations
+    model_config = {
+        "arbitrary_types_allowed": True
+    }
 
-from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+    id: str = "browser_tool_non_local"
+    name: str = "Browser Tool Non Local"
+    description: str = (
+        "General purpose browser tool. Can be used to navigate to a URL and "
+        "complete tasks. Should only be used if the task requires a browser "
+        "and you are sure of the URL."
+    )
+    args_schema: type[BaseModel] = BrowserToolSchema
+    output_schema: tuple[str, str] = ("str", "The Browser tool's response to the user query.")
 
-from browserbase import Browserbase
-from browserbase.types import SessionCreateResponse
-from playwright.sync_api import Page
-from pydantic import BaseModel, ConfigDict, Field
+    @staticmethod
+    def get_bb_instance() -> Browserbase:
+        """Get a Browserbase instance."""
+        return Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
 
-from portia.tool import Tool, ToolHardError
-
-SUPPORTED_BASE_ELEMENTS = [
-    Page,  # Playwright
-    int,  # TODO(Emma): This actually isn't supported, but want to allow for it in the future.
-]
-T = TypeVar("T", *SUPPORTED_BASE_ELEMENTS)  # type: ignore reportGeneralTypeIssues
-
-
-class BrowserbaseAuthenticator(ABC, Generic[T]):
-    """Base class for Browserbase authenticators.
-
-    Authenticators define page scripts to run to check if the user is authenticated, and to
-    bring them to the sign-in page if they are not.
-    """
-
-    @abstractmethod
-    def check_auth(self, _: T, context: ToolRunContext) -> bool:
-        """Check if the tool is authenticated."""
-        raise NotImplementedError("Subclasses must implement this method.")
-
-    @abstractmethod
-    def pre_auth(self, _: T, context: ToolRunContext) -> None:
-        """Pre-auth script to run before authentication."""
-        raise NotImplementedError("Subclasses must implement this method.")
-
-
-class BrowserBaseTool(ABC, Generic[T]):
-    """Base class for Browserbase tools.
-
-    This class provides a base implementation for browser-based tools that use Browserbase for
-    authentication and session management. When fully implemented, it will produce action
-    clarifications for session authentication like regular Portia cloud tools, which will enable
-    the user to sign in, and the agent to proceed once they have confirmed that they have done so.
-
-    In general, you should call `auth_and_run` at the start of the `run` method of your tool, and
-    then implement `post_auth` under the assumption that the tool is authenticated.
-
-    The tool requires a BROWSERBASE_PROJECT_ID environment variable to be set and a
-    BROWSERBASE_API_KEY environment variable to be set which can be found on the
-    [Browserbase dashboard](https://www.browserbase.com/settings). We also recommend that you change
-    the default timeout as when a user handles an authentication clarification they must do so
-    within the timeout.
-
-    The tool is designed to be extended over time with different page crawling mechanisms, for
-    the moment it only supports Playwright, but in the future we expect to add Stagehand and
-    BrowserUse.
-
-    If you want authentication to last across sessions, you should save the context ID against
-    the end-user, and override the `get_context_id` method to return the saved context ID.
-    """
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    authenticator: BrowserbaseAuthenticator[T] | None = None
-
-    def __init__(self, authenticator: BrowserbaseAuthenticator[T] | None = None) -> None:
-        """Initialize the tool.
-
-        Args:
-            authenticator (BrowserbaseAuthenticator[T] | None): The authenticator to use for the
-                tool. If not provided, relevant auth methods must be implemented in the subclass.
-
-        """
-        self.authenticator = authenticator
-
-    @abstractmethod
-    def check_auth(self, script_object: T, context: ToolRunContext) -> bool:
-        """Check if the tool is authenticated.
-
-        This should run a browser based script to determine whether the user is already
-        authenticated.
-        """
-        if self.authenticator:
-            return self.authenticator.check_auth(script_object, context)
-        raise NotImplementedError("Subclasses must implement this method.")
-
-    @abstractmethod
-    def pre_auth(self, script_object: T, context: ToolRunContext) -> None:
-        """Pre-auth script to run before authentication.
-
-        This should run a browser based script to get the user to the sign-in page.
-        """
-        if self.authenticator:
-            self.authenticator.pre_auth(script_object, context)
-        else:
-            raise NotImplementedError("Subclasses must implement this method.")
-
-    @abstractmethod
-    def post_auth(self, _: T, __: ToolRunContext) -> Any:  # noqa: ANN401
-        """Post-auth script to run after authentication.
-
-        The browser based script to run once the user has authenticated.
-        """
-        raise NotImplementedError("Subclasses must implement this method.")
+    bb: Browserbase = Field(default_factory=get_bb_instance)
 
     def get_context_id(self, bb: Browserbase) -> str:
         """Get the Browserbase context id.
@@ -296,11 +217,10 @@ class BrowserBaseTool(ABC, Generic[T]):
 
     def create_session(
         self,
-        bb: Browserbase,
         bb_context_id: str,
     ) -> SessionCreateResponse:
         """Get a fresh session with the given context ID."""
-        return bb.sessions.create(
+        return self.bb.sessions.create(
             project_id=os.environ["BROWSERBASE_PROJECT_ID"],
             browser_settings={
                 "context": {
@@ -312,26 +232,20 @@ class BrowserBaseTool(ABC, Generic[T]):
             keep_alive=True,
         )
 
-    def get_bb_instance(self) -> Browserbase:
-        """Get a Browserbase instance."""
-        return Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
-
     def get_or_create_session(self, context: ToolRunContext, bb: Browserbase) -> tuple[str, str]:
         """Get or create a Browserbase session."""
         context_id = context.execution_context.additional_data.get(
-            "bb_context_id",
-            self.get_context_id(bb),
+            "bb_context_id", self.get_context_id(bb)
         )
         context.execution_context.additional_data["bb_context_id"] = context_id
 
         session_id = context.execution_context.additional_data.get("bb_session_id", None)
         session_connect_url = context.execution_context.additional_data.get(
-            "bb_session_connect_url",
-            None,
+            "bb_session_connect_url", None
         )
 
         if not session_id or not session_connect_url:
-            session = self.create_session(bb, context_id)
+            session = self.create_session(context_id)
             session_connect_url = session.connect_url
             context.execution_context.additional_data["bb_session_id"] = session_id = session.id
             context.execution_context.additional_data["bb_session_connect_url"] = (
@@ -339,3 +253,85 @@ class BrowserBaseTool(ABC, Generic[T]):
             )
 
         return (session_id, session_connect_url)
+
+    def construct_auth_clarification_url(self, ctx: ToolRunContext, sign_in_url: str) -> str:
+        """Construct the URL for the auth clarification."""
+        if not ctx.execution_context.additional_data["bb_session_id"]:
+            raise ToolHardError("Session ID not found")
+        live_view_link = self.bb.sessions.debug(ctx.execution_context.additional_data["bb_session_id"])
+        return live_view_link.debugger_fullscreen_url
+
+    def run(self, ctx: ToolRunContext, url: str, task: str) -> str | ActionClarification:
+        """Run the BrowserTool."""
+        model = ctx.config.resolve_langchain_model(LLM_TOOL_MODEL_KEY)
+        llm = model.to_langchain()
+
+        async def run_browser_tasks() -> str | ActionClarification:
+            # First auth check
+            auth_agent = Agent(
+                task=(
+                    f"Go to {url}. If the user is not signed in, please go to the sign in page, "
+                    "and indicate that human login is required by returning "
+                    "human_login_required=True, and the url of the sign in page as well as "
+                    "what the user should do to sign in. If the user is signed in, please "
+                    "return human_login_required=False."
+                ),
+                llm=llm,
+                browser=self._setup_browser(ctx),
+                controller=Controller(
+                    output_model=BrowserAuthOutput,
+                ),
+            )
+            result = await auth_agent.run()
+            auth_result = BrowserAuthOutput.model_validate(json.loads(result.final_result()))  # type: ignore reportArgumentType
+            if auth_result.human_login_required:
+                if auth_result.user_login_guidance is None or auth_result.login_url is None:
+                    raise ToolHardError(
+                        "Expected user guidance and login URL if human login is required",
+                    )
+                return ActionClarification(
+                    user_guidance=auth_result.user_login_guidance,
+                    action_url=HttpUrl(self.construct_auth_clarification_url(ctx, auth_result.login_url)),
+                    plan_run_id=ctx.plan_run_id,
+                )
+
+            # Main task
+            task_agent = Agent(
+                task=task,
+                llm=llm,
+                browser=self._setup_browser(ctx),
+                controller=Controller(
+                    output_model=BrowserTaskOutput,
+                ),
+            )
+            result = await task_agent.run()
+            task_result = BrowserTaskOutput.model_validate(json.loads(result.final_result()))  # type: ignore reportArgumentType
+            if task_result.human_login_required:
+                if task_result.user_login_guidance is None or task_result.login_url is None:
+                    raise ToolHardError(
+                        "Expected user guidance and login URL if human login is required",
+                    )
+                return ActionClarification(
+                    user_guidance=task_result.user_login_guidance,
+                    action_url=HttpUrl(self.construct_auth_clarification_url(ctx, task_result.login_url)),
+                    plan_run_id=ctx.plan_run_id,
+                )
+            return task_result.task_output
+
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop.run_until_complete(run_browser_tasks())
+
+    def _setup_browser(self, ctx: ToolRunContext) -> Browser:
+        """Get the browser instance to be used by the tool."""
+        bb = self.get_bb_instance()
+        session_id, session_connect_url = self.get_or_create_session(ctx, bb)
+
+        return Browser(
+            config=BrowserConfig(
+                cdp_url=session_connect_url,
+            ),
+        )

--- a/portia/_unstable/browser_tool.py
+++ b/portia/_unstable/browser_tool.py
@@ -292,7 +292,7 @@ class BrowserToolForUrl(BaseBrowserTool):
             url=url,  # type: ignore reportCallIssue
         )
 
-    def run(self, ctx: ToolRunContext, task: str) -> str | ActionClarification:
+    def run(self, ctx: ToolRunContext, task: str) -> str | ActionClarification:  # type: ignore reportIncompatibleMethodOverride
         """Run the BrowserToolForUrl."""
         return super().run(ctx, self.url, task)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ google-generativeai = {version = "^0.8.4", optional = true}
 langchain-google-genai = {version = "^2.0.10", optional = true}
 playwright = { version = "^1.49.0", optional = true }
 browser-use = { version = "^0.1.40", optional = true }
+browserbase = { version = "^1.2.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.8.0"
@@ -60,6 +61,7 @@ all = ["langchain-mistralai", "mistralai", "langchain-google-genai", "google-gen
 
 # Tools that require extra dependencies
 tools-browser-local = ["playwright", "browser-use"]
+tools-browser-browserbase = ["playwright", "browser-use", "browserbase"]
 
 [tool.ruff]
 line-length=100


### PR DESCRIPTION
# Description

Add browserbase support to the browser tool and create the concept of BrowserInfrastructure which enables Browserbase, Local chrome or others to be swapped in and out.

**Coming up next**
- Integration with tool registries
- SDK documentation improvements
- Tests and moving out of unstable

Ticket Link: https://linear.app/portialabs/issue/POR-1019/create-browserbase-version-of-tool

(select all that apply)

- [ ] Bug fix 
- [ X] New feature 
- [ ] Breaking change 
- [ X] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update
