### PR TITLE
Fix cli.py

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -141,6 +141,8 @@ def generate_cli_option_from_pydantic_field(  # noqa: C901, PLR0912
                     field_default = info.default_factory().name  # type: ignore[reportCallIssue]
                 else:
                     field_default = None
+            else:
+                return lambda: None
 
     field_help = info.description or f"Set the value for {option_name}"
 

--- a/portia/config.py
+++ b/portia/config.py
@@ -848,13 +848,13 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
 
     """
     llm_provider_from_api_keys = llm_provider_default_from_api_keys(**kwargs)
-    if (
-        "llm_provider" in kwargs and kwargs["llm_provider"] is not None
-    ) or llm_provider_from_api_keys:
+    if "llm_provider" in kwargs and kwargs["llm_provider"] is not None:
         llm_provider = parse_str_to_enum(
-            kwargs.pop("llm_provider", llm_provider_from_api_keys),
+            kwargs.pop("llm_provider"),
             LLMProvider,
         )
+    elif llm_provider_from_api_keys:
+        llm_provider = llm_provider_from_api_keys
     else:
         llm_provider = None
 

--- a/portia/config.py
+++ b/portia/config.py
@@ -848,7 +848,9 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
 
     """
     llm_provider_from_api_keys = llm_provider_default_from_api_keys(**kwargs)
-    if "llm_provider" in kwargs or llm_provider_from_api_keys:
+    if (
+        "llm_provider" in kwargs and kwargs["llm_provider"] is not None
+    ) or llm_provider_from_api_keys:
         llm_provider = parse_str_to_enum(
             kwargs.pop("llm_provider", llm_provider_from_api_keys),
             LLMProvider,


### PR DESCRIPTION
# Description

Without this, I get the below error with cli.py
```
poetry run python -m portia.cli run "Get the weather in London, then write a poem about Robbie Heywood in London experiencing the current weather, then email it to robbie@portialabs.ai" --env-location ENV_FILE --default-log-level debug
2025-04-14 20:01:30.387 | ERROR | __main__:_get_config:352 - Config value NONE is not valid - Value must be a string or LLMProvider
```

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
