### PR TITLE
Fix two flaky tests

### DIFF
--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -53,8 +53,8 @@ IMPORTANT GUIDLINES:
 - When creating the description for a step of the plan, if you need information from the previous
  step, DO NOT guess what that step will produce - instead, specify the previous step's output as an
  input for this step and allow this to be handled when we execute the plan.
-- If you can't come up with a plan provide a descriptive error instead - do not
- return plans with no steps.
+- If you can't come up with a plan provide a descriptive error instead - DO NOT
+ create plan with zero steps.
 - For EVERY tool that requires an id as an input, make sure to check
  if there's a corresponding tool call that provides the id from natural language if possible.
  For example, if a tool asks for a user ID check if there's a tool call that provides

--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -12,8 +12,8 @@
      - give a name to the variable for the output of the step if it is successful.
      - DO NOT mention the tool you will use in the task description, but MAKE SURE to use it in the tool_id field.
      - IMPORTANT: MAKE SURE to not provide examples or assumptions in the task description.
-    IMPORTANT: If you can't come up with a plan provide a descriptive error instead - do not return plans with no steps.
-    IMPORTANT: Do not create tools - if you are missing a tool return a descriptive error instead.
+    IMPORTANT: If you can't come up with a plan provide a descriptive error instead - DO NOT create plan with zero steps.
+    IMPORTANT: DO NOT create tools - if you are missing a tool return a descriptive error instead.
 </Instructions>
 
 <Examples>{% for example in examples %}

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -475,7 +475,7 @@ def test_portia_run_query_with_example_registry() -> None:
     config = Config.from_default()
 
     portia = Portia(config=config, tools=example_tool_registry)
-    query = "Add 1 + 2 together and then write a haiku about the answer"
+    query = "Add 1 + 2 together and then write me a haiku about the answer"
 
     plan_run = portia.run(query)
     assert plan_run.state == PlanRunState.COMPLETE


### PR DESCRIPTION
# Description

``` Test: test_portia_run_query_requiring_cloud_tools_not_authenticated ``` is failing 1 in 5, duo to producing plans with 0 steps.

 - Fix: Made some planning prompt edits to highlight it should return error instead.

``` Test: test_portia_run_query_with_example_registry ``` is failing 1 in 7, duo haiku step is selecting search_tool instead of llm_tool. 

 - Fix: Made some minor edit in the query to nudge it towards LLM tool.


Both now are passing 10 times in a row, so should be more stable.


## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
