### PR TITLE
[POR-1242] Add variant of action clarification that requires user confirmation

### DIFF
--- a/portia/clarification.py
+++ b/portia/clarification.py
@@ -88,6 +88,8 @@ class ActionClarification(Clarification):
     Attributes:
         category (ClarificationCategory): The category for this clarification, 'Action'.
         action_url (HttpUrl): The URL for the action that the user needs to complete.
+        require_confirmation (bool): Whether the user needs to confirm once the action has been
+            completed.
 
     """
 
@@ -96,6 +98,10 @@ class ActionClarification(Clarification):
         description="The category of this clarification",
     )
     action_url: HttpUrl
+    require_confirmation: bool = Field(
+        default=False,
+        description="Whether the user needs to confirm once the action has been completed.",
+    )
 
     @field_serializer("action_url")
     def serialize_action_url(self, action_url: HttpUrl) -> str:

--- a/portia/cli_clarification_handler.py
+++ b/portia/cli_clarification_handler.py
@@ -30,8 +30,8 @@ class CLIClarificationHandler(ClarificationHandler):
     def handle_action_clarification(
         self,
         clarification: ActionClarification,
-        on_resolution: Callable[[Clarification, object], None],  # noqa: ARG002
-        on_error: Callable[[Clarification, object], None],  # noqa: ARG002
+        on_resolution: Callable[[Clarification, object], None],
+        on_error: Callable[[Clarification, object], None],
     ) -> None:
         """Handle an action clarification.
 
@@ -45,6 +45,14 @@ class CLIClarificationHandler(ClarificationHandler):
                 fg=87,
             ),
         )
+        if clarification.require_confirmation:
+            if click.confirm(
+                text=click.style("Please confirm once the action is complete.", fg=87),
+                default=False,
+            ):
+                on_resolution(clarification, True)  # noqa: FBT003
+            else:
+                on_error(clarification, "Clarification was rejected by the user")
 
     def handle_input_clarification(
         self,

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -229,6 +229,7 @@ class BrowserTool(Tool[str]):
                         result.login_url,
                     ),
                     plan_run_id=ctx.plan_run_id,
+                    require_confirmation=True,
                 )
 
             async def run_agent_task(

--- a/tests/unit/open_source_tools/test_browser_tool.py
+++ b/tests/unit/open_source_tools/test_browser_tool.py
@@ -131,6 +131,7 @@ def test_browser_tool_auth_check(
                 user_guidance="Login to example.com",
                 action_url=HttpUrl("https://example.com/login"),
                 plan_run_id=context.plan_run_id,
+                require_confirmation=True,
             ),
         )
 

--- a/tests/unit/test_cli_clarification_handler.py
+++ b/tests/unit/test_cli_clarification_handler.py
@@ -48,6 +48,43 @@ def test_action_clarification(mock_echo: MagicMock, cli_handler: CLIClarificatio
     on_error.assert_not_called()
 
 
+@patch("portia.cli_clarification_handler.click.echo")
+@patch("portia.cli_clarification_handler.click.confirm")
+def test_action_clarification_with_confirmation(
+    mock_confirm: MagicMock,
+    mock_echo: MagicMock,
+    cli_handler: CLIClarificationHandler,
+) -> None:
+    """Test handling of action clarifications."""
+    on_resolution = MagicMock()
+    on_error = MagicMock()
+
+    mock_confirm.return_value = True
+
+    clarification = ActionClarification(
+        plan_run_id=PlanRunUUID(),
+        user_guidance="Please authenticate",
+        action_url=HttpUrl("https://example.com/auth"),
+        require_confirmation=True,
+    )
+
+    cli_handler.handle_action_clarification(clarification, on_resolution, on_error)
+
+    # Verify echo was called with the expected message
+    mock_echo.assert_called_once()
+    echo_message = mock_echo.call_args[0][0]
+    assert "Please authenticate" in click.unstyle(echo_message)
+    assert "https://example.com/auth" in click.unstyle(echo_message)
+
+    mock_confirm.assert_called_once()
+    confirm_message = mock_confirm.call_args[1]["text"]
+    assert "Please confirm once the action is complete." in click.unstyle(confirm_message)
+
+    # Verify resolution callback was called with True
+    on_resolution.assert_called_once_with(clarification, True)  # noqa: FBT003
+    on_error.assert_not_called()
+
+
 @patch("portia.cli_clarification_handler.click.prompt")
 def test_input_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificationHandler) -> None:
     """Test handling of input clarifications."""
@@ -76,7 +113,8 @@ def test_input_clarification(mock_prompt: MagicMock, cli_handler: CLIClarificati
 
 @patch("portia.cli_clarification_handler.click.prompt")
 def test_multiple_choice_clarification(
-    mock_prompt: MagicMock, cli_handler: CLIClarificationHandler,
+    mock_prompt: MagicMock,
+    cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of multiple choice clarifications."""
     on_resolution = MagicMock()
@@ -110,7 +148,8 @@ def test_multiple_choice_clarification(
 
 @patch("portia.cli_clarification_handler.click.confirm")
 def test_value_confirmation_clarification_confirmed(
-    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler,
+    mock_confirm: MagicMock,
+    cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of value confirmation clarifications when confirmed."""
     on_resolution = MagicMock()
@@ -138,7 +177,8 @@ def test_value_confirmation_clarification_confirmed(
 
 @patch("portia.cli_clarification_handler.click.confirm")
 def test_value_confirmation_clarification_rejected(
-    mock_confirm: MagicMock, cli_handler: CLIClarificationHandler,
+    mock_confirm: MagicMock,
+    cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of value confirmation clarifications when rejected."""
     on_resolution = MagicMock()
@@ -166,7 +206,9 @@ def test_value_confirmation_clarification_rejected(
 @patch("portia.cli_clarification_handler.click.echo")
 @patch("portia.cli_clarification_handler.click.prompt")
 def test_custom_clarification(
-    mock_prompt: MagicMock, mock_echo: MagicMock, cli_handler: CLIClarificationHandler,
+    mock_prompt: MagicMock,
+    mock_echo: MagicMock,
+    cli_handler: CLIClarificationHandler,
 ) -> None:
     """Test handling of custom clarifications."""
     on_resolution = MagicMock()


### PR DESCRIPTION
# Description

Add variant of action clarification that requires user confirmation. Used within browser tools so that the user can perform authentication and then indicate that they have done so.

Ticket Link: https://linear.app/portialabs/issue/POR-1242/create-a-cli-handler-that-works-for-browser-based-tools

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Changelog

### Added
- V0.2.2 Added a variant of ActionClarification which expects confirmation from the user once the action has been completed.
