### PR TITLE
[RUN-48] Pin browser-use version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -220,7 +220,7 @@ description = "Function decoration for backoff and retry"
 optional = true
 python-versions = ">=3.7,<4.0"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
     {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
@@ -233,7 +233,7 @@ description = "Screen-scraping library"
 optional = true
 python-versions = ">=3.7.0"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"},
     {file = "beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b"},
@@ -257,7 +257,7 @@ description = "Make websites accessible for AI agents"
 optional = true
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "browser_use-0.1.40-py3-none-any.whl", hash = "sha256:8deb6846bec00819bf150808357406e7847204c383351147c1f3d261c1904fb9"},
     {file = "browser_use-0.1.40.tar.gz", hash = "sha256:ddafcda30a9f9fe0f63612af5bf19a0ec03454d2774f54543eee70eef7ab369f"},
@@ -287,7 +287,7 @@ description = "The official Python library for the Browserbase API"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"tools-browser-browserbase\""
+markers = "extra == \"tools-browser-browserbase\" or extra == \"all\""
 files = [
     {file = "browserbase-1.2.0-py3-none-any.whl", hash = "sha256:0b8d9429dea58f787b42b0109306f7a193770b78a24329ed13f50864debdf959"},
     {file = "browserbase-1.2.0.tar.gz", hash = "sha256:44a1dbf2562893a8f9447c3d6de6fe72d3ae30fe743a5c2c52439928d0464a7b"},
@@ -308,7 +308,7 @@ description = "Extensible memoizing collections and decorators"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
     {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
@@ -547,7 +547,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -694,7 +694,7 @@ description = "Like `typing._eval_type`, but lets older Python versions use newe
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\""
+markers = "extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\" or extra == \"all\""
 files = [
     {file = "eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a"},
     {file = "eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1"},
@@ -729,7 +729,7 @@ files = [
     {file = "filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"},
     {file = "filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"},
 ]
-markers = {main = "(extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\") and python_version < \"4.0\""}
+markers = {main = "(extra == \"mistral\" or extra == \"mistralai\" or extra == \"all\") and python_version < \"4.0\""}
 
 [package.extras]
 docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
@@ -743,7 +743,7 @@ description = "Infer file type and MIME type of any file/buffer. No external dep
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
     {file = "filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb"},
@@ -859,7 +859,7 @@ description = "File-system specification"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\") and python_version < \"4.0\""
+markers = "(extra == \"mistral\" or extra == \"mistralai\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "fsspec-2025.3.2-py3-none-any.whl", hash = "sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711"},
     {file = "fsspec-2025.3.2.tar.gz", hash = "sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6"},
@@ -900,7 +900,7 @@ description = "Google Ai Generativelanguage API client library"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c"},
     {file = "google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3"},
@@ -922,7 +922,7 @@ description = "Google API client core library"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google_api_core-2.24.2-py3-none-any.whl", hash = "sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9"},
     {file = "google_api_core-2.24.2.tar.gz", hash = "sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696"},
@@ -953,7 +953,7 @@ description = "Google API Client Library for Python"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google_api_python_client-2.166.0-py2.py3-none-any.whl", hash = "sha256:dd8cc74d9fc18538ab05cbd2e93cb4f82382f910c5f6945db06c91f1deae6e45"},
     {file = "google_api_python_client-2.166.0.tar.gz", hash = "sha256:b8cf843bd9d736c134aef76cf1dc7a47c9283a2ef24267b97207b9dd43b30ef7"},
@@ -973,7 +973,7 @@ description = "Google Authentication Library"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a"},
     {file = "google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4"},
@@ -999,7 +999,7 @@ description = "Google Authentication Library: httplib2 transport"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05"},
     {file = "google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d"},
@@ -1016,7 +1016,7 @@ description = "Google Generative AI High level API client library and tools."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "google_generativeai-0.8.4-py3-none-any.whl", hash = "sha256:e987b33ea6decde1e69191ddcaec6ef974458864d243de7191db50c21a7c5b82"},
 ]
@@ -1041,7 +1041,7 @@ description = "Common protobufs used in Google APIs"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "googleapis_common_protos-1.69.2-py3-none-any.whl", hash = "sha256:0b30452ff9c7a27d80bfc5718954063e8ab53dd3697093d3bc99581f5fd24212"},
     {file = "googleapis_common_protos-1.69.2.tar.gz", hash = "sha256:3e1b904a27a33c821b4b749fd31d334c0c9c30e6113023d495e48979a3dc9c5f"},
@@ -1060,7 +1060,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\" or extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\""
+markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\" or extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\""
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -1148,7 +1148,7 @@ description = "HTTP/2-based RPC framework"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "grpcio-1.71.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:c200cb6f2393468142eb50ab19613229dcc7829b5ccee8b658a36005f6669fdd"},
     {file = "grpcio-1.71.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:b2266862c5ad664a380fbbcdbdb8289d71464c42a8c29053820ee78ba0119e5d"},
@@ -1213,7 +1213,7 @@ description = "Status proto mapping for gRPC"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "grpcio_status-1.71.0-py3-none-any.whl", hash = "sha256:843934ef8c09e3e858952887467f8256aac3910c55f077a359a65b2b3cde3e68"},
     {file = "grpcio_status-1.71.0.tar.gz", hash = "sha256:11405fed67b68f406b3f3c7c5ae5104a79d2d309666d10d61b152e91d28fb968"},
@@ -1265,7 +1265,7 @@ description = "A comprehensive HTTP client library."
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc"},
     {file = "httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"},
@@ -1319,7 +1319,7 @@ description = "Client library to download and publish models, datasets and other
 optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\") and python_version < \"4.0\""
+markers = "(extra == \"mistral\" or extra == \"mistralai\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "huggingface_hub-0.30.1-py3-none-any.whl", hash = "sha256:0f6aa5ec5a4e68e5b9e45d556b4e5ea180c58f5a5ffa734e7f38c9d573028959"},
     {file = "huggingface_hub-0.30.1.tar.gz", hash = "sha256:f379e8b8d0791295602538856638460ae3cf679c7f304201eb80fb98c771950e"},
@@ -1559,7 +1559,7 @@ description = "A more powerful JSONPath implementation in modern python"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\""
+markers = "extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\" or extra == \"all\""
 files = [
     {file = "jsonpath-python-1.0.6.tar.gz", hash = "sha256:dd5be4a72d8a2995c3f583cf82bf3cd1a9544cfdabf2d22595b67aff07349666"},
     {file = "jsonpath_python-1.0.6-py3-none-any.whl", hash = "sha256:1e3b78df579f5efc23565293612decee04214609208a2335884b3ee3f786b575"},
@@ -1681,7 +1681,7 @@ description = "An integration package connecting Google's genai package and Lang
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "langchain_google_genai-2.0.10-py3-none-any.whl", hash = "sha256:964a7542fd11fdec7592052b4eaef383227f7c4fa4d754a455e4bf0634f4ad28"},
     {file = "langchain_google_genai-2.0.10.tar.gz", hash = "sha256:b51067b468853856f275bb7b1a85dbaf4467b59fe67e35fcd614fc0d744c810e"},
@@ -1700,7 +1700,7 @@ description = "An integration package connecting Mistral and LangChain"
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\") and python_version < \"4.0\""
+markers = "(extra == \"mistral\" or extra == \"mistralai\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "langchain_mistralai-0.2.10-py3-none-any.whl", hash = "sha256:fc3bc813eab034335236a3b01ba189cd00bcf2b7e6ac57628d0409438bd13425"},
     {file = "langchain_mistralai-0.2.10.tar.gz", hash = "sha256:698620c7dee8ae85bf1ca1ed5b544285c0764c453efead9a4ae34ab884704ce1"},
@@ -1720,7 +1720,7 @@ description = "An integration package connecting Ollama and LangChain"
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\" or extra == \"ollama\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\" or extra == \"ollama\") and python_version < \"4.0\""
 files = [
     {file = "langchain_ollama-0.2.2-py3-none-any.whl", hash = "sha256:8a1ee72dbb6ea3b3ace1d9dd317e472d667a8ed491328550da59f4893a6796f8"},
     {file = "langchain_ollama-0.2.2.tar.gz", hash = "sha256:2d9bcb06ffdbe43c7c6906c46e710d36d33b6b99cd4975cbf54060f13e51c875"},
@@ -1900,7 +1900,7 @@ description = "Convert HTML to markdown."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "markdownify-0.14.1-py3-none-any.whl", hash = "sha256:4c46a6c0c12c6005ddcd49b45a5a890398b002ef51380cd319db62df5e09bc2a"},
     {file = "markdownify-0.14.1.tar.gz", hash = "sha256:a62a7a216947ed0b8dafb95b99b2ef4a0edd1e18d5653c656f68f03db2bfb2f1"},
@@ -2028,7 +2028,7 @@ description = "Python Client SDK for the Mistral AI API."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\""
+markers = "extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\" or extra == \"all\""
 files = [
     {file = "mistralai-1.5.2-py3-none-any.whl", hash = "sha256:5b1112acebbcad1afd7732ce0bd60614975b64999801c555c54768ac41f506ae"},
     {file = "mistralai-1.5.2.tar.gz", hash = "sha256:f39e6e51e8939aac2602e4badcb18712cbee2df33d86100c559333e609b92d17"},
@@ -2052,7 +2052,7 @@ description = "An implementation of time.monotonic() for Python 2 & < 3.3"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "monotonic-1.6-py2.py3-none-any.whl", hash = "sha256:68687e19a14f11f26d140dd5c86f3dba4bf5df58003000ed467e0e2a69bca96c"},
     {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
@@ -2168,7 +2168,7 @@ description = "Type system extensions for programs checked with the mypy type ch
 optional = true
 python-versions = ">=3.5"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\""
+markers = "extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\" or extra == \"all\""
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
@@ -2258,7 +2258,7 @@ description = "The official Python client for Ollama."
 optional = true
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\" or extra == \"ollama\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\" or extra == \"ollama\") and python_version < \"4.0\""
 files = [
     {file = "ollama-0.4.7-py3-none-any.whl", hash = "sha256:85505663cca67a83707be5fb3aeff0ea72e67846cea5985529d8eca4366564a1"},
     {file = "ollama-0.4.7.tar.gz", hash = "sha256:891dcbe54f55397d82d289c459de0ea897e103b86a3f1fad0fdb1895922a75ff"},
@@ -2564,7 +2564,7 @@ description = "A high-level API to automate web browsers"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\""
 files = [
     {file = "playwright-1.51.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bcaaa3d5d73bda659bfb9ff2a288b51e85a91bd89eda86eaf8186550973e416a"},
     {file = "playwright-1.51.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e0ae6eb44297b24738e1a6d9c580ca4243b4e21b7e65cf936a71492c08dd0d4"},
@@ -2602,7 +2602,7 @@ description = "Integrate PostHog into any python application."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "posthog-3.23.0-py2.py3-none-any.whl", hash = "sha256:2b07d06670170ac2e21465dffa8d356722834cc877ab34e583da6e525c1037df"},
     {file = "posthog-3.23.0.tar.gz", hash = "sha256:1ac0305ab6c54a80c4a82c137231f17616bef007bbf474d1a529cda032d808eb"},
@@ -2757,7 +2757,7 @@ description = "Beautiful, Pythonic protocol buffers"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66"},
     {file = "proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012"},
@@ -2776,7 +2776,7 @@ description = ""
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "protobuf-5.29.4-cp310-abi3-win32.whl", hash = "sha256:13eb236f8eb9ec34e63fc8b1d6efd2777d062fa6aaa68268fb67cf77f6839ad7"},
     {file = "protobuf-5.29.4-cp310-abi3-win_amd64.whl", hash = "sha256:bcefcdf3976233f8a502d265eb65ea740c989bacc6c30a58290ed0e519eb4b8d"},
@@ -2822,7 +2822,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
     {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
@@ -2835,7 +2835,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
     {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
@@ -3019,7 +3019,7 @@ description = "A rough port of Node.js's EventEmitter to Python with a few trick
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\""
+markers = "extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\""
 files = [
     {file = "pyee-12.1.1-py3-none-any.whl", hash = "sha256:18a19c650556bb6b32b406d7f017c8f513aceed1ef7ca618fb65de7bd2d347ef"},
     {file = "pyee-12.1.1.tar.gz", hash = "sha256:bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3"},
@@ -3054,7 +3054,7 @@ description = "pyparsing module - Classes and methods to define and execute pars
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf"},
     {file = "pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be"},
@@ -3493,7 +3493,7 @@ description = "Pure-Python RSA implementation"
 optional = true
 python-versions = ">=3.6,<4"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
     {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
@@ -3537,7 +3537,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"},
     {file = "setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"},
@@ -3596,7 +3596,7 @@ description = "A modern CSS selector implementation for Beautiful Soup."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"tools-browser-browserbase\" or extra == \"tools-browser-local\") and python_version < \"4.0\""
+markers = "(extra == \"tools-browser-local\" or extra == \"tools-browser-browserbase\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
     {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
@@ -3809,7 +3809,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\") and python_version < \"4.0\""
+markers = "(extra == \"mistral\" or extra == \"mistralai\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "tokenizers-0.21.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e78e413e9e668ad790a29456e677d9d3aa50a9ad311a40905d6861ba7692cf41"},
     {file = "tokenizers-0.21.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:cd51cd0a91ecc801633829fcd1fda9cf8682ed3477c6243b9a095539de4aecf3"},
@@ -3897,7 +3897,7 @@ description = "Runtime inspection utilities for typing module."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\""
+markers = "extra == \"mistral\" or extra == \"mistralai\" or extra == \"tools-pdf-reader\" or extra == \"all\""
 files = [
     {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
     {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
@@ -3941,7 +3941,7 @@ description = "Implementation of RFC 6570 URI Templates"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "(extra == \"all\" or extra == \"google\") and python_version < \"4.0\""
+markers = "(extra == \"google\" or extra == \"all\") and python_version < \"4.0\""
 files = [
     {file = "uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"},
     {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},
@@ -4246,4 +4246,4 @@ tools-pdf-reader = ["mistralai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "5a94901b349b13dd58aaeb90a9d30be09a98600177b6cbcf89e5e4e3e08e861b"
+content-hash = "f6c5a75b5a11b463c164312c77e161768b3eb77eecfbc4fd7f6fc2d5b9229925"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ langsmith = {version = "^0.3.15", python = ">=3.11,<4.0"}
 google-generativeai = {version = "^0.8.4", optional = true, python = ">=3.11,<4.0"}
 langchain-google-genai = {version = "^2.0.10", optional = true, python = ">=3.11,<4.0"}
 playwright = { version = "^1.49.0", optional = true }
-browser-use = { version = "^0.1.40", optional = true, python = ">=3.11,<4.0" }
+browser-use = { version = "0.1.40", optional = true, python = ">=3.11,<4.0" }
 tiktoken = "^0.9.0"
 jsonref = "^1.1.0"
 browserbase = { version = "^1.2.0", optional = true }


### PR DESCRIPTION
# Description

Browser use version 0.1.41 updates some params in a non-backwards compatible way. We're also pinned anyway at the moment because 0.1.41 depends on a later version of Ollama, so for now, I'd rather just be explicit on the pinning.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
