### PR TITLE
Raise ready status clarifications up-front and after any tool-run clarifications

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1027,7 +1027,6 @@ class Portia:
                     existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}  # pyright: ignore[reportUnhashable]
                     for clarification in ready_response.clarifications:
                         if clarification.id not in existing_clarification_ids:
-                            clarification.step = None  # Update backend to return None for ready
                             plan_run.outputs.clarifications.append(clarification)
                             new_clarifications_raised = True
                             logger().info(

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -336,11 +336,9 @@ class Portia:
         plan = self.storage.get_plan(plan_id=plan_run.plan_id)
 
         # Perform initial readiness check
-        self._check_remaining_tool_readiness(plan, plan_run)
-
-        # If the readiness check resulted in needing clarification, return immediately
-        if plan_run.state == PlanRunState.NEED_CLARIFICATION:
-            logger().debug("Returning plan run early due to readiness check clarifications.")
+        if len(ready_clarifications := self._check_remaining_tool_readiness(plan, plan_run)):
+            self._raise_clarifications(ready_clarifications, plan_run)
+            self._handle_clarifications(plan_run)
             return plan_run
 
         # if the run has execution context associated, but none is set then use it
@@ -363,25 +361,30 @@ class Portia:
             plan_run.execution_context = get_execution_context()
             plan_run = self._execute_plan_run(plan, plan_run)
 
-            # If we don't have a clarification handler, return the plan run even if a clarification
-            # has been raised
-            if not self.execution_hooks.clarification_handler:
-                return plan_run
-
-            clarifications = plan_run.get_outstanding_clarifications()
-            for clarification in clarifications:
-                self.execution_hooks.clarification_handler.handle(
-                    clarification=clarification,
-                    on_resolution=lambda c, r: self.resolve_clarification(c, r) and None,
-                    on_error=lambda c, r: self.error_clarification(c, r) and None,
-                )
-
-            if len(clarifications) > 0:
-                # If clarifications are handled synchronously, we'll go through this immediately.
-                # If they're handled asynchronously, we'll wait for the plan run to be ready.
-                plan_run = self.wait_for_ready(plan_run)
+            self._handle_clarifications(plan_run)
 
         return plan_run
+
+    def _handle_clarifications(self, plan_run: PlanRun) -> None:
+        """Handle any clarifications that are raised during the execution of a plan run."""
+        # If we don't have a clarification handler, return the plan run even if a clarification
+        # has been raised
+        if not self.execution_hooks.clarification_handler:
+            return
+
+        clarifications = plan_run.get_outstanding_clarifications()
+        for clarification in clarifications:
+            self.execution_hooks.clarification_handler.handle(
+                clarification=clarification,
+                on_resolution=lambda c, r: self.resolve_clarification(c, r) and None,
+                on_error=lambda c, r: self.error_clarification(c, r) and None,
+            )
+
+        if len(clarifications) > 0:
+            # If clarifications are handled synchronously, we'll go through this immediately.
+            # If they're handled asynchronously, we'll wait for the plan run to be ready.
+            plan_run = self.wait_for_ready(plan_run)
+        return
 
     def resolve_clarification(
         self,
@@ -652,14 +655,28 @@ class Portia:
                     f"Step output - {last_executed_step_output.get_summary()!s}",
                 )
 
-            if self._raise_clarifications(plan_run, last_executed_step_output, plan):
+            if (
+                len(
+                    new_clarifications := self._get_clarifications_from_output(
+                        last_executed_step_output,
+                        plan_run,
+                    )
+                )
+                > 0
+            ):
                 # If execution raised a clarification, re-check readiness of subsequent tools
                 logger().debug(
                     "Re-checking tool readiness after execution clarification.",
                     plan=str(plan.id),
                     plan_run=str(plan_run.id),
                 )
-                self._check_remaining_tool_readiness(plan, plan_run, start_index=index + 1)
+                ready_clarifications = self._check_remaining_tool_readiness(
+                    plan,
+                    plan_run,
+                    start_index=index + 1,
+                )
+                combined_clarifications = new_clarifications + ready_clarifications
+                self._raise_clarifications(combined_clarifications, plan_run)
                 return plan_run
 
             # persist at the end of each step
@@ -834,16 +851,16 @@ class Portia:
 
         return final_output
 
-    def _raise_clarifications(self, plan_run: PlanRun, step_output: Output, plan: Plan) -> bool:
-        """Update the plan run based on any clarifications raised.
+    def _get_clarifications_from_output(
+        self,
+        step_output: Output,
+        plan_run: PlanRun,
+    ) -> list[Clarification]:
+        """Get clarifications from the output of a step.
 
         Args:
-            plan_run (PlanRun): The PlanRun to execute.
-            step_output (Output): The output of the last step.
-            plan (Plan): The plan to execute.
-
-        Returns:
-            bool: True if clarification is needed and run execution should stop.
+            step_output (Output): The output of the step.
+            plan_run (PlanRun): The plan run to get the clarifications from.
 
         """
         output_value = step_output.get_value()
@@ -857,20 +874,31 @@ class Portia:
             )
             for clarification in new_clarifications:
                 clarification.step = plan_run.current_step_index
-                logger().info(
-                    f"Clarification requested - category: {clarification.category}, "
-                    f"user_guidance: {clarification.user_guidance}.",
-                    plan=str(plan.id),
-                    plan_run=str(plan_run.id),
-                )
-                logger().debug(
-                    f"Clarification requested: {clarification.model_dump_json(indent=4)}",
-                )
+            return new_clarifications
+        return []
 
-            plan_run.outputs.clarifications = plan_run.outputs.clarifications + new_clarifications
-            self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
-            return True
-        return False
+    def _raise_clarifications(self, clarifications: list[Clarification], plan_run: PlanRun) -> None:
+        """Update the plan run based on any clarifications raised.
+
+        Args:
+            clarifications (list[Clarification]): The clarifications to raise.
+            plan_run (PlanRun): The PlanRun to execute.
+
+        """
+        for clarification in clarifications:
+            clarification.step = plan_run.current_step_index
+            logger().info(
+                f"Clarification requested - category: {clarification.category}, "
+                f"user_guidance: {clarification.user_guidance}.",
+                plan=str(plan_run.plan_id),
+                plan_run=str(plan_run.id),
+            )
+            logger().debug(
+                f"Clarification requested: {clarification.model_dump_json(indent=4)}",
+            )
+
+        plan_run.outputs.clarifications = plan_run.outputs.clarifications + clarifications
+        self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
 
     def _get_tool_for_step(self, step: Step, plan_run: PlanRun) -> Tool | None:
         if not step.tool_id:
@@ -982,8 +1010,8 @@ class Portia:
         plan: Plan,
         plan_run: PlanRun,
         start_index: int | None = None,
-    ) -> bool:
-        """Check the ready status of tools in remaining steps and update plan_run if needed.
+    ) -> list[Clarification]:
+        """Check if there are any new clarifications raised by tools in remaining steps.
 
         Args:
             plan: The plan containing the steps.
@@ -992,11 +1020,11 @@ class Portia:
                 current step index.
 
         Returns:
-            True if new clarifications were raised, False otherwise.
+            list[Clarification]: The clarifications raised by the tools.
 
         """
         checked_tool_ids = set()
-        new_clarifications_raised = False
+        ready_clarifications = []
         check_from_index = start_index if start_index is not None else plan_run.current_step_index
         end_user = self.initialize_end_user(plan_run.end_user_id)
 
@@ -1011,43 +1039,21 @@ class Portia:
 
             checked_tool_ids.add(step.tool_id)
             logger().debug(f"Checking readiness for tool: {tool.name} (ID: {step.tool_id})")
-            try:
-                ready_response = tool.ready(
-                    ToolRunContext(
-                        execution_context=plan_run.execution_context,
-                        end_user=end_user,
-                        plan_run_id=plan_run.id,
-                        config=self.config,
-                        # Pass only clarifications relevant to this *specific* step/tool if
-                        # available, otherwise, pass none for the general readiness check.
-                        clarifications=plan_run.get_clarifications_for_step(step_index),
-                    ),
-                )
-                if not ready_response.ready:
-                    existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}  # pyright: ignore[reportUnhashable]
-                    for clarification in ready_response.clarifications:
-                        if clarification.id not in existing_clarification_ids:
-                            plan_run.outputs.clarifications.append(clarification)
-                            new_clarifications_raised = True
-                            logger().info(
-                                f"Tool '{tool.name}' raised clarification: "
-                                f"{clarification.user_guidance}"
-                            )
-            except Exception as e:  # noqa: BLE001
-                logger().warning(
-                    f"Error checking ready status for tool {tool.name} (ID: {step.tool_id}): {e}",
-                    exc_info=True,
-                )
+            ready_response = tool.ready(
+                ToolRunContext(
+                    execution_context=plan_run.execution_context,
+                    end_user=end_user,
+                    plan_run_id=plan_run.id,
+                    config=self.config,
+                    # Pass only clarifications relevant to this *specific* step/tool if
+                    # available, otherwise, pass none for the general readiness check.
+                    clarifications=plan_run.get_clarifications_for_step(step_index),
+                ),
+            )
+            if not ready_response.ready:
+                ready_clarifications.extend(ready_response.clarifications)
 
-        if new_clarifications_raised:
-            # Only change state if it's not already needing clarification by *this* check
-            # (it might already be NEED_CLARIFICATION due to execution)
-            if plan_run.state != PlanRunState.NEED_CLARIFICATION:
-                self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
-            else:
-                # Save the plan run even if state didn't change, to persist new clarifications
-                self.storage.save_plan_run(plan_run)
-        return new_clarifications_raised
+        return ready_clarifications
 
     @staticmethod
     def _log_models(config: Config) -> None:

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -340,8 +340,8 @@ class Portia:
 
         # If the readiness check resulted in needing clarification, return immediately
         if plan_run.state == PlanRunState.NEED_CLARIFICATION:
-           logger().debug("Returning plan run early due to readiness check clarifications.")
-           return plan_run
+            logger().debug("Returning plan run early due to readiness check clarifications.")
+            return plan_run
 
         # if the run has execution context associated, but none is set then use it
         if not is_execution_context_set():
@@ -993,6 +993,7 @@ class Portia:
 
         Returns:
             True if new clarifications were raised, False otherwise.
+
         """
         checked_tool_ids = set()
         new_clarifications_raised = False

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1027,9 +1027,7 @@ class Portia:
                     existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}  # pyright: ignore[reportUnhashable]
                     for clarification in ready_response.clarifications:
                         if clarification.id not in existing_clarification_ids:
-                            clarification.step = (
-                                step_index  # Assign step index for context, even if tool-level
-                            )
+                            clarification.step = None  # Update backend to return None for ready
                             plan_run.outputs.clarifications.append(clarification)
                             new_clarifications_raised = True
                             logger().info(

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -335,6 +335,65 @@ class Portia:
 
         plan = self.storage.get_plan(plan_id=plan_run.plan_id)
 
+        # Check ready status of all tools remaining in the plan
+        checked_tool_ids = set()
+        new_clarifications_raised = False
+        end_user = self.initialize_end_user(plan_run.end_user_id)
+        for step_index in range(plan_run.current_step_index, len(plan.steps)):
+            step = plan.steps[step_index]
+            if not step.tool_id or step.tool_id in checked_tool_ids:
+                continue
+
+            tool = self._get_tool_for_step(step, plan_run)
+            if not tool:
+                continue  # Should not happen if tool_id is set, but defensive check
+
+            checked_tool_ids.add(step.tool_id)
+            logger().debug(f"Checking readiness for tool: {tool.name} (ID: {step.tool_id})")
+            try:
+                ready_response = tool.ready(
+                    ToolRunContext(
+                        execution_context=plan_run.execution_context,
+                        end_user=end_user,
+                        plan_run_id=plan_run.id,
+                        config=self.config,
+                        clarifications=plan_run.get_clarifications_for_step(step_index),
+                    ),
+                )
+                if not ready_response.ready:
+                    existing_clarification_ids = {
+                        c.id for c in plan_run.outputs.clarifications
+                    }
+                    for clarification in ready_response.clarifications:
+                        if clarification.id not in existing_clarification_ids:
+                            clarification.step = (
+                                step_index  # Assign step index for context, even if tool-level
+                            )
+                            plan_run.outputs.clarifications.append(clarification)
+                            new_clarifications_raised = True
+                            logger().info(
+                                f"Tool '{tool.name}' raised clarification: "
+                                f"{clarification.user_guidance}"
+                            )
+            except Exception as e:  # noqa: BLE001
+                logger().warning(
+                    f"Error checking ready status for tool {tool.name} (ID: {step.tool_id}): {e}",
+                    exc_info=True,
+                )
+
+        if new_clarifications_raised:
+            # Only change state if it's not already needing clarification
+            if plan_run.state != PlanRunState.NEED_CLARIFICATION:
+                self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
+            else:
+                # Save the plan run even if state didn't change, to persist new clarifications
+                self.storage.save_plan_run(plan_run)
+
+        # If the readiness check resulted in needing clarification, return immediately
+        if plan_run.state == PlanRunState.NEED_CLARIFICATION:
+            logger().debug("Returning plan run early due to readiness check clarifications.")
+            return plan_run
+
         # if the run has execution context associated, but none is set then use it
         if not is_execution_context_set():
             with execution_context(plan_run.execution_context):
@@ -552,6 +611,7 @@ class Portia:
             execution_context=get_execution_context(),
             end_user_id=end_user.external_id,
         )
+        # Ensure the plan is saved before the plan run
         self.storage.save_plan_run(plan_run)
         return plan_run
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1018,13 +1018,13 @@ class Portia:
                         end_user=end_user,
                         plan_run_id=plan_run.id,
                         config=self.config,
-                        # Pass only clarifications relevant to this *specific* step/tool if available,
-                        # otherwise, pass none for the general readiness check.
+                        # Pass only clarifications relevant to this *specific* step/tool if
+                        # available, otherwise, pass none for the general readiness check.
                         clarifications=plan_run.get_clarifications_for_step(step_index),
                     ),
                 )
                 if not ready_response.ready:
-                    existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}
+                    existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}  # pyright: ignore[reportUnhashable]
                     for clarification in ready_response.clarifications:
                         if clarification.id not in existing_clarification_ids:
                             clarification.step = (

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -361,16 +361,25 @@ class Portia:
             plan_run.execution_context = get_execution_context()
             plan_run = self._execute_plan_run(plan, plan_run)
 
-            self._handle_clarifications(plan_run)
+            if not self._handle_clarifications(plan_run):
+                return plan_run
 
         return plan_run
 
-    def _handle_clarifications(self, plan_run: PlanRun) -> None:
-        """Handle any clarifications that are raised during the execution of a plan run."""
+    def _handle_clarifications(self, plan_run: PlanRun) -> bool:
+        """Handle any clarifications that are raised during the execution of a plan run.
+
+        Args:
+            plan_run (PlanRun): The plan run to handle clarifications for.
+
+        Returns:
+            bool: True if clarifications could not be handled in-band and run execution should stop.
+
+        """
         # If we don't have a clarification handler, return the plan run even if a clarification
         # has been raised
         if not self.execution_hooks.clarification_handler:
-            return
+            return False
 
         clarifications = plan_run.get_outstanding_clarifications()
         for clarification in clarifications:
@@ -384,7 +393,7 @@ class Portia:
             # If clarifications are handled synchronously, we'll go through this immediately.
             # If they're handled asynchronously, we'll wait for the plan run to be ready.
             plan_run = self.wait_for_ready(plan_run)
-        return
+        return len(plan_run.get_outstanding_clarifications()) == 0
 
     def resolve_clarification(
         self,

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -335,64 +335,13 @@ class Portia:
 
         plan = self.storage.get_plan(plan_id=plan_run.plan_id)
 
-        # Check ready status of all tools remaining in the plan
-        checked_tool_ids = set()
-        new_clarifications_raised = False
-        end_user = self.initialize_end_user(plan_run.end_user_id)
-        for step_index in range(plan_run.current_step_index, len(plan.steps)):
-            step = plan.steps[step_index]
-            if not step.tool_id or step.tool_id in checked_tool_ids:
-                continue
-
-            tool = self._get_tool_for_step(step, plan_run)
-            if not tool:
-                continue  # Should not happen if tool_id is set, but defensive check
-
-            checked_tool_ids.add(step.tool_id)
-            logger().debug(f"Checking readiness for tool: {tool.name} (ID: {step.tool_id})")
-            try:
-                ready_response = tool.ready(
-                    ToolRunContext(
-                        execution_context=plan_run.execution_context,
-                        end_user=end_user,
-                        plan_run_id=plan_run.id,
-                        config=self.config,
-                        clarifications=plan_run.get_clarifications_for_step(step_index),
-                    ),
-                )
-                if not ready_response.ready:
-                    existing_clarification_ids = {
-                        c.id for c in plan_run.outputs.clarifications
-                    }
-                    for clarification in ready_response.clarifications:
-                        if clarification.id not in existing_clarification_ids:
-                            clarification.step = (
-                                step_index  # Assign step index for context, even if tool-level
-                            )
-                            plan_run.outputs.clarifications.append(clarification)
-                            new_clarifications_raised = True
-                            logger().info(
-                                f"Tool '{tool.name}' raised clarification: "
-                                f"{clarification.user_guidance}"
-                            )
-            except Exception as e:  # noqa: BLE001
-                logger().warning(
-                    f"Error checking ready status for tool {tool.name} (ID: {step.tool_id}): {e}",
-                    exc_info=True,
-                )
-
-        if new_clarifications_raised:
-            # Only change state if it's not already needing clarification
-            if plan_run.state != PlanRunState.NEED_CLARIFICATION:
-                self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
-            else:
-                # Save the plan run even if state didn't change, to persist new clarifications
-                self.storage.save_plan_run(plan_run)
+        # Perform initial readiness check
+        self._check_remaining_tool_readiness(plan, plan_run)
 
         # If the readiness check resulted in needing clarification, return immediately
         if plan_run.state == PlanRunState.NEED_CLARIFICATION:
-            logger().debug("Returning plan run early due to readiness check clarifications.")
-            return plan_run
+           logger().debug("Returning plan run early due to readiness check clarifications.")
+           return plan_run
 
         # if the run has execution context associated, but none is set then use it
         if not is_execution_context_set():
@@ -704,6 +653,13 @@ class Portia:
                 )
 
             if self._raise_clarifications(plan_run, last_executed_step_output, plan):
+                # If execution raised a clarification, re-check readiness of subsequent tools
+                logger().debug(
+                    "Re-checking tool readiness after execution clarification.",
+                    plan=str(plan.id),
+                    plan_run=str(plan_run.id),
+                )
+                self._check_remaining_tool_readiness(plan, plan_run, start_index=index + 1)
                 return plan_run
 
             # persist at the end of each step
@@ -1020,6 +976,80 @@ class Portia:
             plan_run.outputs.step_outputs[step.output] = step_output
 
         self.storage.save_plan_run(plan_run)
+
+    def _check_remaining_tool_readiness(
+        self,
+        plan: Plan,
+        plan_run: PlanRun,
+        start_index: int | None = None,
+    ) -> bool:
+        """Check the ready status of tools in remaining steps and update plan_run if needed.
+
+        Args:
+            plan: The plan containing the steps.
+            plan_run: The current plan run.
+            start_index: The step index to start checking from. Defaults to the plan run's
+                current step index.
+
+        Returns:
+            True if new clarifications were raised, False otherwise.
+        """
+        checked_tool_ids = set()
+        new_clarifications_raised = False
+        check_from_index = start_index if start_index is not None else plan_run.current_step_index
+        end_user = self.initialize_end_user(plan_run.end_user_id)
+
+        for step_index in range(check_from_index, len(plan.steps)):
+            step = plan.steps[step_index]
+            if not step.tool_id or step.tool_id in checked_tool_ids:
+                continue
+
+            tool = self._get_tool_for_step(step, plan_run)
+            if not tool:
+                continue  # Should not happen if tool_id is set, but defensive check
+
+            checked_tool_ids.add(step.tool_id)
+            logger().debug(f"Checking readiness for tool: {tool.name} (ID: {step.tool_id})")
+            try:
+                ready_response = tool.ready(
+                    ToolRunContext(
+                        execution_context=plan_run.execution_context,
+                        end_user=end_user,
+                        plan_run_id=plan_run.id,
+                        config=self.config,
+                        # Pass only clarifications relevant to this *specific* step/tool if available,
+                        # otherwise, pass none for the general readiness check.
+                        clarifications=plan_run.get_clarifications_for_step(step_index),
+                    ),
+                )
+                if not ready_response.ready:
+                    existing_clarification_ids = {c.id for c in plan_run.outputs.clarifications}
+                    for clarification in ready_response.clarifications:
+                        if clarification.id not in existing_clarification_ids:
+                            clarification.step = (
+                                step_index  # Assign step index for context, even if tool-level
+                            )
+                            plan_run.outputs.clarifications.append(clarification)
+                            new_clarifications_raised = True
+                            logger().info(
+                                f"Tool '{tool.name}' raised clarification: "
+                                f"{clarification.user_guidance}"
+                            )
+            except Exception as e:  # noqa: BLE001
+                logger().warning(
+                    f"Error checking ready status for tool {tool.name} (ID: {step.tool_id}): {e}",
+                    exc_info=True,
+                )
+
+        if new_clarifications_raised:
+            # Only change state if it's not already needing clarification by *this* check
+            # (it might already be NEED_CLARIFICATION due to execution)
+            if plan_run.state != PlanRunState.NEED_CLARIFICATION:
+                self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
+            else:
+                # Save the plan run even if state didn't change, to persist new clarifications
+                self.storage.save_plan_run(plan_run)
+        return new_clarifications_raised
 
     @staticmethod
     def _log_models(config: Config) -> None:

--- a/tests/unit/execution_agents/test_default_execution_agent.py
+++ b/tests/unit/execution_agents/test_default_execution_agent.py
@@ -348,17 +348,17 @@ def test_verifier_model_schema_validation() -> None:
 
     required_field1 = next(arg for arg in result_inputs.args if arg.name == "required_field1")
     required_field2 = next(arg for arg in result_inputs.args if arg.name == "required_field2")
-    assert required_field1.schema_invalid, (
-        "required_field1 should be marked as missing when validation fails"
-    )
-    assert required_field2.schema_invalid, (
-        "required_field2 should be marked as missing when validation fails"
-    )
+    assert (
+        required_field1.schema_invalid
+    ), "required_field1 should be marked as missing when validation fails"
+    assert (
+        required_field2.schema_invalid
+    ), "required_field2 should be marked as missing when validation fails"
 
     optional_field = next(arg for arg in result_inputs.args if arg.name == "optional_field")
-    assert not optional_field.schema_invalid, (
-        "optional_field should not be marked as missing when validation fails"
-    )
+    assert (
+        not optional_field.schema_invalid
+    ), "optional_field should not be marked as missing when validation fails"
 
 
 def test_tool_calling_model_no_hallucinations() -> None:

--- a/tests/unit/test_portia_auth_forward.py
+++ b/tests/unit/test_portia_auth_forward.py
@@ -1,4 +1,5 @@
 """Tests for pull auth forward changes."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -35,7 +36,8 @@ class ReadyTool(Tool):
         is_ready = (
             self.is_ready
             if isinstance(self.is_ready, bool)
-            else self.is_ready.pop(0) if isinstance(self.is_ready, list) and len(self.is_ready) > 0
+            else self.is_ready.pop(0)
+            if isinstance(self.is_ready, list) and len(self.is_ready) > 0
             else False
         )
         if is_ready:

--- a/tests/unit/test_portia_auth_forward.py
+++ b/tests/unit/test_portia_auth_forward.py
@@ -1,4 +1,7 @@
 """Tests for pull auth forward changes."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, HttpUrl
 
@@ -8,9 +11,11 @@ from portia.execution_agents.output import LocalOutput, Output
 from portia.plan import PlanBuilder, Step
 from portia.plan_run import PlanRun, PlanRunState
 from portia.portia import Portia
-from portia.prefixed_uuid import PlanRunUUID
 from portia.tool import ReadyResponse, Tool, ToolRunContext, _ArgsSchemaPlaceholder
 from tests.utils import get_test_config
+
+if TYPE_CHECKING:
+    from portia.prefixed_uuid import PlanRunUUID
 
 
 class ReadyTool(Tool):
@@ -22,12 +27,18 @@ class ReadyTool(Tool):
     args_schema: type[BaseModel] = _ArgsSchemaPlaceholder
     output_schema: tuple[str, str] = ("ReadyResponse", "A response from the tool")
 
-    is_ready: bool = False
+    is_ready: bool | list[bool] = False
     auth_url: str = "https://fake.portiaai.test/auth"
 
     def _get_clarifications(self, plan_run_id: PlanRunUUID) -> list[Clarification]:
         """Generate clarifications for the ready check."""
-        if self.is_ready:
+        is_ready = (
+            self.is_ready
+            if isinstance(self.is_ready, bool)
+            else self.is_ready.pop(0) if isinstance(self.is_ready, list) and len(self.is_ready) > 0
+            else False
+        )
+        if is_ready:
             return []
         return [  # pyright: ignore[reportReturnType]
             ActionClarification(
@@ -147,14 +158,13 @@ class CustomPortia(Portia):
 
 def test_tool_raise_clarification_all_remaining_tool_ready_status_rechecked() -> None:
     """Test that all remaining steps have their tool ready status checked on any interruption."""
-    ready_tool = ReadyTool()
-    is_ready_tool = ReadyTool(id="is_ready_tool", is_ready=True)
-
-    portia = CustomPortia(config=get_test_config(), tools=[ready_tool, is_ready_tool])
+    ready_tool = ReadyTool(is_ready=True)
+    ready_once_tool = ReadyTool(id="ready_once_tool", is_ready=[True, False])
+    portia = CustomPortia(config=get_test_config(), tools=[ready_tool, ready_once_tool])
     plan = (
         PlanBuilder()
-        .step("raise_clarification", is_ready_tool.id)
         .step("raise_clarification", ready_tool.id)
+        .step("2", ready_once_tool.id)
         .build()
     )
     plan_run = portia.create_plan_run(plan, end_user="123")

--- a/tests/unit/test_portia_auth_forward.py
+++ b/tests/unit/test_portia_auth_forward.py
@@ -56,6 +56,7 @@ def test_portia_resume_tool_requires_clarification() -> None:
     portia = Portia(config=get_test_config(), tools=[ready_tool])
     plan = PlanBuilder().step("", ready_tool.id).build()
     plan_run = portia.create_plan_run(plan, end_user="123")
+    portia.storage.save_plan(plan)  # Explicitly save plan for test
 
     output_plan_run = portia.resume(plan_run)
     assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
@@ -64,7 +65,7 @@ def test_portia_resume_tool_requires_clarification() -> None:
     assert isinstance(outstanding_clarification, ActionClarification)
     assert outstanding_clarification.resolved is False
     assert outstanding_clarification.plan_run_id == plan_run.id
-    assert outstanding_clarification.action_url == "https://fake.portiaai.test/auth"
+    assert str(outstanding_clarification.action_url) == "https://fake.portiaai.test/auth"
 
 
 def test_portia_resume_multiple_instances_of_same_tool() -> None:
@@ -76,6 +77,7 @@ def test_portia_resume_multiple_instances_of_same_tool() -> None:
     portia = Portia(config=get_test_config(), tools=[ready_tool, ready_tool])
     plan = PlanBuilder().step("1", ready_tool.id).step("2", ready_tool.id).build()
     plan_run = portia.create_plan_run(plan, end_user="123")
+    portia.storage.save_plan(plan)  # Explicitly save plan for test
 
     output_plan_run = portia.resume(plan_run)
     assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
@@ -84,7 +86,7 @@ def test_portia_resume_multiple_instances_of_same_tool() -> None:
     assert isinstance(outstanding_clarification, ActionClarification)
     assert outstanding_clarification.resolved is False
     assert outstanding_clarification.plan_run_id == plan_run.id
-    assert outstanding_clarification.action_url == "https://fake.portiaai.test/auth"
+    assert str(outstanding_clarification.action_url) == "https://fake.portiaai.test/auth"
 
 
 def test_portia_resume_multiple_tools_require_clarification() -> None:
@@ -94,6 +96,7 @@ def test_portia_resume_multiple_tools_require_clarification() -> None:
     portia = Portia(config=get_test_config(), tools=[ready_tool, ready_tool_2])
     plan = PlanBuilder().step("1", ready_tool.id).step("2", ready_tool_2.id).build()
     plan_run = portia.create_plan_run(plan, end_user="123")
+    portia.storage.save_plan(plan)  # Explicitly save plan for test
 
     output_plan_run = portia.resume(plan_run)
     assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
@@ -101,11 +104,11 @@ def test_portia_resume_multiple_tools_require_clarification() -> None:
     outstanding_clarifications = output_plan_run.get_outstanding_clarifications()
     assert isinstance(outstanding_clarifications[0], ActionClarification)
     assert outstanding_clarifications[0].plan_run_id == plan_run.id
-    assert outstanding_clarifications[0].action_url == "https://fake.portiaai.test/auth"
+    assert str(outstanding_clarifications[0].action_url) == "https://fake.portiaai.test/auth"
     assert outstanding_clarifications[0].resolved is False
     assert isinstance(outstanding_clarifications[1], ActionClarification)
     assert outstanding_clarifications[1].plan_run_id == plan_run.id
-    assert outstanding_clarifications[1].action_url == "https://fake.portiaai.test/auth2"
+    assert str(outstanding_clarifications[1].action_url) == "https://fake.portiaai.test/auth2"
     assert outstanding_clarifications[1].resolved is False
 
 
@@ -155,6 +158,7 @@ def test_tool_raise_clarification_all_remaining_tool_ready_status_rechecked() ->
         .build()
     )
     plan_run = portia.create_plan_run(plan, end_user="123")
+    portia.storage.save_plan(plan)  # Explicitly save plan for test
 
     output_plan_run = portia.resume(plan_run)
     assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
@@ -166,5 +170,5 @@ def test_tool_raise_clarification_all_remaining_tool_ready_status_rechecked() ->
     assert outstanding_clarifications[0].resolved is False
     assert isinstance(outstanding_clarifications[1], ActionClarification)
     assert outstanding_clarifications[1].plan_run_id == plan_run.id
-    assert outstanding_clarifications[1].action_url == ready_tool.auth_url
+    assert str(outstanding_clarifications[1].action_url) == ready_tool.auth_url
     assert outstanding_clarifications[1].resolved is False

--- a/tests/unit/test_portia_auth_forward.py
+++ b/tests/unit/test_portia_auth_forward.py
@@ -1,0 +1,170 @@
+"""Tests for pull auth forward changes."""
+
+from pydantic import BaseModel, HttpUrl
+
+from portia.clarification import ActionClarification, Clarification, InputClarification
+from portia.execution_agents.base_execution_agent import BaseExecutionAgent
+from portia.execution_agents.output import LocalOutput, Output
+from portia.plan import PlanBuilder, Step
+from portia.plan_run import PlanRun, PlanRunState
+from portia.portia import Portia
+from portia.prefixed_uuid import PlanRunUUID
+from portia.tool import ReadyResponse, Tool, ToolRunContext, _ArgsSchemaPlaceholder
+from tests.utils import get_test_config
+
+
+class ReadyTool(Tool):
+    """A tool that can be set to ready or not ready."""
+
+    id: str = "ready_tool"
+    name: str = "Ready Tool"
+    description: str = "A tool that can be set to ready or not ready."
+    args_schema: type[BaseModel] = _ArgsSchemaPlaceholder
+    output_schema: tuple[str, str] = ("ReadyResponse", "A response from the tool")
+
+    is_ready: bool = False
+    auth_url: str = "https://fake.portiaai.test/auth"
+
+    def _get_clarifications(self, plan_run_id: PlanRunUUID) -> list[Clarification]:
+        """Generate clarifications for the ready check."""
+        if self.is_ready:
+            return []
+        return [  # pyright: ignore[reportReturnType]
+            ActionClarification(
+                user_guidance="user guidance",
+                plan_run_id=plan_run_id,
+                action_url=HttpUrl(self.auth_url),
+            )
+        ]
+
+    def ready(self, ctx: ToolRunContext) -> ReadyResponse:
+        """Is the tool ready."""
+        clarifications = self._get_clarifications(ctx.plan_run_id)
+        return ReadyResponse(
+            ready=len(clarifications) == 0,
+            clarifications=clarifications,
+        )
+
+    def run(self, ctx: ToolRunContext) -> None:  # noqa: ARG002
+        """Run the tool."""
+        return
+
+
+def test_portia_resume_tool_requires_clarification() -> None:
+    """Test that a tool that requires clarification gets raised at start of plan run."""
+    ready_tool = ReadyTool()
+    portia = Portia(config=get_test_config(), tools=[ready_tool])
+    plan = PlanBuilder().step("", ready_tool.id).build()
+    plan_run = portia.create_plan_run(plan, end_user="123")
+
+    output_plan_run = portia.resume(plan_run)
+    assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
+    assert len(output_plan_run.get_outstanding_clarifications()) == 1
+    outstanding_clarification = output_plan_run.get_outstanding_clarifications()[0]
+    assert isinstance(outstanding_clarification, ActionClarification)
+    assert outstanding_clarification.resolved is False
+    assert outstanding_clarification.plan_run_id == plan_run.id
+    assert outstanding_clarification.action_url == "https://fake.portiaai.test/auth"
+
+
+def test_portia_resume_multiple_instances_of_same_tool() -> None:
+    """Test clarification handling for multiple instances of the same tool.
+
+    Only one clarification should be raised for the tool.
+    """
+    ready_tool = ReadyTool()
+    portia = Portia(config=get_test_config(), tools=[ready_tool, ready_tool])
+    plan = PlanBuilder().step("1", ready_tool.id).step("2", ready_tool.id).build()
+    plan_run = portia.create_plan_run(plan, end_user="123")
+
+    output_plan_run = portia.resume(plan_run)
+    assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
+    assert len(output_plan_run.get_outstanding_clarifications()) == 1
+    outstanding_clarification = output_plan_run.get_outstanding_clarifications()[0]
+    assert isinstance(outstanding_clarification, ActionClarification)
+    assert outstanding_clarification.resolved is False
+    assert outstanding_clarification.plan_run_id == plan_run.id
+    assert outstanding_clarification.action_url == "https://fake.portiaai.test/auth"
+
+
+def test_portia_resume_multiple_tools_require_clarification() -> None:
+    """Test clarifications are raised for multiple tools in a plan run if they require it."""
+    ready_tool = ReadyTool(auth_url="https://fake.portiaai.test/auth")
+    ready_tool_2 = ReadyTool(id="ready_tool_2", auth_url="https://fake.portiaai.test/auth2")
+    portia = Portia(config=get_test_config(), tools=[ready_tool, ready_tool_2])
+    plan = PlanBuilder().step("1", ready_tool.id).step("2", ready_tool_2.id).build()
+    plan_run = portia.create_plan_run(plan, end_user="123")
+
+    output_plan_run = portia.resume(plan_run)
+    assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
+    assert len(output_plan_run.get_outstanding_clarifications()) == 2
+    outstanding_clarifications = output_plan_run.get_outstanding_clarifications()
+    assert isinstance(outstanding_clarifications[0], ActionClarification)
+    assert outstanding_clarifications[0].plan_run_id == plan_run.id
+    assert outstanding_clarifications[0].action_url == "https://fake.portiaai.test/auth"
+    assert outstanding_clarifications[0].resolved is False
+    assert isinstance(outstanding_clarifications[1], ActionClarification)
+    assert outstanding_clarifications[1].plan_run_id == plan_run.id
+    assert outstanding_clarifications[1].action_url == "https://fake.portiaai.test/auth2"
+    assert outstanding_clarifications[1].resolved is False
+
+
+class RaiseClarificationAgent(BaseExecutionAgent):
+    """A dummy execution agent that raises a clarification on run."""
+
+    def execute_sync(self) -> Output:
+        """Execute the agent - return a clarification."""
+        return LocalOutput(
+            value=[
+                InputClarification(
+                    user_guidance="user guidance",
+                    plan_run_id=self.plan_run.id,
+                    argument_name="argument_name",
+                )
+            ]
+        )
+
+
+class CustomPortia(Portia):
+    """A custom portia that uses a custom execution agent."""
+
+    def _get_agent_for_step(self, step: Step, plan_run: PlanRun) -> BaseExecutionAgent:
+        if step.task == "raise_clarification":
+            tool = self._get_tool_for_step(step, plan_run)
+            return RaiseClarificationAgent(
+                step=step,
+                plan_run=plan_run,
+                config=self.config,
+                end_user=self.initialize_end_user(plan_run.end_user_id),
+                agent_memory=self.storage,
+                tool=tool,
+            )
+        return super()._get_agent_for_step(step, plan_run)
+
+
+def test_tool_raise_clarification_all_remaining_tool_ready_status_rechecked() -> None:
+    """Test that all remaining steps have their tool ready status checked on any interruption."""
+    ready_tool = ReadyTool()
+    is_ready_tool = ReadyTool(id="is_ready_tool", is_ready=True)
+
+    portia = CustomPortia(config=get_test_config(), tools=[ready_tool, is_ready_tool])
+    plan = (
+        PlanBuilder()
+        .step("raise_clarification", is_ready_tool.id)
+        .step("raise_clarification", ready_tool.id)
+        .build()
+    )
+    plan_run = portia.create_plan_run(plan, end_user="123")
+
+    output_plan_run = portia.resume(plan_run)
+    assert output_plan_run.state == PlanRunState.NEED_CLARIFICATION
+    assert len(output_plan_run.get_outstanding_clarifications()) == 2
+    outstanding_clarifications = output_plan_run.get_outstanding_clarifications()
+    assert isinstance(outstanding_clarifications[0], InputClarification)
+    assert outstanding_clarifications[0].plan_run_id == plan_run.id
+    assert outstanding_clarifications[0].argument_name == "argument_name"
+    assert outstanding_clarifications[0].resolved is False
+    assert isinstance(outstanding_clarifications[1], ActionClarification)
+    assert outstanding_clarifications[1].plan_run_id == plan_run.id
+    assert outstanding_clarifications[1].action_url == ready_tool.auth_url
+    assert outstanding_clarifications[1].resolved is False


### PR DESCRIPTION
# Description

The goal is to check for any clarifications we can possibly detect and raise all of them as early as possible to avoid repeated interruptions to the flow.

Currently, the only type of clarification that can be detected ahead of time is tool-readiness (i.e. Auth).

More specifically it will now:
* Check all remaining steps for tool ready status and raise all resulting clarifications up-front (start of `resume`)
* Check all remaining steps for tool ready status after a clarification is raised from a task for any other reason

Ticket Link: https://linear.app/portialabs/issue/POR-1231/pull-the-portia-cloud-tool-auth-forward-to-before-planruns-execute

> [!WARNING]
> Need to think carefully about the release of this change as it currently depends on the platform being released first (with the update to the ready endpoint - [PR](https://github.com/portiaAI/platform/pull/410))
> GIven the platform prod release currently is dependent on already-merged SDK changes, it doesnt seem a good idea to create a bi-directional dependency.
> For that reason, the simplest thing would be to wait until after the next prod release for this PR to get merged.

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [x] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
