### PR TITLE
Sort async clarification handling

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -539,9 +539,9 @@ class Portia:
             return plan_run
 
         plan = self.storage.get_plan(plan_run.plan_id)
-        plan_run = self.storage.get_plan_run(plan_run.id)
-        current_step_clarifications = plan_run.get_clarifications_for_step()
         while plan_run.state != PlanRunState.READY_TO_RESUME:
+            plan_run = self.storage.get_plan_run(plan_run.id)
+            current_step_clarifications = plan_run.get_clarifications_for_step()
             if tries >= max_retries:
                 raise InvalidPlanRunStateError("Run is not ready to resume after max retries")
 


### PR DESCRIPTION
# Description

Without this, even when we resolve a clarification async, we don't re-fetch the plan_run and so we don't pick up that change.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
