### PR TITLE
Add extra argument to LLMTool `input_data: list[str]`

### DIFF
--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -22,8 +22,9 @@ class LLMToolSchema(BaseModel):
     )
     input_data: list[str] = Field(
         default_factory=list,
-        description="Any relevant data that should be used to complete the task. This should "
-        "include all relevant data in their entirety (i.e. not a summary).",
+        description="Any relevant data that should be used to complete the task. Important: This "
+        "should include all relevant data in their entirety, from the first to the last character "
+        "(i.e. NOT a summary).",
     )
 
 

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -15,7 +15,8 @@ class LLMToolSchema(BaseModel):
 
     task: str = Field(
         ...,
-        description="The task to be completed by the LLM tool.",
+        description="The task to be completed by the LLM tool including all relevant "
+        "context and inputs in full detail.",
     )
 
 

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -16,7 +16,8 @@ class LLMToolSchema(BaseModel):
     task: str = Field(
         ...,
         description="The task to be completed by the LLM tool including all relevant "
-        "context and inputs in full detail.",
+        "context and inputs in their entirety (i.e. not a summary or a cropped version of "
+        "the full context and inputs)",
     )
 
 

--- a/tests/unit/open_source_tools/test_llm_tool.py
+++ b/tests/unit/open_source_tools/test_llm_tool.py
@@ -39,7 +39,7 @@ def test_llm_tool_plan_run(
 
 def test_llm_tool_schema_valid_input() -> None:
     """Test that the LLMToolSchema correctly validates the input."""
-    schema_data = {"task": "Solve a math problem"}
+    schema_data = {"task": "Solve a math problem", "input_data": ["1 + 1 = 2"]}
     schema = LLMToolSchema(**schema_data)
 
     assert schema.task == "Solve a math problem"


### PR DESCRIPTION
# Description

The Execution Agent sometimes fails to pass inputs to the LLM Tool - it seems to think that the `task` argument should be the same as the Step task parameter, but that then misses inputs (variables and other context).

See doc for context of the decisions that went into fixing this: https://docs.google.com/document/d/1p3I8M9YnL5w2o1JMmFevbGrCHqWH0b0PiLY_bpSuTJE/edit?tab=t.0


Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
