### PR TITLE
[POR-1374] configure auto generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - do not merge
+      - question
+      - wontfix
+      - invalid
+    authors:
+  categories:
+    - title: Bug fixes 🛠
+      labels:
+        - bugs
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/generate-notes-after-release.yml
+++ b/.github/workflows/generate-notes-after-release.yml
@@ -1,0 +1,49 @@
+name: append release notes to changelog and sync to docs after release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  generate-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Append release notes to CHANGELOG.md
+        run: |
+          echo -e "## ${{ github.event.release.tag_name }} - ${{ github.event.release.published_at }}\n\n${{ github.event.release.body }}\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG.md for release ${{ github.event.release.tag_name }}"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Docs repo
+        uses: actions/checkout@v4
+        with:
+          repository: portiaAI/docs
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          path: docs-repo
+
+      - name: Copy generated docs
+        run: |
+          cp CHANGELOG.md docs-repo/docs/CHANGELOG.md
+
+      - name: Commit and push changes
+        run: |
+          cd docs-repo
+          git add docs/CHANGELOG.md
+          git commit -m "Sync SDK changelog for release ${{ github.event.release.tag_name }}" || echo "No changes to commit"
+          git push origin main


### PR DESCRIPTION
# Description
Add .github/release.yml to configure automatic inclusion of PRs in GitHub release notes.
Reference: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

Ticket Link: https://linear.app/portialabs/issue/POR-1374/start-generating-release-notes 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
