### PR TITLE
Anthropic models: Increase max tokens and fall back on instructor for structured output

### DIFF
--- a/portia/model.py
+++ b/portia/model.py
@@ -441,7 +441,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         self,
         messages: list[Message],
         schema: type[BaseModelT],
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ARG002
     ) -> BaseModelT:
         """Call the model in structured output mode targeting the given Pydantic model.
 
@@ -454,9 +454,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             BaseModelT: The structured response from the model.
 
         """
-        if schema.__name__ == "StepsOrError":
-            return self.get_structured_response_instructor(messages, schema)
-        return super().get_structured_response(messages, schema, **kwargs)
+        return self.get_structured_response_instructor(messages, schema)
 
     def get_structured_response_instructor(
         self,

--- a/portia/model.py
+++ b/portia/model.py
@@ -462,7 +462,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         structured_client = self._client.with_structured_output(schema, include_raw=True, **kwargs)
         raw_response = structured_client.invoke(langchain_messages)
         if not isinstance(raw_response, dict):
-            raise TypeError(f"Expected dict, got {type(raw_response)}")
+            raise TypeError(f"Expected dict, got {type(raw_response).__name__}.")
         # Anthropic sometimes struggles serializing large JSON responses, so we fall back to
         # instructor if the response is above a certain size.
         if isinstance(raw_response.get("parsing_error"), ValidationError) and (

--- a/portia/model.py
+++ b/portia/model.py
@@ -15,7 +15,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from langsmith import wrappers
 from openai import AzureOpenAI, OpenAI
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from portia.common import validate_extras_dependencies
 
@@ -466,7 +466,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             raise TypeError(f"Expected dict, got {type(raw_response)}")
         # Anthropic sometimes struggles serializing large JSON responses, so we fall back to
         # instructor if the response is above a certain size.
-        if (raw_response.get("parsing_error") or {}).get("error") == "ValidationError" and (
+        if isinstance(raw_response.get("parsing_error"), ValidationError) and (
             len(tiktoken.get_encoding("gpt2").encode(json.dumps(raw_response["raw"])))
             > self._output_instructor_threshold
         ):

--- a/portia/model.py
+++ b/portia/model.py
@@ -466,7 +466,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         # instructor if the response is above a certain size.
         if (
             isinstance(response, dict)
-            and response.get("parsing_error", {}).get("error") == "ValidationError"
+            and (response.get("parsing_error") or {}).get("error") == "ValidationError"
             and (
                 len(tiktoken.get_encoding("gpt2").encode(json.dumps(response["raw"])))
                 > self._output_instructor_threshold

--- a/portia/model.py
+++ b/portia/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
@@ -467,7 +466,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         # Anthropic sometimes struggles serializing large JSON responses, so we fall back to
         # instructor if the response is above a certain size.
         if isinstance(raw_response.get("parsing_error"), ValidationError) and (
-            len(tiktoken.get_encoding("gpt2").encode(json.dumps(raw_response["raw"])))
+            len(tiktoken.get_encoding("gpt2").encode(raw_response["raw"].model_dump_json()))
             > self._output_instructor_threshold
         ):
             return self.get_structured_response_instructor(messages, schema)

--- a/portia/model.py
+++ b/portia/model.py
@@ -406,6 +406,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         api_key: SecretStr,
         timeout: int = 120,
         max_retries: int = 3,
+        max_tokens: int = 8096,
         **kwargs: Any,
     ) -> None:
         """Initialize with Anthropic client.
@@ -414,6 +415,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             model_name: Name of the Anthropic model
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries
+            max_tokens: Maximum number of tokens to generate
             api_key: API key for Anthropic
             **kwargs: Additional keyword arguments to pass to ChatAnthropic
 
@@ -422,14 +424,18 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             model_name=model_name,
             timeout=timeout,
             max_retries=max_retries,
+            max_tokens=max_tokens,  # pyright: ignore[reportCallIssue]
             api_key=api_key,
             **kwargs,
         )
         super().__init__(client, model_name)
         self._instructor_client = instructor.from_anthropic(
-            client=wrappers.wrap_anthropic(Anthropic(api_key=api_key.get_secret_value())),
+            client=wrappers.wrap_anthropic(
+                Anthropic(api_key=api_key.get_secret_value()),
+            ),
             mode=instructor.Mode.ANTHROPIC_JSON,
         )
+        self.max_tokens = max_tokens
 
     def get_structured_response(
         self,
@@ -463,7 +469,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             model=self.model_name,
             response_model=schema,
             messages=instructor_messages,
-            max_tokens=2048,
+            max_tokens=self.max_tokens,
         )
 
 

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -503,6 +503,7 @@ def test_portia_run_query_requiring_cloud_tools_not_authenticated() -> None:
         portia.plan(query)
     assert "PORTIA_API_KEY is required to use Portia cloud tools." in str(e.value)
 
+
 @pytest.mark.parametrize(("llm_provider", "default_model_name"), PLANNING_PROVIDERS)
 def test_portia_plan_steps_inputs_dependencies(
     llm_provider: LLMProvider,
@@ -539,15 +540,16 @@ def test_portia_plan_steps_inputs_dependencies(
     assert plan.steps[1].condition is None, "Second step should not have a condition"
 
     assert len(plan.steps[2].inputs) == 2, "Third step should have (calculation and haiku) inputs"
-    assert (
-        {inp.name for inp in plan.steps[2].inputs} == {plan.steps[0].output, plan.steps[1].output}
-    ), "Third step inputs should match outputs of (calculation and haiku) steps"
+    assert {inp.name for inp in plan.steps[2].inputs} == {
+        plan.steps[0].output,
+        plan.steps[1].output,
+    }, "Third step inputs should match outputs of (calculation and haiku) steps"
     assert plan.steps[2].condition is None, "Third step should not have a condition"
     assert plan.steps[2].tool_id == "llm_tool", "Third step should be llm_tool"
 
     assert len(plan.steps[3].inputs) >= 1, "Fourth step should have summary input"
-    assert (
-        any(inp.name == plan.steps[2].output for inp in plan.steps[3].inputs)
+    assert any(
+        inp.name == plan.steps[2].output for inp in plan.steps[3].inputs
     ), "Fourth step inputs should have summary input"
     assert plan.steps[3].tool_id == "file_writer_tool", "Fourth step should be file_writer_tool"
     assert "100" in str(plan.steps[3].condition), "Fourth step condition does not contain 100"

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,14 +1,17 @@
 """Unit tests for the Message class in portia.model."""
 
 from types import SimpleNamespace
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from portia.model import (
+    AnthropicGenerativeModel,
     GenerativeModel,
     LangChainGenerativeModel,
     LLMProvider,
@@ -176,3 +179,44 @@ def test_langchain_model_structured_output_returns_dict() -> None:
     )
     assert isinstance(result, StructuredOutputTestModel)
     assert result.test_field == "Response from model"
+
+
+def test_anthropic_model_structured_output_returns_dict() -> None:
+    """Test that AnthropicModel.structured_output returns a dict."""
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+    structured_output = MagicMock()
+    mock_chat_anthropic.with_structured_output.return_value = structured_output
+    structured_output.invoke.return_value = None
+
+    with mock.patch("portia.model.ChatAnthropic") as mock_chat_anthropic_cls:
+        mock_chat_anthropic_cls.return_value = mock_chat_anthropic
+        model = AnthropicGenerativeModel(model_name="test", api_key=SecretStr("test"))
+        with pytest.raises(TypeError, match="Expected dict, got None"):
+            model.get_structured_response(
+                messages=[Message(role="user", content="Hello")],
+                schema=StructuredOutputTestModel,
+            )
+
+
+def test_anthropic_model_structured_output_fallback_to_instructor() -> None:
+    """Test that AnthropicModel.structured_output falls back to instructor when expected."""
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+    structured_output = MagicMock()
+    mock_chat_anthropic.with_structured_output.return_value = structured_output
+    structured_output.invoke.return_value = {
+        "parsing_error": ValidationError("Test error", []),
+        "raw": AIMessage(content=" ".join("portia" for _ in range(10000))),
+        "parsed": None,
+    }
+
+    with (
+        mock.patch("portia.model.ChatAnthropic") as mock_chat_anthropic_cls,
+        mock.patch("instructor.from_anthropic") as mock_instructor,
+    ):
+        mock_chat_anthropic_cls.return_value = mock_chat_anthropic
+        model = AnthropicGenerativeModel(model_name="test", api_key=SecretStr("test"))
+        _ = model.get_structured_response(
+            messages=[Message(role="user", content="Hello")],
+            schema=StructuredOutputTestModel,
+        )
+        mock_instructor.return_value.chat.completions.create.assert_called_once()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -181,7 +181,7 @@ def test_langchain_model_structured_output_returns_dict() -> None:
     assert result.test_field == "Response from model"
 
 
-def test_anthropic_model_structured_output_returns_dict() -> None:
+def test_anthropic_model_structured_output_returns_invalid_data() -> None:
     """Test that AnthropicModel.structured_output returns a dict."""
     mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
     structured_output = MagicMock()
@@ -196,6 +196,24 @@ def test_anthropic_model_structured_output_returns_dict() -> None:
                 messages=[Message(role="user", content="Hello")],
                 schema=StructuredOutputTestModel,
             )
+
+
+def test_anthropic_model_structured_output_returns_dict() -> None:
+    """Test that AnthropicModel.structured_output returns a dict."""
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+    structured_output = MagicMock()
+    mock_chat_anthropic.with_structured_output.return_value = structured_output
+    structured_output.invoke.return_value = {"parsed": {"test_field": "Response from model"}}
+
+    with mock.patch("portia.model.ChatAnthropic") as mock_chat_anthropic_cls:
+        mock_chat_anthropic_cls.return_value = mock_chat_anthropic
+        model = AnthropicGenerativeModel(model_name="test", api_key=SecretStr("test"))
+        result = model.get_structured_response(
+            messages=[Message(role="user", content="Hello")],
+            schema=StructuredOutputTestModel,
+        )
+        assert isinstance(result, StructuredOutputTestModel)
+        assert result.test_field == "Response from model"
 
 
 def test_anthropic_model_structured_output_fallback_to_instructor() -> None:


### PR DESCRIPTION
# Description

Claude 3.5 defaults to 1024 tokens output which breaks the execution agent for larger (tool) inputs. This is a problem for the LLM tool, which sometimes need passing the large values via the new `input_data: list[str]` arg.

Claude 3.5 and 3.7 also struggle with structuring the JSON for large inputs into tool arguments (see eval PR link below). 

Instructor JSON mode doesnt have this problem, but it does introduce overhead of extra input tokens and introduces a separate problem where Claude writes a message before the JSON (because we are using Instructor `Mode.ANTHROPIC_JSON`)

For this reason, I've implemented the instructor mode as a fall back ONLY when Claude is trying to parse a large value into a JSON (which you can determine by asking Langchain to return raw responses)

Related eval PR https://github.com/portiaAI/platform/pull/384

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
