### PR TITLE
Turn on agent memory feature flag by default

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -467,7 +467,7 @@ class Config(BaseModel):
         self.feature_flags = {
             # Fill here with any default feature flags.
             # e.g. CONDITIONAL_FLAG: True,
-            FEATURE_FLAG_AGENT_MEMORY_ENABLED: False,
+            FEATURE_FLAG_AGENT_MEMORY_ENABLED: True,
             **self.feature_flags,
         }
         return self


### PR DESCRIPTION
# Description

I think this is ready to be turned on by default. If everything goes well for a week, I'll remove the feature flag and commit to this.

## Type of change

(select all that apply)

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
