### PR TITLE
Add execution hooks for tool calls

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -90,39 +90,34 @@ class ExecutionHooks:
 
     Hooks include:
     - clarification_handler: Used to handle clarifications that arise during the run of a plan.
-    - before_first_tool_call: Called before the first tool call in a plan run.
-    - before_tool_call: Called before each tool call.
-    - after_tool_call: Called after each tool call.
-    - after_last_tool_call: Called after the last tool call in a plan run.
+    - before_first_step: Called before the first step in a plan run.
+    - before_step: Called before each step.
+    - after_step: Called after each step.
+    - after_last_step: Called after the last step in a plan run.
     """
 
     def __init__(
         self,
         clarification_handler: ClarificationHandler | None = None,
-        before_first_tool_call: Callable | None = None,
-        before_tool_call: Callable | None = None,
-        after_tool_call: Callable | None = None,
-        after_last_tool_call: Callable | None = None,
+        before_first_step: Callable[[Plan, PlanRun], None] | None = None,
+        before_step: Callable[[Plan, PlanRun, Step], None] | None = None,
+        after_step: Callable[[Plan, PlanRun, Step, Output], None] | None = None,
+        after_last_step: Callable[[Plan, PlanRun], None] | None = None,
     ) -> None:
         """Initialize ExecutionHooks with default values.
 
         Args:
-            clarification_handler (ClarificationHandler | None): Handler for clarifications.
-            before_first_tool_call (Callable | None): Hook called before the first tool call
-                in a plan run. Function signature: (plan: Plan, plan_run: PlanRun) -> None
-            before_tool_call (Callable | None): Hook called before each tool call.
-                Function signature: (plan: Plan, plan_run: PlanRun, step: Step) -> None
-            after_tool_call (Callable | None): Hook called after each tool call.
-                Function signature: (plan: Plan, plan_run: PlanRun, step: Step, output) -> None
-            after_last_tool_call (Callable | None): Hook called after the last tool call
-                in a plan run. Function signature: (plan: Plan, plan_run: PlanRun) -> None
-
+            clarification_handler: Handler for clarifications.
+            before_first_step: Hook called before the first step in a plan run.
+            before_step: Hook called before each step.
+            after_step: Hook called after each step.
+            after_last_step: Hook called after the last step in a plan run.
         """
         self.clarification_handler = clarification_handler
-        self.before_first_tool_call = before_first_tool_call
-        self.before_tool_call = before_tool_call
-        self.after_tool_call = after_tool_call
-        self.after_last_tool_call = after_last_tool_call
+        self.before_first_step = before_first_step
+        self.before_step = before_step
+        self.after_step = after_step
+        self.after_last_step = after_last_step
 
 
 class Portia:
@@ -585,7 +580,7 @@ class Portia:
         self.storage.save_plan_run(plan_run)
         return plan_run
 
-    def _execute_plan_run(self, plan: Plan, plan_run: PlanRun) -> PlanRun:  # noqa: C901
+    def _execute_plan_run(self, plan: Plan, plan_run: PlanRun) -> PlanRun:
         """Execute the run steps, updating the run state as needed.
 
         Args:
@@ -613,9 +608,9 @@ class Portia:
             f"Plan Run State is updated to {plan_run.state!s}.{dashboard_message}",
         )
 
-        # Call the before_first_tool_call hook if it exists
-        if self.execution_hooks.before_first_tool_call:
-            self.execution_hooks.before_first_tool_call(plan, plan_run)
+        # Call the before_first_step hook if it exists
+        if self.execution_hooks.before_first_step:
+            self.execution_hooks.before_first_step(plan, plan_run)
 
         last_executed_step_output = self._get_last_executed_step_output(plan, plan_run)
         introspection_agent = self._get_introspection_agent()
@@ -642,9 +637,9 @@ class Portia:
                 plan_run=str(plan_run.id),
             )
 
-            # Call the before_tool_call hook if it exists
-            if self.execution_hooks.before_tool_call:
-                self.execution_hooks.before_tool_call(plan, plan_run, step)
+            # Call the before_step hook if it exists
+            if self.execution_hooks.before_step:
+                self.execution_hooks.before_step(plan, plan_run, step)
 
             # we pass read only copies of the state to the agent so that the portia remains
             # responsible for handling the output of the agent and updating the state.
@@ -682,9 +677,9 @@ class Portia:
                     f"Step output - {last_executed_step_output.get_summary()!s}",
                 )
 
-                # Call the after_tool_call hook if it exists
-                if self.execution_hooks.after_tool_call:
-                    self.execution_hooks.after_tool_call(
+                # Call the after_step hook if it exists
+                if self.execution_hooks.after_step:
+                    self.execution_hooks.after_step(
                         plan, plan_run, step, last_executed_step_output
                     )
 
@@ -704,9 +699,9 @@ class Portia:
                 last_executed_step_output,
             )
 
-        # Call the after_last_tool_call hook if it exists
-        if self.execution_hooks.after_last_tool_call:
-            self.execution_hooks.after_last_tool_call(plan, plan_run)
+        # Call the after_last_step hook if it exists
+        if self.execution_hooks.after_last_step:
+            self.execution_hooks.after_last_step(plan, plan_run)
 
         self._set_plan_run_state(plan_run, PlanRunState.COMPLETE)
         self._log_final_output(plan_run, plan)

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -585,7 +585,7 @@ class Portia:
         self.storage.save_plan_run(plan_run)
         return plan_run
 
-    def _execute_plan_run(self, plan: Plan, plan_run: PlanRun) -> PlanRun:
+    def _execute_plan_run(self, plan: Plan, plan_run: PlanRun) -> PlanRun:  # noqa: C901
         """Execute the run steps, updating the run state as needed.
 
         Args:

--- a/tests/unit/test_execution_hooks.py
+++ b/tests/unit/test_execution_hooks.py
@@ -7,60 +7,51 @@ from portia.portia import ExecutionHooks
 
 def test_execution_hooks_initialization() -> None:
     """Test that the ExecutionHooks class can be initialized with all hooks."""
-    # Create mock hooks
     clarification_handler_mock = MagicMock()
-    before_first_tool_call_mock = MagicMock()
-    before_tool_call_mock = MagicMock()
-    after_tool_call_mock = MagicMock()
-    after_last_tool_call_mock = MagicMock()
+    before_first_step_mock = MagicMock()
+    before_step_mock = MagicMock()
+    after_step_mock = MagicMock()
+    after_last_step_mock = MagicMock()
 
-    # Create execution hooks with all mocks
     execution_hooks = ExecutionHooks(
         clarification_handler=clarification_handler_mock,
-        before_first_tool_call=before_first_tool_call_mock,
-        before_tool_call=before_tool_call_mock,
-        after_tool_call=after_tool_call_mock,
-        after_last_tool_call=after_last_tool_call_mock,
+        before_first_step=before_first_step_mock,
+        before_step=before_step_mock,
+        after_step=after_step_mock,
+        after_last_step=after_last_step_mock,
     )
 
-    # Assert that all hooks are set correctly
     assert execution_hooks.clarification_handler == clarification_handler_mock
-    assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
-    assert execution_hooks.before_tool_call == before_tool_call_mock
-    assert execution_hooks.after_tool_call == after_tool_call_mock
-    assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
+    assert execution_hooks.before_first_step == before_first_step_mock
+    assert execution_hooks.before_step == before_step_mock
+    assert execution_hooks.after_step == after_step_mock
+    assert execution_hooks.after_last_step == after_last_step_mock
 
 
 def test_execution_hooks_default_values() -> None:
     """Test that the ExecutionHooks class initializes with default values."""
-    # Create execution hooks with no arguments
     execution_hooks = ExecutionHooks()
 
-    # Assert that all hooks are None by default
     assert execution_hooks.clarification_handler is None
-    assert execution_hooks.before_first_tool_call is None
-    assert execution_hooks.before_tool_call is None
-    assert execution_hooks.after_tool_call is None
-    assert execution_hooks.after_last_tool_call is None
+    assert execution_hooks.before_first_step is None
+    assert execution_hooks.before_step is None
+    assert execution_hooks.after_step is None
+    assert execution_hooks.after_last_step is None
 
 
 def test_execution_hooks_partial_initialization() -> None:
     """Test that the ExecutionHooks class can be initialized with some hooks."""
-    # Create mock hooks
-    before_first_tool_call_mock = MagicMock()
-    after_last_tool_call_mock = MagicMock()
+    before_first_step_mock = MagicMock()
+    after_last_step_mock = MagicMock()
 
-    # Create execution hooks with some mocks
     execution_hooks = ExecutionHooks(
-        before_first_tool_call=before_first_tool_call_mock,
-        after_last_tool_call=after_last_tool_call_mock,
+        before_first_step=before_first_step_mock,
+        after_last_step=after_last_step_mock,
     )
 
-    # Assert that specified hooks are set correctly
-    assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
-    assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
+    assert execution_hooks.before_first_step == before_first_step_mock
+    assert execution_hooks.after_last_step == after_last_step_mock
 
-    # Assert that unspecified hooks are None
     assert execution_hooks.clarification_handler is None
-    assert execution_hooks.before_tool_call is None
-    assert execution_hooks.after_tool_call is None
+    assert execution_hooks.before_step is None
+    assert execution_hooks.after_step is None

--- a/tests/unit/test_execution_hooks.py
+++ b/tests/unit/test_execution_hooks.py
@@ -1,0 +1,67 @@
+"""Tests for execution hooks."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from portia.portia import ExecutionHooks
+
+
+def test_execution_hooks_initialization():
+    """Test that the ExecutionHooks class can be initialized with all hooks."""
+    # Create mock hooks
+    clarification_handler_mock = MagicMock()
+    before_first_tool_call_mock = MagicMock()
+    before_tool_call_mock = MagicMock()
+    after_tool_call_mock = MagicMock()
+    after_last_tool_call_mock = MagicMock()
+    
+    # Create execution hooks with all mocks
+    execution_hooks = ExecutionHooks(
+        clarification_handler=clarification_handler_mock,
+        before_first_tool_call=before_first_tool_call_mock,
+        before_tool_call=before_tool_call_mock,
+        after_tool_call=after_tool_call_mock,
+        after_last_tool_call=after_last_tool_call_mock,
+    )
+    
+    # Assert that all hooks are set correctly
+    assert execution_hooks.clarification_handler == clarification_handler_mock
+    assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
+    assert execution_hooks.before_tool_call == before_tool_call_mock
+    assert execution_hooks.after_tool_call == after_tool_call_mock
+    assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
+
+
+def test_execution_hooks_default_values():
+    """Test that the ExecutionHooks class initializes with default values."""
+    # Create execution hooks with no arguments
+    execution_hooks = ExecutionHooks()
+    
+    # Assert that all hooks are None by default
+    assert execution_hooks.clarification_handler is None
+    assert execution_hooks.before_first_tool_call is None
+    assert execution_hooks.before_tool_call is None
+    assert execution_hooks.after_tool_call is None
+    assert execution_hooks.after_last_tool_call is None
+
+
+def test_execution_hooks_partial_initialization():
+    """Test that the ExecutionHooks class can be initialized with some hooks."""
+    # Create mock hooks
+    before_first_tool_call_mock = MagicMock()
+    after_last_tool_call_mock = MagicMock()
+    
+    # Create execution hooks with some mocks
+    execution_hooks = ExecutionHooks(
+        before_first_tool_call=before_first_tool_call_mock,
+        after_last_tool_call=after_last_tool_call_mock,
+    )
+    
+    # Assert that specified hooks are set correctly
+    assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
+    assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
+    
+    # Assert that unspecified hooks are None
+    assert execution_hooks.clarification_handler is None
+    assert execution_hooks.before_tool_call is None
+    assert execution_hooks.after_tool_call is None

--- a/tests/unit/test_execution_hooks.py
+++ b/tests/unit/test_execution_hooks.py
@@ -1,12 +1,11 @@
 """Tests for execution hooks."""
 
-import pytest
 from unittest.mock import MagicMock
 
 from portia.portia import ExecutionHooks
 
 
-def test_execution_hooks_initialization():
+def test_execution_hooks_initialization() -> None:
     """Test that the ExecutionHooks class can be initialized with all hooks."""
     # Create mock hooks
     clarification_handler_mock = MagicMock()
@@ -14,7 +13,7 @@ def test_execution_hooks_initialization():
     before_tool_call_mock = MagicMock()
     after_tool_call_mock = MagicMock()
     after_last_tool_call_mock = MagicMock()
-    
+
     # Create execution hooks with all mocks
     execution_hooks = ExecutionHooks(
         clarification_handler=clarification_handler_mock,
@@ -23,7 +22,7 @@ def test_execution_hooks_initialization():
         after_tool_call=after_tool_call_mock,
         after_last_tool_call=after_last_tool_call_mock,
     )
-    
+
     # Assert that all hooks are set correctly
     assert execution_hooks.clarification_handler == clarification_handler_mock
     assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
@@ -32,11 +31,11 @@ def test_execution_hooks_initialization():
     assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
 
 
-def test_execution_hooks_default_values():
+def test_execution_hooks_default_values() -> None:
     """Test that the ExecutionHooks class initializes with default values."""
     # Create execution hooks with no arguments
     execution_hooks = ExecutionHooks()
-    
+
     # Assert that all hooks are None by default
     assert execution_hooks.clarification_handler is None
     assert execution_hooks.before_first_tool_call is None
@@ -45,22 +44,22 @@ def test_execution_hooks_default_values():
     assert execution_hooks.after_last_tool_call is None
 
 
-def test_execution_hooks_partial_initialization():
+def test_execution_hooks_partial_initialization() -> None:
     """Test that the ExecutionHooks class can be initialized with some hooks."""
     # Create mock hooks
     before_first_tool_call_mock = MagicMock()
     after_last_tool_call_mock = MagicMock()
-    
+
     # Create execution hooks with some mocks
     execution_hooks = ExecutionHooks(
         before_first_tool_call=before_first_tool_call_mock,
         after_last_tool_call=after_last_tool_call_mock,
     )
-    
+
     # Assert that specified hooks are set correctly
     assert execution_hooks.before_first_tool_call == before_first_tool_call_mock
     assert execution_hooks.after_last_tool_call == after_last_tool_call_mock
-    
+
     # Assert that unspecified hooks are None
     assert execution_hooks.clarification_handler is None
     assert execution_hooks.before_tool_call is None


### PR DESCRIPTION
This PR adds new execution hooks to the ExecutionHooks class:

* before_first_tool_call: Called before the first tool call in a plan run
* before_tool_call: Called before each tool call
* after_tool_call: Called after each tool call
* after_last_tool_call: Called after the last tool call in a plan run

These hooks allow for more fine-grained control and monitoring of the execution process, enabling users to implement custom logic at different stages of the tool execution lifecycle.

Added unit tests to verify the hooks are properly initialized.