### PR TITLE
Make sure if portia-cloud-replan fails we still exit with PlanError

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -244,9 +244,8 @@ class Portia:
                     end_user,
                     example_plans,
                 )
-            else:
-                logger().error(f"Error in planning - {outcome.error}")
-                raise PlanError(outcome.error)
+            logger().error(f"Error in planning - {outcome.error}")
+            raise PlanError(outcome.error)
         plan = Plan(
             plan_context=PlanContext(
                 query=query,

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -502,8 +502,8 @@ def test_portia_run_query_requiring_cloud_tools_not_authenticated() -> None:
 
     portia = Portia(config=config)
     query = (
-        "Send an email to John Doe using the Gmail tool. Only use the Gmail tool and "
-        "fail if you can't use it."
+        "Send an email to John Doe (john.doe@example.com) using the Gmail tool. Only use the Gmail "
+        "tool and fail if you can't use it."
     )
 
     with pytest.raises(PlanError) as e:


### PR DESCRIPTION
# Description

When debugging a flakey test `test_portia_run_query_requiring_cloud_tools_not_authenticated` I realised we dont exit with a PlanError if the _replan_ fails. This change makes sure we always to exit with a PlanError in this case.

Also improved the flakey test by adding email address to the prompt (the reason for the flake was that the planner complained about lack of email address sometimes (actually very rarely, which is odd)

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
