### PR TITLE
Add step check to before_first_step_execution

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -645,7 +645,7 @@ class Portia:
             f"Plan Run State is updated to {plan_run.state!s}.{dashboard_message}",
         )
 
-        if self.execution_hooks.before_first_step_execution:
+        if self.execution_hooks.before_first_step_execution and plan_run.current_step_index == 0:
             self.execution_hooks.before_first_step_execution(
                 ReadOnlyPlan.from_plan(plan), ReadOnlyPlanRun.from_plan_run(plan_run)
             )


### PR DESCRIPTION
# Description

Without this, we call before `before_first_step_execution` when resuming a plan after handling a clarification, which I don't think is the right behaviour

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
