### PR TITLE
Add agent memory to one-shot agent

### DIFF
--- a/portia/execution_agents/base_execution_agent.py
+++ b/portia/execution_agents/base_execution_agent.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from portia.execution_agents.output import Output
     from portia.plan import Step
     from portia.plan_run import PlanRun
+    from portia.storage import AgentMemory
     from portia.tool import Tool, ToolRunContext
 
 
@@ -33,12 +34,13 @@ class BaseExecutionAgent:
     performance.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         step: Step,
         plan_run: PlanRun,
         config: Config,
         end_user: EndUser,
+        agent_memory: AgentMemory,
         tool: Tool | None = None,
     ) -> None:
         """Initialize the base agent with the given args.
@@ -53,6 +55,7 @@ class BaseExecutionAgent:
             plan_run (PlanRun): The run that contains the step and related data.
             config (Config): The configuration settings for the agent.
             end_user (EndUser): The end user for the execution.
+            agent_memory (AgentMemory): The agent memory for persisting outputs.
             tool (Tool | None): An optional tool associated with the agent (default is None).
 
         """
@@ -61,6 +64,7 @@ class BaseExecutionAgent:
         self.config = config
         self.plan_run = plan_run
         self.end_user = end_user
+        self.agent_memory = agent_memory
 
     @abstractmethod
     def execute_sync(self) -> Output:

--- a/portia/execution_agents/memory_extraction.py
+++ b/portia/execution_agents/memory_extraction.py
@@ -1,0 +1,70 @@
+"""Memory extraction step for execution agents.
+
+This module provides a step that extracts memory from previous outputs for use in execution agents.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from portia.errors import InvalidPlanRunStateError
+from portia.execution_agents.context import StepInput
+from portia.execution_agents.output import AgentMemoryOutput, LocalOutput
+from portia.logger import logger
+
+if TYPE_CHECKING:
+    from portia.execution_agents.base_execution_agent import BaseExecutionAgent
+
+
+class MemoryExtractionStep:
+    """A step that extracts memory from the context."""
+
+    def __init__(
+        self,
+        agent: BaseExecutionAgent,
+    ) -> None:
+        """Initialize the memory extraction step.
+
+        Args:
+            agent (BaseExecutionAgent): The agent using the memory extraction step.
+
+        """
+        self.agent = agent
+
+    def invoke(self, _: dict[str, Any]) -> dict[str, Any]:
+        """Invoke the model with the given message state.
+
+        Returns:
+            dict[str, Any]: The LangGraph state update to step_inputs
+
+        """
+        step_inputs = []
+        previous_outputs = self.agent.plan_run.outputs.step_outputs
+        for step_input in self.agent.step.inputs:
+            if step_input.name not in previous_outputs:
+                raise InvalidPlanRunStateError("Received unknown step input: %s", step_input.name)
+            previous_output = previous_outputs.get(step_input.name)
+
+            match previous_output:
+                case LocalOutput():
+                    output_value = previous_output.value
+                case AgentMemoryOutput():
+                    output_value = self.agent.agent_memory.get_plan_run_output(
+                        previous_output.output_name,
+                        self.agent.plan_run.id,
+                    ).value
+                case _:
+                    logger().warning(
+                        "Received unknown output type: %s",
+                        previous_output,
+                    )
+                    continue
+
+            step_inputs.append(
+                StepInput(
+                    name=step_input.name,
+                    value=output_value,
+                    description=step_input.description,
+                ),
+            )
+        return {"step_inputs": step_inputs}

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -15,16 +15,15 @@ from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplat
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.prebuilt import ToolNode
 
-from portia.errors import InvalidAgentError, InvalidPlanRunStateError
+from portia.errors import InvalidAgentError
 from portia.execution_agents.base_execution_agent import BaseExecutionAgent
-from portia.execution_agents.context import StepInput
 from portia.execution_agents.execution_utils import (
     AgentNode,
     next_state_after_tool_call,
     process_output,
     tool_call_or_end,
 )
-from portia.execution_agents.output import AgentMemoryOutput, LocalOutput
+from portia.execution_agents.memory_extraction import MemoryExtractionStep
 from portia.execution_agents.utils.step_summarizer import StepSummarizer
 from portia.execution_context import get_execution_context
 from portia.tool import ToolRunContext
@@ -34,12 +33,19 @@ if TYPE_CHECKING:
 
     from portia.config import Config
     from portia.end_user import EndUser
+    from portia.execution_agents.context import StepInput
     from portia.execution_agents.output import Output
     from portia.model import GenerativeModel
     from portia.plan import Step
     from portia.plan_run import PlanRun
     from portia.storage import AgentMemory
     from portia.tool import Tool
+
+
+class ExecutionState(MessagesState):
+    """State for the execution agent."""
+
+    step_inputs: list[StepInput]
 
 
 class OneShotToolCallingModel:
@@ -54,7 +60,6 @@ class OneShotToolCallingModel:
 
     Args:
         model (GenerativeModel): The language model to use for generating responses.
-        context (str): The context to provide to the language model when generating a response.
         tools (list[StructuredTool]): A list of tools that can be used during the task.
         agent (OneShotAgent): The agent responsible for managing the task.
 
@@ -88,32 +93,32 @@ class OneShotToolCallingModel:
     def __init__(
         self,
         model: GenerativeModel,
-        context: str,
         tools: list[StructuredTool],
         agent: OneShotAgent,
+        tool_context: ToolRunContext,
     ) -> None:
         """Initialize the OneShotToolCallingModel.
 
         Args:
             model (GenerativeModel): The language model to use for generating responses.
-            context (str): The context to be used when generating the response.
             tools (list[StructuredTool]): A list of tools that can be used during the task.
             agent (OneShotAgent): The agent that is managing the task.
+            tool_context (ToolRunContext): The context for the tool.
 
         """
         self.model = model
-        self.context = context
         self.agent = agent
         self.tools = tools
+        self.tool_context = tool_context
 
-    def invoke(self, state: MessagesState) -> dict[str, Any]:
+    def invoke(self, state: ExecutionState) -> dict[str, Any]:
         """Invoke the model with the given message state.
 
         This method formats the input for the language model using the query, context,
         and past errors, then generates a response by invoking the model.
 
         Args:
-            state (MessagesState): The state containing the messages and other necessary data.
+            state (ExecutionState): The state containing the messages and other necessary data.
 
         Returns:
             dict[str, Any]: A dictionary containing the model's generated response.
@@ -122,10 +127,11 @@ class OneShotToolCallingModel:
         model = self.model.to_langchain().bind_tools(self.tools)
         messages = state["messages"]
         past_errors = [msg for msg in messages if "ToolSoftError" in msg.content]
+        context = self.agent.get_system_context(self.tool_context, state["step_inputs"])
         response = model.invoke(
             self.tool_calling_prompt.format_messages(
                 query=self.agent.step.task,
-                context=self.context,
+                context=context,
                 past_errors=past_errors,
             ),
         )
@@ -136,13 +142,16 @@ class OneShotAgent(BaseExecutionAgent):
     """Agent responsible for achieving a task by using langgraph.
 
     This agent performs the following steps:
-    1. Calls the tool with unverified arguments.
-    2. Retries tool calls up to 4 times.
+    1. Extracts inputs from agent memory (if applicable)
+    2. Calls the tool with unverified arguments.
+    3. Retries tool calls up to 4 times.
 
     Args:
         step (Step): The current step in the task plan.
         plan_run (PlanRun): The run that defines the task execution process.
         config (Config): The configuration settings for the agent.
+        agent_memory (AgentMemory): The agent memory for persisting outputs.
+        end_user (EndUser): The end user for the execution.
         tool (Tool | None): The tool to be used for the task (optional).
 
     Methods:
@@ -155,7 +164,7 @@ class OneShotAgent(BaseExecutionAgent):
         step: Step,
         plan_run: PlanRun,
         config: Config,
-        agent_memory: AgentMemory,  # noqa: ARG002
+        agent_memory: AgentMemory,
         end_user: EndUser,
         tool: Tool | None = None,
     ) -> None:
@@ -165,12 +174,12 @@ class OneShotAgent(BaseExecutionAgent):
             step (Step): The current step in the task plan.
             plan_run (PlanRun): The run that defines the task execution process.
             config (Config): The configuration settings for the agent.
-            agent_memory (AgentMemory): Not supported in this execution agent.
+            agent_memory (AgentMemory): The agent memory for persisting outputs.
             end_user (EndUser): The end user for the execution.
             tool (Tool | None): The tool to be used for the task (optional).
 
         """
-        super().__init__(step, plan_run, config, end_user, tool)
+        super().__init__(step, plan_run, config, end_user, agent_memory, tool)
 
     def execute_sync(self) -> Output:
         """Run the core execution logic of the task.
@@ -183,28 +192,7 @@ class OneShotAgent(BaseExecutionAgent):
         """
         if not self.tool:
             raise InvalidAgentError("No tool available")
-        if any(
-            isinstance(output, AgentMemoryOutput)
-            for output in self.plan_run.outputs.step_outputs.values()
-        ):
-            raise InvalidPlanRunStateError(
-                "One-shot agent does not support pulling outputs from agent memory",
-            )
 
-        previous_outputs = {
-            output_name: output.value
-            for output_name, output in self.plan_run.outputs.step_outputs.items()
-            if isinstance(output, LocalOutput)
-        }
-        step_inputs = [
-            StepInput(
-                name=step_input.name,
-                value=previous_outputs.get(step_input.name),
-                description=step_input.description,
-            )
-            for step_input in self.step.inputs
-            if step_input.name in previous_outputs
-        ]
         tool_run_ctx = ToolRunContext(
             execution_context=get_execution_context(),
             end_user=self.end_user,
@@ -213,7 +201,6 @@ class OneShotAgent(BaseExecutionAgent):
             clarifications=self.plan_run.get_clarifications_for_step(),
         )
 
-        context = self.get_system_context(tool_run_ctx, step_inputs)
         model = self.config.get_execution_model()
         tools = [
             self.tool.to_langchain_with_artifact(
@@ -222,17 +209,21 @@ class OneShotAgent(BaseExecutionAgent):
         ]
         tool_node = ToolNode(tools)
 
-        graph = StateGraph(MessagesState)
+        graph = StateGraph(ExecutionState)
+        graph.add_node(AgentNode.MEMORY_EXTRACTION, MemoryExtractionStep(self).invoke)
+        graph.add_edge(START, AgentNode.MEMORY_EXTRACTION)
+
         graph.add_node(
             AgentNode.TOOL_AGENT,
-            OneShotToolCallingModel(model, context, tools, self).invoke,
+            OneShotToolCallingModel(model, tools, self, tool_run_ctx).invoke,
         )
+        graph.add_edge(AgentNode.MEMORY_EXTRACTION, AgentNode.TOOL_AGENT)
+
         graph.add_node(AgentNode.TOOLS, tool_node)
         graph.add_node(
             AgentNode.SUMMARIZER,
             StepSummarizer(self.config, model, self.tool, self.step).invoke,
         )
-        graph.add_edge(START, AgentNode.TOOL_AGENT)
 
         # Use execution manager for state transitions
         graph.add_conditional_edges(
@@ -246,6 +237,6 @@ class OneShotAgent(BaseExecutionAgent):
         graph.add_edge(AgentNode.SUMMARIZER, END)
 
         app = graph.compile()
-        invocation_result = app.invoke({"messages": []})
+        invocation_result = app.invoke({"messages": [], "step_inputs": []})
 
         return process_output(invocation_result["messages"], self.tool)

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -731,8 +731,7 @@ class Portia:
             )
 
         logger().info(
-            f"Evaluating condition for Step #{current_step_index}: "
-            f"#{step.condition}",
+            f"Evaluating condition for Step #{current_step_index}: #{step.condition}",
         )
 
         pre_step_outcome = introspection_agent.pre_step_introspection(

--- a/tests/unit/execution_agents/test_base_execution_agent.py
+++ b/tests/unit/execution_agents/test_base_execution_agent.py
@@ -16,6 +16,7 @@ from portia.execution_agents.base_execution_agent import BaseExecutionAgent
 from portia.execution_agents.context import StepInput
 from portia.execution_agents.output import LocalOutput
 from portia.prefixed_uuid import PlanRunUUID
+from portia.storage import InMemoryStorage
 from tests.utils import get_test_config, get_test_plan_run, get_test_tool_context
 
 
@@ -27,6 +28,7 @@ def test_base_agent_default_context() -> None:
         plan_run,
         get_test_config(),
         EndUser(external_id="test"),
+        InMemoryStorage(),
         None,
     )
     context = agent.get_system_context(

--- a/tests/unit/execution_agents/test_default_execution_agent.py
+++ b/tests/unit/execution_agents/test_default_execution_agent.py
@@ -19,7 +19,6 @@ from portia.errors import InvalidAgentError, InvalidPlanRunStateError
 from portia.execution_agents.default_execution_agent import (
     MAX_RETRIES,
     DefaultExecutionAgent,
-    MemoryExtractionStep,
     ParserModel,
     ToolArgument,
     ToolCallingModel,
@@ -28,9 +27,10 @@ from portia.execution_agents.default_execution_agent import (
     VerifiedToolInputs,
     VerifierModel,
 )
+from portia.execution_agents.memory_extraction import MemoryExtractionStep
 from portia.execution_agents.output import LocalOutput, Output
 from portia.model import LangChainGenerativeModel
-from portia.plan import Step, Variable
+from portia.plan import Step
 from portia.storage import InMemoryStorage
 from portia.tool import Tool
 from tests.utils import (
@@ -348,17 +348,17 @@ def test_verifier_model_schema_validation() -> None:
 
     required_field1 = next(arg for arg in result_inputs.args if arg.name == "required_field1")
     required_field2 = next(arg for arg in result_inputs.args if arg.name == "required_field2")
-    assert (
-        required_field1.schema_invalid
-    ), "required_field1 should be marked as missing when validation fails"
-    assert (
-        required_field2.schema_invalid
-    ), "required_field2 should be marked as missing when validation fails"
+    assert required_field1.schema_invalid, (
+        "required_field1 should be marked as missing when validation fails"
+    )
+    assert required_field2.schema_invalid, (
+        "required_field2 should be marked as missing when validation fails"
+    )
 
     optional_field = next(arg for arg in result_inputs.args if arg.name == "optional_field")
-    assert (
-        not optional_field.schema_invalid
-    ), "optional_field should not be marked as missing when validation fails"
+    assert not optional_field.schema_invalid, (
+        "optional_field should not be marked as missing when validation fails"
+    )
 
 
 def test_tool_calling_model_no_hallucinations() -> None:
@@ -854,115 +854,3 @@ def test_verifier_model_edge_cases() -> None:
     agent.tool = None
     with pytest.raises(InvalidPlanRunStateError):
         verifier_model.invoke({"messages": [], "step_inputs": []})
-
-
-def test_memory_extraction_step_no_inputs() -> None:
-    """Test MemoryExtractionStep with no step inputs."""
-    (_, plan_run) = get_test_plan_run()
-    agent = DefaultExecutionAgent(
-        step=Step(task="DESCRIPTION_STRING", output="$out"),
-        plan_run=plan_run,
-        config=get_test_config(),
-        tool=None,
-        agent_memory=InMemoryStorage(),
-        end_user=EndUser(external_id="123"),
-    )
-
-    memory_extraction_step = MemoryExtractionStep(agent=agent)
-    result = memory_extraction_step.invoke({"messages": [], "step_inputs": []})
-
-    assert result == {"step_inputs": []}
-
-
-def test_memory_extraction_step_with_inputs() -> None:
-    """Test MemoryExtractionStep with step inputs (one local, one from agent memory)."""
-    (_, plan_run) = get_test_plan_run()
-
-    storage = InMemoryStorage()
-    saved_output = storage.save_plan_run_output(
-        "$memory_output",
-        LocalOutput(value="memory_value"),
-        plan_run.id,
-    )
-    plan_run.outputs.step_outputs = {
-        "$local_output": LocalOutput(value="local_value"),
-        "$memory_output": saved_output,
-    }
-
-    agent = DefaultExecutionAgent(
-        step=Step(
-            task="DESCRIPTION_STRING",
-            output="$out",
-            inputs=[
-                Variable(name="$local_output", description="Local input description"),
-                Variable(name="$memory_output", description="Memory input description"),
-            ],
-        ),
-        plan_run=plan_run,
-        config=get_test_config(),
-        tool=None,
-        agent_memory=storage,
-        end_user=EndUser(external_id="123"),
-    )
-
-    memory_extraction_step = MemoryExtractionStep(agent=agent)
-    result = memory_extraction_step.invoke({"messages": [], "step_inputs": []})
-
-    assert len(result["step_inputs"]) == 2
-    assert result["step_inputs"][0].name == "$local_output"
-    assert result["step_inputs"][0].value == "local_value"
-    assert result["step_inputs"][0].description == "Local input description"
-    assert result["step_inputs"][1].name == "$memory_output"
-    assert result["step_inputs"][1].value == "memory_value"
-    assert result["step_inputs"][1].description == "Memory input description"
-
-
-def test_memory_extraction_step_errors_with_missing_input() -> None:
-    """Test MemoryExtractionStep ignores step inputs that aren't in previous outputs."""
-    (_, plan_run) = get_test_plan_run()
-    agent = DefaultExecutionAgent(
-        step=Step(
-            task="DESCRIPTION_STRING",
-            output="$out",
-            inputs=[
-                Variable(name="$missing_input", description="Missing input description"),
-                Variable(name="$a", description="A value"),
-            ],
-        ),
-        plan_run=plan_run,
-        config=get_test_config(),
-        tool=None,
-        agent_memory=InMemoryStorage(),
-        end_user=EndUser(external_id="123"),
-    )
-
-    memory_extraction_step = MemoryExtractionStep(agent=agent)
-    with pytest.raises(InvalidPlanRunStateError):
-        memory_extraction_step.invoke({"messages": [], "step_inputs": []})
-
-
-def test_memory_extraction_step_handles_unknown_output_type() -> None:
-    """Test MemoryExtractionStep handles unknown output types gracefully."""
-    (_, plan_run) = get_test_plan_run()
-    plan_run.outputs.step_outputs = {
-        "$unexpected_input": SimpleNamespace(value="Unexpected input value"),  # pyright: ignore[reportAttributeAccessIssue]
-    }
-    agent = DefaultExecutionAgent(
-        step=Step(
-            task="DESCRIPTION_STRING",
-            output="$out",
-            inputs=[
-                Variable(name="$unexpected_input", description="Unexpected input description"),
-            ],
-        ),
-        plan_run=plan_run,
-        config=get_test_config(),
-        tool=None,
-        agent_memory=InMemoryStorage(),
-        end_user=EndUser(external_id="123"),
-    )
-
-    memory_extraction_step = MemoryExtractionStep(agent=agent)
-    result = memory_extraction_step.invoke({"messages": [], "step_inputs": []})
-
-    assert len(result["step_inputs"]) == 0

--- a/tests/unit/execution_agents/test_memory_extraction.py
+++ b/tests/unit/execution_agents/test_memory_extraction.py
@@ -1,0 +1,128 @@
+"""Tests for memory extraction step."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from portia.end_user import EndUser
+from portia.errors import InvalidPlanRunStateError
+from portia.execution_agents.base_execution_agent import BaseExecutionAgent
+from portia.execution_agents.memory_extraction import MemoryExtractionStep
+from portia.execution_agents.output import LocalOutput
+from portia.plan import Step, Variable
+from portia.storage import InMemoryStorage
+from tests.utils import get_test_config, get_test_plan_run
+
+
+def test_memory_extraction_step_no_inputs() -> None:
+    """Test MemoryExtractionStep with no step inputs."""
+    (_, plan_run) = get_test_plan_run()
+    agent = BaseExecutionAgent(
+        step=Step(task="DESCRIPTION_STRING", output="$out"),
+        plan_run=plan_run,
+        config=get_test_config(),
+        end_user=EndUser(external_id="123"),
+        agent_memory=InMemoryStorage(),
+        tool=None,
+    )
+
+    memory_extraction_step = MemoryExtractionStep(agent=agent)
+    result = memory_extraction_step.invoke({})
+
+    assert result == {"step_inputs": []}
+
+
+def test_memory_extraction_step_with_inputs() -> None:
+    """Test MemoryExtractionStep with step inputs (one local, one from agent memory)."""
+    (_, plan_run) = get_test_plan_run()
+
+    storage = InMemoryStorage()
+    saved_output = storage.save_plan_run_output(
+        "$memory_output",
+        LocalOutput(value="memory_value"),
+        plan_run.id,
+    )
+    plan_run.outputs.step_outputs = {
+        "$local_output": LocalOutput(value="local_value"),
+        "$memory_output": saved_output,
+    }
+
+    agent = BaseExecutionAgent(
+        step=Step(
+            task="DESCRIPTION_STRING",
+            output="$out",
+            inputs=[
+                Variable(name="$local_output", description="Local input description"),
+                Variable(name="$memory_output", description="Memory input description"),
+            ],
+        ),
+        plan_run=plan_run,
+        config=get_test_config(),
+        tool=None,
+        agent_memory=storage,
+        end_user=EndUser(external_id="123"),
+    )
+
+    memory_extraction_step = MemoryExtractionStep(agent=agent)
+    result = memory_extraction_step.invoke({})
+
+    assert len(result["step_inputs"]) == 2
+    assert result["step_inputs"][0].name == "$local_output"
+    assert result["step_inputs"][0].value == "local_value"
+    assert result["step_inputs"][0].description == "Local input description"
+    assert result["step_inputs"][1].name == "$memory_output"
+    assert result["step_inputs"][1].value == "memory_value"
+    assert result["step_inputs"][1].description == "Memory input description"
+
+
+def test_memory_extraction_step_errors_with_missing_input() -> None:
+    """Test MemoryExtractionStep ignores step inputs that aren't in previous outputs."""
+    (_, plan_run) = get_test_plan_run()
+    agent = BaseExecutionAgent(
+        step=Step(
+            task="DESCRIPTION_STRING",
+            output="$out",
+            inputs=[
+                Variable(name="$missing_input", description="Missing input description"),
+                Variable(name="$a", description="A value"),
+            ],
+        ),
+        plan_run=plan_run,
+        config=get_test_config(),
+        tool=None,
+        agent_memory=InMemoryStorage(),
+        end_user=EndUser(external_id="123"),
+    )
+
+    memory_extraction_step = MemoryExtractionStep(agent=agent)
+    with pytest.raises(InvalidPlanRunStateError):
+        memory_extraction_step.invoke({})
+
+
+def test_memory_extraction_step_handles_unknown_output_type() -> None:
+    """Test MemoryExtractionStep handles unknown output types gracefully."""
+    (_, plan_run) = get_test_plan_run()
+    plan_run.outputs.step_outputs = {
+        "$unexpected_input": SimpleNamespace(value="Unexpected input value"),  # pyright: ignore[reportAttributeAccessIssue]
+    }
+    agent = BaseExecutionAgent(
+        step=Step(
+            task="DESCRIPTION_STRING",
+            output="$out",
+            inputs=[
+                Variable(name="$unexpected_input", description="Unexpected input description"),
+            ],
+        ),
+        plan_run=plan_run,
+        config=get_test_config(),
+        tool=None,
+        agent_memory=InMemoryStorage(),
+        end_user=EndUser(external_id="123"),
+    )
+
+    memory_extraction_step = MemoryExtractionStep(agent=agent)
+    result = memory_extraction_step.invoke({})
+
+    assert len(result["step_inputs"]) == 0


### PR DESCRIPTION
# Description

Adds agent memory to one-shot agent. I originally wasn't sure about doing this, but realise we def should now tunic are using it. Most of the diff is just moving the MemoryExtractionStep into its own file.

## Type of change

(select all that apply)

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
