### PR TITLE
Improve CLI config for models and providers

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -848,9 +848,9 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
 
     """
     llm_provider_from_api_keys = llm_provider_default_from_api_keys(**kwargs)
-    if "llm_provider" in kwargs and kwargs["llm_provider"] is not None:
+    if "llm_provider" in kwargs and (kwargs_provider := kwargs.pop("llm_provider")) is not None:
         llm_provider = parse_str_to_enum(
-            kwargs.pop("llm_provider"),
+            kwargs_provider,
             LLMProvider,
         )
     elif llm_provider_from_api_keys:


### PR DESCRIPTION
# Description

Re-enables `--llm-provider` 

Enables e.g. `--default-model=anthropic/claude-3-5-sonnet-latest` or `--planning-model=openai/gpt-4o`

Handle `Enum | None` fields (in an admittedly brittle way) and fields from the `GenerativeModelsConfig`



Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
