### PR TITLE
Added e2e test for input/ouputs dependencies

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -125,11 +125,8 @@ jobs:
           PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_EVAL_API_ENDPOINT }}
         run: |
           EVAL_OUTPUT=$(uv run cli.py introspection eval --slice_name=main --model=anthropic/claude-3-5-sonnet-latest --threshold_file=introspection/thresholds/claude-3-5-sonnet-latest/thresholds_local.yaml --reps 2 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=pr,env=local,repo=sdk"  --max_concurrency 32)
-          echo $EVAL_OUTPUT
           echo "eval_url=$(echo "$EVAL_OUTPUT" | grep -o 'https://smith.langchain.com/.*')" >> $GITHUB_OUTPUT
           echo "eval_name=$(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")" >> $GITHUB_OUTPUT
-          # Debug the extracted experiment name
-          echo "Extracted introspection experiment name: $(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")"
           if echo "$EVAL_OUTPUT" | grep -q "EVAL BREACH"; then
             BREACHES=$(echo "$EVAL_OUTPUT" | grep "EVAL BREACH:" | tr '\n' ' ' | sed 's/"/\\"/g')
             echo "BREACHES: $BREACHES"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -125,8 +125,11 @@ jobs:
           PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_EVAL_API_ENDPOINT }}
         run: |
           EVAL_OUTPUT=$(uv run cli.py introspection eval --slice_name=main --model=anthropic/claude-3-5-sonnet-latest --threshold_file=introspection/thresholds/claude-3-5-sonnet-latest/thresholds_local.yaml --reps 2 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=pr,env=local,repo=sdk"  --max_concurrency 32)
+          echo $EVAL_OUTPUT
           echo "eval_url=$(echo "$EVAL_OUTPUT" | grep -o 'https://smith.langchain.com/.*')" >> $GITHUB_OUTPUT
           echo "eval_name=$(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")" >> $GITHUB_OUTPUT
+          # Debug the extracted experiment name
+          echo "Extracted introspection experiment name: $(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")"
           if echo "$EVAL_OUTPUT" | grep -q "EVAL BREACH"; then
             BREACHES=$(echo "$EVAL_OUTPUT" | grep "EVAL BREACH:" | tr '\n' ' ' | sed 's/"/\\"/g')
             echo "BREACHES: $BREACHES"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -146,7 +146,7 @@ jobs:
           PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_EVAL_API_ENDPOINT }}
           AGENT_VERIFIER_EXPERIMENT_ID: ${{ steps.eval_agent_execution.outputs.eval_name }}
           QUERY_PLANNER_EXPERIMENT_ID: ${{ steps.eval_query_planner.outputs.eval_name }}
-          INTROSPECTION_AGENT_EXPERIMENT_ID: ${{ steps.eval_query_planner.outputs.eval_name }}
+          INTROSPECTION_AGENT_EXPERIMENT_ID: ${{ steps.eval_agent_introspection.outputs.eval_name }}
         run: |
           uv run jupyter nbconvert --to markdown --execute analysis/github_analysis.ipynb --output notebook_output.md --no-input
           cat analysis/notebook_output.md

--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -6,7 +6,6 @@
      - you need to ensure that all the information for carrying out the step will be provided in the combination of the task description and the inputs.
      - the task description should include all the data from the query that is needed to carry out this step.
      - DO NOT specify information in the step description that is already being passed in by an input
-     - all the data needed for the condition should be provided as part of the step inputs
      - MAKE SURE inputs are ONLY referencing variables from previous steps, IT SHOULD NOT contain any other data.
      - Make sure all IDs and URLs from the query are included in the task description as they are, and do not calculate/assume any data yourself.
      - give a name to the variable for the output of the step if it is successful.

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -40,6 +40,16 @@ CORE_PROVIDERS = [
     ),
 ]
 
+PLANNING_PROVIDERS = [
+    (
+        LLMProvider.OPENAI,
+        "openai/o3-mini",
+    ),
+    (
+        LLMProvider.ANTHROPIC,
+        "anthropic/claude-3-5-sonnet-latest",
+    ),
+]
 
 PROVIDER_MODELS = [
     *CORE_PROVIDERS,
@@ -492,3 +502,56 @@ def test_portia_run_query_requiring_cloud_tools_not_authenticated() -> None:
     with pytest.raises(PlanError) as e:
         portia.plan(query)
     assert "PORTIA_API_KEY is required to use Portia cloud tools." in str(e.value)
+
+@pytest.mark.parametrize(("llm_provider", "default_model_name"), PLANNING_PROVIDERS)
+def test_portia_plan_steps_inputs_dependencies(
+    llm_provider: LLMProvider,
+    default_model_name: str,
+) -> None:
+    """Test that a dynamically generated plan properly creates step dependencies."""
+    config = Config.from_default(
+        llm_provider=llm_provider,
+        default_model=default_model_name,
+        storage_class=StorageClass.MEMORY,
+    )
+
+    portia = Portia(config=config, tools=open_source_tool_registry)
+
+    # Simple query that requires multiple dependent steps
+    query = """First calculate 25 * 3, then write a haiku about the result,
+    and finally summarize the haiku with the result of the calculation.
+    If the result of the calculation is greater than 100, then final summary should
+     be saved to a file.
+    """
+
+    # Generate the plan
+    plan = portia.plan(query)
+
+    print(plan.pretty_print())
+
+    assert len(plan.steps) == 4, "Plan should have 4 steps"
+
+    assert plan.steps[0].inputs == [], "First step should not have inputs"
+    assert plan.steps[0].tool_id == "calculator_tool", "First step should have the calculator tool"
+    assert plan.steps[0].condition is None, "First step should not have a condition"
+
+    assert len(plan.steps[1].inputs) == 1, "Second step should have 1 input from calculation step"
+    assert (
+        plan.steps[1].inputs[0].name == plan.steps[0].output
+    ), "Second step should equal the output of the first step"
+    assert plan.steps[1].tool_id == "llm_tool", "Second step should have the LLM tool"
+    assert plan.steps[1].condition is None, "Second step should not have a condition"
+
+    assert len(plan.steps[2].inputs) == 2, "Third step should have (calculation and haiku) inputs"
+    assert (
+        {inp.name for inp in plan.steps[2].inputs} == {plan.steps[0].output, plan.steps[1].output}
+    ), "Third step inputs should match outputs of (calculation and haiku) steps"
+    assert plan.steps[2].condition is None, "Third step should not have a condition"
+    assert plan.steps[2].tool_id == "llm_tool", "Third step should be llm_tool"
+
+    assert len(plan.steps[3].inputs) >= 1, "Fourth step should have summary input"
+    assert (
+        any(inp.name == plan.steps[2].output for inp in plan.steps[3].inputs)
+    ), "Fourth step inputs should have summary input"
+    assert plan.steps[3].tool_id == "file_writer_tool", "Fourth step should be file_writer_tool"
+    assert "100" in str(plan.steps[3].condition), "Fourth step condition does not contain 100"

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -517,17 +517,13 @@ def test_portia_plan_steps_inputs_dependencies(
 
     portia = Portia(config=config, tools=open_source_tool_registry)
 
-    # Simple query that requires multiple dependent steps
     query = """First calculate 25 * 3, then write a haiku about the result,
     and finally summarize the haiku with the result of the calculation.
     If the result of the calculation is greater than 100, then final summary should
      be saved to a file.
     """
 
-    # Generate the plan
     plan = portia.plan(query)
-
-    print(plan.pretty_print())
 
     assert len(plan.steps) == 4, "Plan should have 4 steps"
 


### PR DESCRIPTION
# Description

- Add one e2e test to verify outputs are following into inputs as expected.
- Fix GH summary for introspection agent evals ([successful summary](https://github.com/portiaAI/portia-sdk-python/actions/runs/14623002112)).


Ticket Link: https://linear.app/portialabs/issue/POR-1252/add-e2e-test-to-capture-outputs-passed-as-inputs-in-steps

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
