### PR TITLE
Do not show toolIDs in log output for plan

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -223,9 +223,7 @@ class Portia:
             f"Plan created with {len(plan.steps)} steps",
             plan=str(plan.id),
         )
-        logger().debug(
-            "Plan: " + plan.model_dump_json(indent=4),
-        )
+        logger().debug(plan.pretty_print())
 
         return plan
 


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

Ticket Link: [POR-1211](https://linear.app/portialabs/issue/POR-1211/we-should-show-the-plan-in-the-logs-output-without-the-toolids)

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots
<img width="1556" alt="Screenshot 2025-04-22 at 23 18 34" src="https://github.com/user-attachments/assets/780fc643-1c57-4d96-9ada-7fbd6711dcfa" />


(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
