### PR TITLE
[POR-1021] Persist authentication for browserbase

### DIFF
--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -523,7 +523,7 @@ if BROWSERBASE_AVAILABLE:
 
         def step_complete(self, ctx: ToolRunContext) -> None:
             """Call when the step is complete closes the session to persist context."""
-            if ctx.execution_context.additional_data["bb_session_id"]:
+            if ctx.execution_context.additional_data.get("bb_session_id"):
                 self.bb.sessions.update(
                     ctx.execution_context.additional_data["bb_session_id"],
                     project_id=self.project_id,  # type: ignore reportArgumentType

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -912,6 +912,7 @@ class Portia:
                 )
 
             plan_run.outputs.clarifications = plan_run.outputs.clarifications + new_clarifications
+            print(f"plan run was {plan_run.model_dump_json(indent=4)}")
             self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
             return True
         return False

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -912,7 +912,6 @@ class Portia:
                 )
 
             plan_run.outputs.clarifications = plan_run.outputs.clarifications + new_clarifications
-            print(f"plan run was {plan_run.model_dump_json(indent=4)}")
             self._set_plan_run_state(plan_run, PlanRunState.NEED_CLARIFICATION)
             return True
         return False

--- a/tests/unit/open_source_tools/test_browser_tool.py
+++ b/tests/unit/open_source_tools/test_browser_tool.py
@@ -81,6 +81,9 @@ class MockBrowserInfrastructureProvider(BrowserInfrastructureProvider):
         """Construct the auth clarification for testing."""
         return HttpUrl(sign_in_url)
 
+    def step_complete(self, _: ToolRunContext) -> None:  # type: ignore reportIncompatibleMethodOverride
+        """Call when the step is complete to e.g release the session."""
+
 
 @pytest.fixture
 def mock_browser_infrastructure_provider() -> BrowserInfrastructureProvider:
@@ -375,7 +378,9 @@ def test_browserbase_provider_get_context_id(
     mock_context.id = "test_context_id"
     mock_browserbase_provider.bb.contexts.create.return_value = mock_context  # type: ignore reportFunctionMemberAccess
 
-    context_id = mock_browserbase_provider.get_context_id(mock_browserbase_provider.bb)
+    context_id = mock_browserbase_provider.get_context_id(
+        mock_context, mock_browserbase_provider.bb
+    )
 
     mock_browserbase_provider.bb.contexts.create.assert_called_once_with(project_id="test_project")  # type: ignore reportFunctionMemberAccess
     assert context_id == "test_context_id"


### PR DESCRIPTION
# Description

Use persistent contexts to persist auth cookies across plan runs, using end user persistence.

Ticket Link:
- https://linear.app/portialabs/issue/POR-1303/ensure-session-is-closed-at-end-of-task
- https://linear.app/portialabs/issue/POR-1021/add-session-persistence-using-end-user-storage

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Changelog

### Added
- v0.3.2: Added auth and cookie persistence across runs within Browserbase for browser tools
