### PR TITLE
Expose Config.get_model, rename GenerativeModelsConfig and expose more types from __init__

### DIFF
--- a/portia/__init__.py
+++ b/portia/__init__.py
@@ -21,6 +21,7 @@ from portia.config import (
     SUPPORTED_OPENAI_MODELS,
     Config,
     ExecutionAgentType,
+    GenerativeModelsConfig,
     LLMModel,
     LogLevel,
     PlanningAgentType,
@@ -62,7 +63,11 @@ from portia.logger import logger
 from portia.mcp_session import SseMcpClientConfig, StdioMcpClientConfig
 
 # Open source tools
-from portia.model import LLMProvider
+from portia.model import (
+    GenerativeModel,
+    LLMProvider,
+    Message,
+)
 from portia.open_source_tools.llm_tool import LLMTool
 from portia.open_source_tools.local_file_reader_tool import FileReaderTool
 from portia.open_source_tools.local_file_writer_tool import FileWriterTool
@@ -111,6 +116,8 @@ __all__ = [
     "ExecutionHooks",
     "FileReaderTool",
     "FileWriterTool",
+    "GenerativeModel",
+    "GenerativeModelsConfig",
     "InMemoryToolRegistry",
     "InputClarification",
     "InvalidAgentError",
@@ -123,6 +130,7 @@ __all__ = [
     "LLMTool",
     "LogLevel",
     "McpToolRegistry",
+    "Message",
     "MultipleChoiceClarification",
     "Output",
     "Plan",

--- a/portia/_unstable/browser_tool.py
+++ b/portia/_unstable/browser_tool.py
@@ -113,7 +113,7 @@ class BaseBrowserTool(Tool[str]):
     args_schema: type[BaseModel] = Field(init_var=True, default=BrowserToolSchema)
     output_schema: tuple[str, str] = ("str", "The Browser tool's response to the user query.")
 
-    model: GenerativeModel | None = Field(
+    model: GenerativeModel | None | str = Field(
         default=None,
         exclude=True,
         description="The model to use for the BrowserTool. If not provided, "
@@ -134,7 +134,7 @@ class BaseBrowserTool(Tool[str]):
 
     def run(self, ctx: ToolRunContext, url: str, task: str) -> str | ActionClarification:
         """Run the BrowserTool."""
-        model = self.model or ctx.config.get_default_model()
+        model = ctx.config.get_model(self.model) or ctx.config.get_default_model()
         llm = model.to_langchain()
 
         async def run_browser_tasks() -> str | ActionClarification:
@@ -274,7 +274,7 @@ class BrowserToolForUrl(BaseBrowserTool):
         id: str | None = None,  # noqa: A002
         name: str | None = None,
         description: str | None = None,
-        model: GenerativeModel | None = NotSet,
+        model: GenerativeModel | None | str = NotSet,
         infrastructure_option: BrowserInfrastructureOption | None = NotSet,
     ) -> None:
         """Initialize the BrowserToolForUrl."""

--- a/portia/open_source_tools/image_understanding_tool.py
+++ b/portia/open_source_tools/image_understanding_tool.py
@@ -63,7 +63,7 @@ class ImageUnderstandingTool(Tool[str]):
         """
     tool_context: str = ""
 
-    model: GenerativeModel | None = Field(
+    model: GenerativeModel | None | str = Field(
         default=None,
         exclude=True,
         description="The model to use for the ImageUnderstandingTool. If not provided, "
@@ -72,7 +72,7 @@ class ImageUnderstandingTool(Tool[str]):
 
     def run(self, ctx: ToolRunContext, **kwargs: Any) -> str:
         """Run the ImageTool."""
-        model = self.model or ctx.config.get_default_model()
+        model = ctx.config.get_model(self.model) or ctx.config.get_default_model()
 
         tool_schema = ImageUnderstandingToolSchema(**kwargs)
 

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -53,7 +53,7 @@ class LLMTool(Tool[str]):
         """
     tool_context: str = ""
 
-    model: GenerativeModel | None = Field(
+    model: GenerativeModel | str | None = Field(
         default=None,
         exclude=True,
         description="The model to use for the LLMTool. If not provided, "
@@ -62,7 +62,7 @@ class LLMTool(Tool[str]):
 
     def run(self, ctx: ToolRunContext, task: str) -> str:
         """Run the LLMTool."""
-        model = self.model or ctx.config.get_default_model()
+        model = ctx.config.get_model(self.model) or ctx.config.get_default_model()
 
         # Define system and user messages
         context = (

--- a/portia/storage.py
+++ b/portia/storage.py
@@ -119,7 +119,7 @@ class PlanStorage(ABC):
             NotImplementedError: If the method is not implemented.
 
         """
-        raise NotImplementedError("get_similar_plans is not implemented") # pragma: no cover
+        raise NotImplementedError("get_similar_plans is not implemented")  # pragma: no cover
 
 
 class PlanRunListResponse(BaseModel):

--- a/tests/unit/execution_agents/utils/test_final_output_summarizer.py
+++ b/tests/unit/execution_agents/utils/test_final_output_summarizer.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from portia.config import Config, GenerativeModels
+from portia.config import Config, GenerativeModelsConfig
 from portia.execution_agents.output import LocalOutput
 from portia.execution_agents.utils.final_output_summarizer import FinalOutputSummarizer
 from portia.introspection_agents.introspection_agent import PreStepIntrospectionOutcome
@@ -22,7 +22,7 @@ def mock_summarizer_model() -> mock.MagicMock:
 @pytest.fixture
 def summarizer_config(mock_summarizer_model: mock.MagicMock) -> Config:
     """Create a summarizer config with a mocked model."""
-    return get_test_config(models=GenerativeModels(summarizer_model=mock_summarizer_model))
+    return get_test_config(models=GenerativeModelsConfig(summarizer_model=mock_summarizer_model))
 
 
 def test_summarizer_agent_execute_sync(

--- a/tests/unit/introspection_agents/test_default_introspection_agent.py
+++ b/tests/unit/introspection_agents/test_default_introspection_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from langchain_core.messages import HumanMessage
 
-from portia.config import GenerativeModels
+from portia.config import GenerativeModelsConfig
 from portia.execution_agents.output import LocalOutput
 from portia.introspection_agents.default_introspection_agent import DefaultIntrospectionAgent
 from portia.introspection_agents.introspection_agent import (
@@ -32,7 +32,7 @@ def mock_introspection_model() -> MagicMock:
 def introspection_agent(mock_introspection_model: MagicMock) -> DefaultIntrospectionAgent:
     """Create an instance of the DefaultIntrospectionAgent with mocked config."""
     mock_config = get_test_config(
-        models=GenerativeModels(
+        models=GenerativeModelsConfig(
             introspection_model=mock_introspection_model,
         ),
     )

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -18,7 +18,7 @@ from portia.clarification import (
 from portia.config import (
     FEATURE_FLAG_AGENT_MEMORY_ENABLED,
     Config,
-    GenerativeModels,
+    GenerativeModelsConfig,
     StorageClass,
 )
 from portia.errors import InvalidPlanRunStateError, PlanError, PlanRunNotFoundError
@@ -61,7 +61,7 @@ def default_model() -> MagicMock:
 def portia(planning_model: MagicMock, default_model: MagicMock) -> Portia:
     """Fixture to create a Portia instance for testing."""
     config = get_test_config(
-        models=GenerativeModels(
+        models=GenerativeModelsConfig(
             planning_model=planning_model,
             default_model=default_model,
         ),
@@ -77,7 +77,7 @@ def portia_with_agent_memory(planning_model: MagicMock, default_model: MagicMock
         # Set a small threshold value so all outputs are stored in agent memory
         feature_flags={FEATURE_FLAG_AGENT_MEMORY_ENABLED: True},
         large_output_threshold_tokens=3,
-        models=GenerativeModels(
+        models=GenerativeModelsConfig(
             planning_model=planning_model,
             default_model=default_model,
         ),
@@ -142,7 +142,7 @@ def test_portia_run_query_tool_list(planning_model: MagicMock) -> None:
     query = "example query"
     portia = Portia(
         config=get_test_config(
-            models=GenerativeModels(
+            models=GenerativeModelsConfig(
                 planning_model=planning_model,
             ),
         ),
@@ -166,7 +166,7 @@ def test_portia_run_query_disk_storage(planning_model: MagicMock) -> None:
             storage_class=StorageClass.DISK,
             openai_api_key=SecretStr("123"),
             storage_dir=tmp_dir,
-            models=GenerativeModels(
+            models=GenerativeModelsConfig(
                 planning_model=planning_model,
             ),
         )
@@ -779,7 +779,7 @@ def test_portia_handle_clarification(planning_model: MagicMock) -> None:
     """Test that portia can handle a clarification."""
     clarification_handler = TestClarificationHandler()
     portia = Portia(
-        config=get_test_config(models=GenerativeModels(planning_model=planning_model)),
+        config=get_test_config(models=GenerativeModelsConfig(planning_model=planning_model)),
         tools=[ClarificationTool()],
         execution_hooks=ExecutionHooks(clarification_handler=clarification_handler),
     )


### PR DESCRIPTION
# Description

* `get_model` exposed allows us to instantiate models from a canonical string like `openai/gpt-4o` which makes configuring Tool models more ergonomic
* Renamed `GenerativeModels` to `GenerativeModelsConfig` 
* Exposed main `Model` types from `portia.__init__`

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
