### PR TITLE
Move CLI clarification handler to a separate file

### DIFF
--- a/portia/clarification_handler.py
+++ b/portia/clarification_handler.py
@@ -1,8 +1,7 @@
 """Clarification Handler.
 
 This module defines the base ClarificationHandler interface that determines how to handle
-clarifications that arise during the run of a plan. It also provides a
-CLIClarificationHandler implementation that handles clarifications via the CLI.
+clarifications that arise during the run of a plan.
 """
 
 from __future__ import annotations

--- a/portia/cli_clarification_handler.py
+++ b/portia/cli_clarification_handler.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Callable
 import click
 
 from portia.clarification_handler import ClarificationHandler
-from portia.logger import logger
 
 if TYPE_CHECKING:
     from portia.clarification import (
@@ -39,7 +38,7 @@ class CLIClarificationHandler(ClarificationHandler):
         Does this by showing the user the URL on the CLI and instructing them to click on
         it to proceed.
         """
-        logger().info(
+        click.echo(
             click.style(
                 f"{clarification.user_guidance} -- Please click on the link below to proceed."
                 f"{clarification.action_url}",

--- a/portia/cli_clarification_handler.py
+++ b/portia/cli_clarification_handler.py
@@ -1,0 +1,98 @@
+"""CLI Clarification Handler.
+
+This module provides a CLI-specific implementation of the ClarificationHandler
+that handles clarifications via the command-line interface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Callable
+
+import click
+
+from portia.clarification_handler import ClarificationHandler
+from portia.logger import logger
+
+if TYPE_CHECKING:
+    from portia.clarification import (
+        ActionClarification,
+        Clarification,
+        CustomClarification,
+        InputClarification,
+        MultipleChoiceClarification,
+        ValueConfirmationClarification,
+    )
+
+
+class CLIClarificationHandler(ClarificationHandler):
+    """Handles clarifications by obtaining user input from the CLI."""
+
+    def handle_action_clarification(
+        self,
+        clarification: ActionClarification,
+        on_resolution: Callable[[Clarification, object], None],  # noqa: ARG002
+        on_error: Callable[[Clarification, object], None],  # noqa: ARG002
+    ) -> None:
+        """Handle an action clarification.
+
+        Does this by showing the user the URL on the CLI and instructing them to click on
+        it to proceed.
+        """
+        logger().info(
+            click.style(
+                f"{clarification.user_guidance} -- Please click on the link below to proceed."
+                f"{clarification.action_url}",
+                fg=87,
+            ),
+        )
+
+    def handle_input_clarification(
+        self,
+        clarification: InputClarification,
+        on_resolution: Callable[[Clarification, object], None],
+        on_error: Callable[[Clarification, object], None],  # noqa: ARG002
+    ) -> None:
+        """Handle a user input clarifications by asking the user for input from the CLI."""
+        user_input = click.prompt(
+            click.style(clarification.user_guidance + "\nPlease enter a value", fg=87),
+        )
+        return on_resolution(clarification, user_input)
+
+    def handle_multiple_choice_clarification(
+        self,
+        clarification: MultipleChoiceClarification,
+        on_resolution: Callable[[Clarification, object], None],
+        on_error: Callable[[Clarification, object], None],  # noqa: ARG002
+    ) -> None:
+        """Handle a multi-choice clarification by asking the user for input from the CLI."""
+        choices = click.Choice(clarification.options)
+        user_input = click.prompt(
+            click.style(clarification.user_guidance + "\nPlease choose a value:\n", fg=87),
+            type=choices,
+        )
+        return on_resolution(clarification, user_input)
+
+    def handle_value_confirmation_clarification(
+        self,
+        clarification: ValueConfirmationClarification,
+        on_resolution: Callable[[Clarification, object], None],
+        on_error: Callable[[Clarification, object], None],
+    ) -> None:
+        """Handle a value confirmation clarification by asking the user to confirm from the CLI."""
+        if click.confirm(text=click.style(clarification.user_guidance, fg=87), default=False):
+            on_resolution(clarification, True)  # noqa: FBT003
+        else:
+            on_error(clarification, "Clarification was rejected by the user")
+
+    def handle_custom_clarification(
+        self,
+        clarification: CustomClarification,
+        on_resolution: Callable[[Clarification, object], None],
+        on_error: Callable[[Clarification, object], None],  # noqa: ARG002
+    ) -> None:
+        """Handle a custom clarification."""
+        click.echo(click.style(clarification.user_guidance, fg=87))
+        click.echo(click.style(f"Additional data: {json.dumps(clarification.data)}", fg=87))
+        user_input = click.prompt(click.style("\nPlease enter a value:\n", fg=87))
+        return on_resolution(clarification, user_input)

--- a/tests/unit/test_cli_clarification_handler.py
+++ b/tests/unit/test_cli_clarification_handler.py
@@ -28,21 +28,21 @@ def test_action_clarification(mock_logger: MagicMock, cli_handler: CLIClarificat
     """Test handling of action clarifications."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     clarification = ActionClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Please authenticate",
         action_url=HttpUrl("https://example.com/auth"),
     )
-    
+
     cli_handler.handle_action_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify logger was called with the expected message
     mock_logger.return_value.info.assert_called_once()
     log_message = mock_logger.return_value.info.call_args[0][0]
     assert "Please authenticate" in log_message
     assert "https://example.com/auth" in log_message
-    
+
     # Verify callbacks were not called
     on_resolution.assert_not_called()
     on_error.assert_not_called()
@@ -53,54 +53,56 @@ def test_input_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificati
     """Test handling of input clarifications."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     mock_prompt.return_value = "user input"
-    
+
     clarification = InputClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Enter your name",
         argument_name="name",
     )
-    
+
     cli_handler.handle_input_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify prompt was called
     mock_prompt.assert_called_once()
     prompt_text = mock_prompt.call_args[0][0]
     assert "Enter your name" in click.unstyle(prompt_text)
-    
+
     # Verify resolution callback was called with user input
     on_resolution.assert_called_once_with(clarification, "user input")
     on_error.assert_not_called()
 
 
 @patch("portia.cli_clarification_handler.click.prompt")
-def test_multiple_choice_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificationHandler) -> None:
+def test_multiple_choice_clarification(
+    mock_prompt: MagicMock, cli_handler: CLIClarificationHandler,
+) -> None:
     """Test handling of multiple choice clarifications."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     mock_prompt.return_value = "option2"
-    
+
     clarification = MultipleChoiceClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Choose a color",
         argument_name="color",
         options=["option1", "option2", "option3"],
     )
-    
+
     cli_handler.handle_multiple_choice_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify prompt was called with choices
     mock_prompt.assert_called_once()
     prompt_text = mock_prompt.call_args[0][0]
     assert "Choose a color" in click.unstyle(prompt_text)
-    
+
     # Verify type parameter was a click.Choice with the correct options
     choice_type = mock_prompt.call_args[1]["type"]
     assert isinstance(choice_type, click.Choice)
     assert choice_type.choices == ["option1", "option2", "option3"]
-    
+
     # Verify resolution callback was called with selected option
     on_resolution.assert_called_once_with(clarification, "option2")
     on_error.assert_not_called()
@@ -108,53 +110,53 @@ def test_multiple_choice_clarification(mock_prompt: MagicMock, cli_handler: CLIC
 
 @patch("portia.cli_clarification_handler.click.confirm")
 def test_value_confirmation_clarification_confirmed(
-    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler
+    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of value confirmation clarifications when confirmed."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     mock_confirm.return_value = True
-    
+
     clarification = ValueConfirmationClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Confirm deletion?",
         argument_name="confirm_delete",
     )
-    
+
     cli_handler.handle_value_confirmation_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify confirm was called
     mock_confirm.assert_called_once()
     confirm_text = mock_confirm.call_args[1]["text"]
     assert "Confirm deletion?" in click.unstyle(confirm_text)
-    
+
     # Verify resolution callback was called with True
-    on_resolution.assert_called_once_with(clarification, True)
+    on_resolution.assert_called_once_with(clarification, True)  # noqa: FBT003
     on_error.assert_not_called()
 
 
 @patch("portia.cli_clarification_handler.click.confirm")
 def test_value_confirmation_clarification_rejected(
-    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler
+    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of value confirmation clarifications when rejected."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     mock_confirm.return_value = False
-    
+
     clarification = ValueConfirmationClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Confirm deletion?",
         argument_name="confirm_delete",
     )
-    
+
     cli_handler.handle_value_confirmation_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify confirm was called
     mock_confirm.assert_called_once()
-    
+
     # Verify error callback was called with rejection message
     on_resolution.assert_not_called()
     on_error.assert_called_once()
@@ -164,23 +166,23 @@ def test_value_confirmation_clarification_rejected(
 @patch("portia.cli_clarification_handler.click.echo")
 @patch("portia.cli_clarification_handler.click.prompt")
 def test_custom_clarification(
-    mock_prompt: MagicMock, mock_echo: MagicMock, cli_handler: CLIClarificationHandler
+    mock_prompt: MagicMock, mock_echo: MagicMock, cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of custom clarifications."""
     on_resolution = MagicMock()
     on_error = MagicMock()
-    
+
     mock_prompt.return_value = "custom response"
-    
+
     clarification = CustomClarification(
         plan_run_id=PlanRunUUID(),
         user_guidance="Custom action needed",
         name="custom_action",
         data={"key1": "value1", "key2": "value2"},
     )
-    
+
     cli_handler.handle_custom_clarification(clarification, on_resolution, on_error)
-    
+
     # Verify echo was called twice (once for guidance, once for data)
     assert mock_echo.call_count == 2
     guidance_text = mock_echo.call_args_list[0][0][0]
@@ -188,10 +190,10 @@ def test_custom_clarification(
     assert "Custom action needed" in click.unstyle(guidance_text)
     assert "key1" in click.unstyle(data_text)
     assert "value1" in click.unstyle(data_text)
-    
+
     # Verify prompt was called
     mock_prompt.assert_called_once()
-    
+
     # Verify resolution callback was called with user input
     on_resolution.assert_called_once_with(clarification, "custom response")
     on_error.assert_not_called()

--- a/tests/unit/test_cli_clarification_handler.py
+++ b/tests/unit/test_cli_clarification_handler.py
@@ -23,8 +23,8 @@ def cli_handler() -> CLIClarificationHandler:
     return CLIClarificationHandler()
 
 
-@patch("portia.cli_clarification_handler.logger")
-def test_action_clarification(mock_logger: MagicMock, cli_handler: CLIClarificationHandler) -> None:
+@patch("portia.cli_clarification_handler.click.echo")
+def test_action_clarification(mock_echo: MagicMock, cli_handler: CLIClarificationHandler) -> None:
     """Test handling of action clarifications."""
     on_resolution = MagicMock()
     on_error = MagicMock()
@@ -37,11 +37,11 @@ def test_action_clarification(mock_logger: MagicMock, cli_handler: CLIClarificat
 
     cli_handler.handle_action_clarification(clarification, on_resolution, on_error)
 
-    # Verify logger was called with the expected message
-    mock_logger.return_value.info.assert_called_once()
-    log_message = mock_logger.return_value.info.call_args[0][0]
-    assert "Please authenticate" in log_message
-    assert "https://example.com/auth" in log_message
+    # Verify echo was called with the expected message
+    mock_echo.assert_called_once()
+    echo_message = mock_echo.call_args[0][0]
+    assert "Please authenticate" in click.unstyle(echo_message)
+    assert "https://example.com/auth" in click.unstyle(echo_message)
 
     # Verify callbacks were not called
     on_resolution.assert_not_called()

--- a/tests/unit/test_cli_clarification_handler.py
+++ b/tests/unit/test_cli_clarification_handler.py
@@ -1,0 +1,197 @@
+"""Tests for the CLI clarification handler."""
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from pydantic import HttpUrl
+
+from portia.clarification import (
+    ActionClarification,
+    CustomClarification,
+    InputClarification,
+    MultipleChoiceClarification,
+    ValueConfirmationClarification,
+)
+from portia.cli_clarification_handler import CLIClarificationHandler
+from portia.prefixed_uuid import PlanRunUUID
+
+
+@pytest.fixture
+def cli_handler() -> CLIClarificationHandler:
+    """Create a CLI clarification handler for testing."""
+    return CLIClarificationHandler()
+
+
+@patch("portia.cli_clarification_handler.logger")
+def test_action_clarification(mock_logger: MagicMock, cli_handler: CLIClarificationHandler) -> None:
+    """Test handling of action clarifications."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    clarification = ActionClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Please authenticate",
+        action_url=HttpUrl("https://example.com/auth"),
+    )
+    
+    cli_handler.handle_action_clarification(clarification, on_resolution, on_error)
+    
+    # Verify logger was called with the expected message
+    mock_logger.return_value.info.assert_called_once()
+    log_message = mock_logger.return_value.info.call_args[0][0]
+    assert "Please authenticate" in log_message
+    assert "https://example.com/auth" in log_message
+    
+    # Verify callbacks were not called
+    on_resolution.assert_not_called()
+    on_error.assert_not_called()
+
+
+@patch("portia.cli_clarification_handler.click.prompt")
+def test_input_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificationHandler) -> None:
+    """Test handling of input clarifications."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    mock_prompt.return_value = "user input"
+    
+    clarification = InputClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Enter your name",
+        argument_name="name",
+    )
+    
+    cli_handler.handle_input_clarification(clarification, on_resolution, on_error)
+    
+    # Verify prompt was called
+    mock_prompt.assert_called_once()
+    prompt_text = mock_prompt.call_args[0][0]
+    assert "Enter your name" in click.unstyle(prompt_text)
+    
+    # Verify resolution callback was called with user input
+    on_resolution.assert_called_once_with(clarification, "user input")
+    on_error.assert_not_called()
+
+
+@patch("portia.cli_clarification_handler.click.prompt")
+def test_multiple_choice_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificationHandler) -> None:
+    """Test handling of multiple choice clarifications."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    mock_prompt.return_value = "option2"
+    
+    clarification = MultipleChoiceClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Choose a color",
+        argument_name="color",
+        options=["option1", "option2", "option3"],
+    )
+    
+    cli_handler.handle_multiple_choice_clarification(clarification, on_resolution, on_error)
+    
+    # Verify prompt was called with choices
+    mock_prompt.assert_called_once()
+    prompt_text = mock_prompt.call_args[0][0]
+    assert "Choose a color" in click.unstyle(prompt_text)
+    
+    # Verify type parameter was a click.Choice with the correct options
+    choice_type = mock_prompt.call_args[1]["type"]
+    assert isinstance(choice_type, click.Choice)
+    assert choice_type.choices == ["option1", "option2", "option3"]
+    
+    # Verify resolution callback was called with selected option
+    on_resolution.assert_called_once_with(clarification, "option2")
+    on_error.assert_not_called()
+
+
+@patch("portia.cli_clarification_handler.click.confirm")
+def test_value_confirmation_clarification_confirmed(
+    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler
+) -> None:
+    """Test handling of value confirmation clarifications when confirmed."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    mock_confirm.return_value = True
+    
+    clarification = ValueConfirmationClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Confirm deletion?",
+        argument_name="confirm_delete",
+    )
+    
+    cli_handler.handle_value_confirmation_clarification(clarification, on_resolution, on_error)
+    
+    # Verify confirm was called
+    mock_confirm.assert_called_once()
+    confirm_text = mock_confirm.call_args[1]["text"]
+    assert "Confirm deletion?" in click.unstyle(confirm_text)
+    
+    # Verify resolution callback was called with True
+    on_resolution.assert_called_once_with(clarification, True)
+    on_error.assert_not_called()
+
+
+@patch("portia.cli_clarification_handler.click.confirm")
+def test_value_confirmation_clarification_rejected(
+    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler
+) -> None:
+    """Test handling of value confirmation clarifications when rejected."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    mock_confirm.return_value = False
+    
+    clarification = ValueConfirmationClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Confirm deletion?",
+        argument_name="confirm_delete",
+    )
+    
+    cli_handler.handle_value_confirmation_clarification(clarification, on_resolution, on_error)
+    
+    # Verify confirm was called
+    mock_confirm.assert_called_once()
+    
+    # Verify error callback was called with rejection message
+    on_resolution.assert_not_called()
+    on_error.assert_called_once()
+    assert "rejected" in on_error.call_args[0][1]
+
+
+@patch("portia.cli_clarification_handler.click.echo")
+@patch("portia.cli_clarification_handler.click.prompt")
+def test_custom_clarification(
+    mock_prompt: MagicMock, mock_echo: MagicMock, cli_handler: CLIClarificationHandler
+) -> None:
+    """Test handling of custom clarifications."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+    
+    mock_prompt.return_value = "custom response"
+    
+    clarification = CustomClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Custom action needed",
+        name="custom_action",
+        data={"key1": "value1", "key2": "value2"},
+    )
+    
+    cli_handler.handle_custom_clarification(clarification, on_resolution, on_error)
+    
+    # Verify echo was called twice (once for guidance, once for data)
+    assert mock_echo.call_count == 2
+    guidance_text = mock_echo.call_args_list[0][0][0]
+    data_text = mock_echo.call_args_list[1][0][0]
+    assert "Custom action needed" in click.unstyle(guidance_text)
+    assert "key1" in click.unstyle(data_text)
+    assert "value1" in click.unstyle(data_text)
+    
+    # Verify prompt was called
+    mock_prompt.assert_called_once()
+    
+    # Verify resolution callback was called with user input
+    on_resolution.assert_called_once_with(clarification, "custom response")
+    on_error.assert_not_called()


### PR DESCRIPTION
This PR moves the CLIClarificationHandler from cli.py to a new file cli_clarification_handler.py to improve code organization and maintainability.