### PR TITLE
Updates from plan input dogfooding

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,15 +4,10 @@ from dotenv import load_dotenv
 
 from portia import (
     Config,
-    LocalDataValue,
     LogLevel,
-    PlanRunState,
     Portia,
     example_tool_registry,
 )
-from portia.cli import CLIExecutionHooks
-from portia.end_user import EndUser
-from portia.plan import PlanInput
 
 load_dotenv()
 
@@ -23,56 +18,53 @@ portia = Portia(
 
 
 # Simple Example
+# plan_run = portia.run(
+#    "Get the temperature in London and Sydney and then add the two temperatures rounded to 2DP",
+# )
+#
+## We can also provide additional data about the end user to the process
+# plan_run = portia.run(
+#    "Please tell me a joke that is customized to my favorite sport",
+#    end_user=EndUser(
+#        external_id="user_789",
+#        email="hello@portialabs.ai",
+#        additional_data={
+#            "favorite_sport": "football",
+#        },
+#    ),
+# )
+#
+## When we hit a clarification we can ask our end user for clarification then resume the process
+## Deliberate typo in the second place name to hit the clarification
+# plan_run = portia.run(
+#    "Get the temperature in London and xydwne and then add the two temperatures rounded to 2DP",
+# )
+#
+## Fetch run
+# plan_run = portia.storage.get_plan_run(plan_run.id)
+## Update clarifications
+# if plan_run.state == PlanRunState.NEED_CLARIFICATION:
+#    for c in plan_run.get_outstanding_clarifications():
+#        # Here you prompt the user for the response to the clarification
+#        # via whatever mechanism makes sense for your use-case.
+#        new_value = "Sydney"
+#        plan_run = portia.resolve_clarification(
+#            plan_run=plan_run,
+#            clarification=c,
+#            response=new_value,
+#        )
+#
+## You can also pass in a clarification handler to manage clarifications
+# portia = Portia(
+#    Config.from_default(default_log_level=LogLevel.DEBUG),
+#    tools=example_tool_registry,
+#    execution_hooks=CLIExecutionHooks(),
+# )
+# plan_run = portia.run(
+#    "Get the temperature in London and xydwne and then add the two temperatures rounded to 2DP",
+# )
+#
+## You can pass inputs into a plan
 plan_run = portia.run(
-    "Get the temperature in London and Sydney and then add the two temperatures rounded to 2DP",
+    "Get the temperature for the provided city", plan_run_inputs={"$city": "Lisbon"}
 )
-
-# We can also provide additional data about the end user to the process
-plan_run = portia.run(
-    "Please tell me a joke that is customized to my favorite sport",
-    end_user=EndUser(
-        external_id="user_789",
-        email="hello@portialabs.ai",
-        additional_data={
-            "favorite_sport": "football",
-        },
-    ),
-)
-
-# When we hit a clarification we can ask our end user for clarification then resume the process
-# Deliberate typo in the second place name to hit the clarification
-plan_run = portia.run(
-    "Get the temperature in London and xydwne and then add the two temperatures rounded to 2DP",
-)
-
-# Fetch run
-plan_run = portia.storage.get_plan_run(plan_run.id)
-# Update clarifications
-if plan_run.state == PlanRunState.NEED_CLARIFICATION:
-    for c in plan_run.get_outstanding_clarifications():
-        # Here you prompt the user for the response to the clarification
-        # via whatever mechanism makes sense for your use-case.
-        new_value = "Sydney"
-        plan_run = portia.resolve_clarification(
-            plan_run=plan_run,
-            clarification=c,
-            response=new_value,
-        )
-
-# You can also pass in a clarification handler to manage clarifications
-portia = Portia(
-    Config.from_default(default_log_level=LogLevel.DEBUG),
-    tools=example_tool_registry,
-    execution_hooks=CLIExecutionHooks(),
-)
-plan_run = portia.run(
-    "Get the temperature in London and xydwne and then add the two temperatures rounded to 2DP",
-)
-
-# You can pass inputs into a plan
-plan_run_inputs = {
-    PlanInput(name="$city", description="The city to get the temperature for"): LocalDataValue(
-        value="Lisbon"
-    ),
-}
-plan_run = portia.run("Get the temperature for the provided city", plan_run_inputs=plan_run_inputs)

--- a/portia/introspection_agents/default_introspection_agent.py
+++ b/portia/introspection_agents/default_introspection_agent.py
@@ -50,7 +50,7 @@ You are a highly skilled reviewer who reviews in flight plan execution. Your job
 the condition for the current step. Your outcome is fed to another orchestrator that controls
 the execution of the remaining steps.
 
-IMPORTANT GUIDLINES:
+IMPORTANT GUIDELINES:
 - Pay close attention to the steps giving and its tasks, there is no alternative flows or other
 steps other than what's been giving to you for this plan execution.
 - Do not assume data, you should evaluate the condition ONLY based on data given.

--- a/portia/plan.py
+++ b/portia/plan.py
@@ -242,7 +242,10 @@ class PlanInput(BaseModel):
         default=None,
     )
     value: Serializable | None = Field(
-        description="The value of the input.",
+        description=(
+            "The value of the input. This is only used when running a plan and isn't used during "
+            "planning."
+        ),
         default=None,
     )
 

--- a/portia/plan.py
+++ b/portia/plan.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
+from portia.common import Serializable
 from portia.prefixed_uuid import PlanUUID
 
 
@@ -171,7 +172,7 @@ class PlanBuilder:
         return Plan(
             plan_context=PlanContext(query=self.query, tool_ids=tool_ids),
             steps=self.steps,
-            inputs=self.plan_inputs,
+            plan_inputs=self.plan_inputs,
         )
 
     def _get_step_index_or_raise(self, step_index: int | None) -> int:
@@ -235,8 +236,14 @@ class PlanInput(BaseModel):
     name: str = Field(
         description="The name of the input",
     )
-    description: str = Field(
-        description="A description of the input.",
+    description: str | None = Field(
+        description="A description of the input. This is used during planning to help the planning "
+        "agent understand how to use the input.",
+        default=None,
+    )
+    value: Serializable | None = Field(
+        description="The value of the input.",
+        default=None,
     )
 
     def pretty_print(self) -> str:
@@ -246,7 +253,7 @@ class PlanInput(BaseModel):
             str: A pretty print representation of the input's name, and description.
 
         """
-        return f"{self.name}: ({self.description})"
+        return f"{self.name}: ({self.description or 'No description'})"
 
     def __hash__(self) -> int:
         """Make PlanInput hashable by using name and description as the hash key."""
@@ -309,9 +316,10 @@ class Step(BaseModel):
         """
         message = (
             f"- {self.task}\n"
-            f"  Inputs: {', '.join([in_variable.pretty_print() for in_variable in self.inputs])}\n"
-            f"  Tool ID: {self.tool_id}\n"
-            f"  Output: {self.output}\n"
+            f"    Inputs: {', '
+                           .join([in_variable.pretty_print() for in_variable in self.inputs])}\n"
+            f"    Tool ID: {self.tool_id}\n"
+            f"    Output: {self.output}\n"
         )
         if self.condition:
             message += f"  Condition: {self.condition}\n"
@@ -401,7 +409,7 @@ class Plan(BaseModel):
     )
     plan_context: PlanContext = Field(description="The context for when the plan was created.")
     steps: list[Step] = Field(description="The set of steps to solve the query.")
-    inputs: list[PlanInput] = Field(
+    plan_inputs: list[PlanInput] = Field(
         default=[],
         description="The inputs required by the plan.",
     )
@@ -417,7 +425,7 @@ class Plan(BaseModel):
             f"PlanModel(id={self.id!r},"
             f"plan_context={self.plan_context!r}, "
             f"steps={self.steps!r}, "
-            f"inputs={self.inputs!r}"
+            f"inputs={self.plan_inputs!r}"
         )
 
     @classmethod
@@ -438,7 +446,9 @@ class Plan(BaseModel):
                 tool_ids=response_json["tool_ids"],
             ),
             steps=[Step.model_validate(step) for step in response_json["steps"]],
-            inputs=[PlanInput.model_validate(input_) for input_ in response_json.get("inputs", [])],
+            plan_inputs=[
+                PlanInput.model_validate(input_) for input_ in response_json.get("inputs", [])
+            ],
         )
 
     def pretty_print(self) -> str:
@@ -455,9 +465,11 @@ class Plan(BaseModel):
         tools_summary = f"{len(portia_tools)} portia tools, {len(other_tools)} other tools"
 
         inputs_section = ""
-        if self.inputs:
+        if self.plan_inputs:
             inputs_section = (
-                "Inputs:\n" + "\n".join([input_.pretty_print() for input_ in self.inputs]) + "\n"
+                "Inputs:\n    "
+                + "\n    ".join([input_.pretty_print() for input_ in self.plan_inputs])
+                + "\n"
             )
 
         return (
@@ -482,7 +494,7 @@ class Plan(BaseModel):
             raise ValueError("Outputs + conditions must be unique")
 
         # Validate plan input names are unique
-        input_names = [input_.name for input_ in self.inputs]
+        input_names = [input_.name for input_ in self.plan_inputs]
         if len(input_names) != len(set(input_names)):
             raise ValueError("Plan input names must be unique")
 
@@ -513,5 +525,5 @@ class ReadOnlyPlan(Plan):
             id=plan.id,
             plan_context=plan.plan_context,
             steps=plan.steps,
-            inputs=plan.inputs,
+            plan_inputs=plan.plan_inputs,
         )

--- a/portia/plan.py
+++ b/portia/plan.py
@@ -230,8 +230,7 @@ class PlanInput(BaseModel):
 
     """
 
-    # Use frozen=True to allow this to be a dictionary key
-    model_config = ConfigDict(extra="ignore", frozen=True)
+    model_config = ConfigDict(extra="ignore")
 
     name: str = Field(
         description="The name of the input",
@@ -257,16 +256,6 @@ class PlanInput(BaseModel):
 
         """
         return f"{self.name}: ({self.description or 'No description'})"
-
-    def __hash__(self) -> int:
-        """Make PlanInput hashable by using name and description as the hash key."""
-        return hash((self.name, self.description))
-
-    def __eq__(self, other: object) -> bool:
-        """Compare PlanInput objects for equality based on name."""
-        if not isinstance(other, PlanInput):
-            return False
-        return self.name == other.name and self.description == other.description
 
 
 class Step(BaseModel):

--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -51,7 +51,7 @@ class DefaultPlanningAgent(BasePlanningAgent):
 You are an outstanding task planner who can leverage many tools at their disposal. Your job is
 to provide a detailed plan of action in the form of a set of steps to respond to a user's prompt.
 
-IMPORTANT GUIDLINES:
+IMPORTANT GUIDELINES:
 - When using multiple tools, pay attention to the  tools to make sure the chain of steps works,
  but DO NOT provide any examples or assumptions  in the task descriptions.
 - If you are missing information do not  make up placeholder variables like example@example.com.
@@ -59,8 +59,8 @@ IMPORTANT GUIDLINES:
  step, DO NOT guess what that step will produce - instead, specify the previous step's output as an
  input for this step and allow this to be handled when we execute the plan.
 - If you can't come up with a plan provide a descriptive error instead - DO NOT
- create a plan with zero steps. When returning an error, return only only the JSON object with
- the error message filled in - DO NOT include text (explaining the error or otherwise) outside of
+ create a plan with zero steps. When returning an error, return only the JSON object with
+ the error message filled in - DO NOT include text (explaining the error or otherwise) outside
  the JSON object.
 - For EVERY tool that requires an id as an input, make sure to check
  if there's a corresponding tool call that provides the id from natural language if possible.

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -31,6 +31,7 @@ from portia.clarification import (
     ClarificationCategory,
 )
 from portia.cloud import PortiaCloudClient
+from portia.common import Serializable
 from portia.config import (
     Config,
     ExecutionAgentType,
@@ -82,7 +83,6 @@ from portia.tool_registry import (
 from portia.tool_wrapper import ToolCallWrapper
 
 if TYPE_CHECKING:
-    from portia.common import Serializable
     from portia.execution_agents.base_execution_agent import BaseExecutionAgent
     from portia.planning_agents.base_planning_agent import BasePlanningAgent
 
@@ -161,7 +161,7 @@ class Portia:
         tools: list[Tool] | list[str] | None = None,
         example_plans: list[Plan] | None = None,
         end_user: str | EndUser | None = None,
-        plan_run_inputs: dict[PlanInput, Serializable] | None = None,
+        plan_run_inputs: list[PlanInput] | list[dict[str, str]] | dict[str, str] | None = None,
     ) -> PlanRun:
         """End-to-end function to generate a plan and then execute it.
 
@@ -174,18 +174,53 @@ class Portia:
             example_plans (list[Plan] | None): Optional list of example plans. If not
             provide a default set of example plans will be used.
             end_user (str | EndUser | None = None): The end user for this plan run.
-            plan_run_inputs (dict[PlanInput, Serializable] | None): Optional dictionary mapping
-                PlanInput objects to their values.
+            plan_run_inputs (list[PlanInput] | list[dict[str, str]] | dict[str, str] | None):
+                Optional dictionary mapping PlanInput objects to their values. This can be a list
+                of Planinput objects, a list of dicts with keys "name", "description" (optional)
+                and "value", or a dict of plan run input name to value.
 
         Returns:
             PlanRun: The run resulting from executing the query.
 
         """
-        plan_inputs = list(plan_run_inputs.keys()) if plan_run_inputs else None
-        plan = self.plan(query, tools, example_plans, end_user, plan_inputs)
+        coerced_plan_run_inputs = self._coerce_plan_run_inputs(plan_run_inputs)
+        plan = self.plan(query, tools, example_plans, end_user, coerced_plan_run_inputs)
         end_user = self.initialize_end_user(end_user)
-        plan_run = self.create_plan_run(plan, end_user, plan_run_inputs)
+        plan_run = self.create_plan_run(plan, end_user, coerced_plan_run_inputs)
         return self.resume(plan_run)
+
+    def _coerce_plan_run_inputs(
+        self,
+        plan_run_inputs: list[PlanInput]
+        | list[dict[str, Serializable]]
+        | dict[str, Serializable]
+        | None,
+    ) -> list[PlanInput] | None:
+        """Coerce plan inputs from any input type into a list of PlanInputs we use internally."""
+        if plan_run_inputs is None:
+            return None
+        if isinstance(plan_run_inputs, list):
+            to_return = []
+            for plan_run_input in plan_run_inputs:
+                if isinstance(plan_run_input, dict):
+                    if "name" not in plan_run_input or "value" not in plan_run_input:
+                        raise ValueError("Plan input must have a name and value")
+                    to_return.append(
+                        PlanInput(
+                            name=plan_run_input["name"],
+                            description=plan_run_input.get("description", None),
+                            value=plan_run_input["value"],
+                        )
+                    )
+                else:
+                    to_return.append(plan_run_input)
+            return to_return
+        if isinstance(plan_run_inputs, dict):
+            to_return = []
+            for key, value in plan_run_inputs.items():
+                to_return.append(PlanInput(name=key, value=value))
+            return to_return
+        return None
 
     def plan(
         self,
@@ -193,7 +228,7 @@ class Portia:
         tools: list[Tool] | list[str] | None = None,
         example_plans: list[Plan] | None = None,
         end_user: str | EndUser | None = None,
-        plan_inputs: list[PlanInput] | None = None,
+        plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None = None,
     ) -> Plan:
         """Plans how to do the query given the set of tools and any examples.
 
@@ -205,7 +240,10 @@ class Portia:
             provide a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
             plan_inputs (list[PlanInput] | None): Optional list of PlanInput objects defining
-              the inputs required for the plan.
+              the inputs required for the plan. This can be a list of Planinput objects, a list of
+              dicts with keys "name" and "description" (optional), or a list of plan run input
+              names. If a value is provided with a PlanInput object or in a dictionary, it will be
+              ignored as values are only used when running the plan.
 
         Returns:
             Plan: The plan for executing the query.
@@ -226,12 +264,13 @@ class Portia:
         end_user = self.initialize_end_user(end_user)
         logger().info(f"Running planning_agent for query - {query}")
         planning_agent = self._get_planning_agent()
+        coerced_plan_inputs = self._coerce_plan_inputs(plan_inputs)
         outcome = planning_agent.generate_steps_or_error(
             query=query,
             tool_list=tools,
             end_user=end_user,
             examples=example_plans,
-            plan_inputs=plan_inputs,
+            plan_inputs=coerced_plan_inputs,
         )
         if outcome.error:
             if (
@@ -252,7 +291,7 @@ class Portia:
                 tool_ids=[tool.id for tool in tools],
             ),
             steps=outcome.steps,
-            inputs=plan_inputs or [],
+            plan_inputs=coerced_plan_inputs or [],
         )
         self.storage.save_plan(plan)
         logger().info(
@@ -263,11 +302,39 @@ class Portia:
 
         return plan
 
+    def _coerce_plan_inputs(
+        self, plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None
+    ) -> list[PlanInput] | None:
+        """Coerce plan inputs from any input type into a list of PlanInputs we use internally."""
+        if plan_inputs is None:
+            return None
+        if isinstance(plan_inputs, list):
+            to_return = []
+            for plan_input in plan_inputs:
+                if isinstance(plan_input, dict):
+                    if "name" not in plan_input:
+                        raise ValueError("Plan input must have a name and description")
+                    to_return.append(
+                        PlanInput(
+                            name=plan_input["name"],
+                            description=plan_input.get("description", None),
+                        )
+                    )
+                elif isinstance(plan_input, str):
+                    to_return.append(PlanInput(name=plan_input))
+                else:
+                    to_return.append(plan_input)
+            return to_return
+        return None
+
     def run_plan(
         self,
         plan: Plan | PlanUUID | UUID,
         end_user: str | EndUser | None = None,
-        plan_run_inputs: dict[PlanInput, Serializable] | None = None,
+        plan_run_inputs: list[PlanInput]
+        | list[dict[str, Serializable]]
+        | dict[str, Serializable]
+        | None = None,
     ) -> PlanRun:
         """Run a plan.
 
@@ -275,13 +342,15 @@ class Portia:
             plan (Plan | PlanUUID | UUID): The plan to run, or the ID of the plan to load from
               storage.
             end_user (str | EndUser | None = None): The end user to use.
-            plan_run_inputs (dict[PlanInput, Serializable] | None): Optional dictionary mapping
-                PlanInput objects to their values.
+            plan_run_inputs (list[PlanInput] | list[dict[str, Serializable]] | dict[str, Serializable] | None):
+              Optional dictionary mapping PlanInput objects to their values. This can be a list of
+              Planinput objects, a list of dicts with keys "name", "description" (optional) and
+              "value", or a dict of plan run input name to value.
 
         Returns:
             PlanRun: The resulting PlanRun object.
 
-        """
+        """  # noqa: E501
         # ensure we have the plan in storage.
         # we won't if for example the user used PlanBuilder instead of dynamic planning.
         plan_id = (
@@ -300,7 +369,8 @@ class Portia:
                 raise PlanNotFoundError(plan_id) from None
 
         end_user = self.initialize_end_user(end_user)
-        plan_run = self.create_plan_run(plan, end_user, plan_run_inputs)
+        coerced_plan_run_inputs = self._coerce_plan_run_inputs(plan_run_inputs)
+        plan_run = self.create_plan_run(plan, end_user, coerced_plan_run_inputs)
         return self.resume(plan_run)
 
     def resume(
@@ -356,49 +426,47 @@ class Portia:
         self,
         plan: Plan,
         plan_run: PlanRun,
-        plan_run_inputs: dict[PlanInput, Serializable] | None,
+        plan_run_inputs: list[PlanInput] | None = None,
     ) -> None:
         """Process plan input values and add them to the plan run.
 
         Args:
             plan (Plan): The plan containing required inputs.
             plan_run (PlanRun): The plan run to update with input values.
-            plan_run_inputs (dict[PlanInput, Serializable] | None): Values for plan inputs.
+            plan_run_inputs (list[PlanInput] | None): Values for plan inputs.
 
         Raises:
             ValueError: If required plan inputs are missing.
 
         """
-        if plan.inputs and not plan_run_inputs:
+        if plan.plan_inputs and not plan_run_inputs:
             raise ValueError("Inputs are required for this plan but have not been specified")
-        if plan_run_inputs and not plan.inputs:
+        if plan_run_inputs and not plan.plan_inputs:
             logger().warning(
                 "Inputs are not required for this plan but plan inputs were provided",
             )
 
-        if plan_run_inputs and plan.inputs:
-            input_values_by_name = {
-                input_obj.name: value for input_obj, value in plan_run_inputs.items()
-            }
+        if plan_run_inputs and plan.plan_inputs:
+            input_values_by_name = {input_obj.name: input_obj for input_obj in plan_run_inputs}
 
             # Validate all required inputs are provided
             missing_inputs = [
                 input_obj.name
-                for input_obj in plan.inputs
+                for input_obj in plan.plan_inputs
                 if input_obj.name not in input_values_by_name
             ]
             if missing_inputs:
                 raise ValueError(f"Missing required plan input values: {', '.join(missing_inputs)}")
 
-            for plan_input in plan.inputs:
+            for plan_input in plan.plan_inputs:
                 if plan_input.name in input_values_by_name:
                     plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
-                        value=input_values_by_name[plan_input.name]
+                        value=input_values_by_name[plan_input.name].value
                     )
 
             # Check for unknown inputs
             for input_obj in plan_run_inputs:
-                if not any(plan_input.name == input_obj.name for plan_input in plan.inputs):
+                if not any(plan_input.name == input_obj.name for plan_input in plan.plan_inputs):
                     logger().warning(f"Ignoring unknown plan input: {input_obj.name}")
 
             self.storage.save_plan_run(plan_run)
@@ -593,14 +661,14 @@ class Portia:
         self,
         plan: Plan,
         end_user: str | EndUser | None = None,
-        plan_run_inputs: dict[PlanInput, Serializable] | None = None,
+        plan_run_inputs: list[PlanInput] | None = None,
     ) -> PlanRun:
         """Create a PlanRun from a Plan.
 
         Args:
             plan (Plan): The plan to create a plan run from.
             end_user (str | EndUser | None = None): The end user this plan run is for.
-            plan_run_inputs (dict[PlanInput, Serializable] | None = None): The plan inputs for the
+            plan_run_inputs (list[PlanInput] | None = None): The plan inputs for the
               plan run with their values.
 
         Returns:

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -220,7 +220,7 @@ class Portia:
             for key, value in plan_run_inputs.items():
                 to_return.append(PlanInput(name=key, value=value))
             return to_return
-        return None
+        raise ValueError("Invalid plan run inputs received")
 
     def plan(
         self,
@@ -325,7 +325,7 @@ class Portia:
                 else:
                     to_return.append(plan_input)
             return to_return
-        return None
+        raise ValueError("Invalid plan inputs received")
 
     def run_plan(
         self,

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -31,7 +31,6 @@ from portia.clarification import (
     ClarificationCategory,
 )
 from portia.cloud import PortiaCloudClient
-from portia.common import Serializable
 from portia.config import (
     Config,
     ExecutionAgentType,
@@ -83,6 +82,7 @@ from portia.tool_registry import (
 from portia.tool_wrapper import ToolCallWrapper
 
 if TYPE_CHECKING:
+    from portia.common import Serializable
     from portia.execution_agents.base_execution_agent import BaseExecutionAgent
     from portia.planning_agents.base_planning_agent import BasePlanningAgent
 
@@ -175,9 +175,9 @@ class Portia:
             provide a default set of example plans will be used.
             end_user (str | EndUser | None = None): The end user for this plan run.
             plan_run_inputs (list[PlanInput] | list[dict[str, str]] | dict[str, str] | None):
-                Optional dictionary mapping PlanInput objects to their values. This can be a list
-                of Planinput objects, a list of dicts with keys "name", "description" (optional)
-                and "value", or a dict of plan run input name to value.
+                Provides input values for the run. This can be a list of PlanInput objects, a list
+                of dicts with keys "name", "description" (optional) and "value", or a dict of
+                plan run input name to value.
 
         Returns:
             PlanRun: The run resulting from executing the query.
@@ -239,11 +239,11 @@ class Portia:
             example_plans (list[Plan] | None): Optional list of example plans. If not
             provide a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
-            plan_inputs (list[PlanInput] | None): Optional list of PlanInput objects defining
-              the inputs required for the plan. This can be a list of Planinput objects, a list of
-              dicts with keys "name" and "description" (optional), or a list of plan run input
-              names. If a value is provided with a PlanInput object or in a dictionary, it will be
-              ignored as values are only used when running the plan.
+            plan_inputs (list[PlanInput] | None): Optional list of inputs required for the plan.
+              This can be a list of Planinput objects, a list of dicts with keys "name" and
+              "description" (optional), or a list of plan run input names. If a value is provided
+              with a PlanInput object or in a dictionary, it will be ignored as values are only
+              used when running the plan.
 
         Returns:
             Plan: The plan for executing the query.
@@ -343,9 +343,9 @@ class Portia:
               storage.
             end_user (str | EndUser | None = None): The end user to use.
             plan_run_inputs (list[PlanInput] | list[dict[str, Serializable]] | dict[str, Serializable] | None):
-              Optional dictionary mapping PlanInput objects to their values. This can be a list of
-              Planinput objects, a list of dicts with keys "name", "description" (optional) and
-              "value", or a dict of plan run input name to value.
+              Provides input values for the run. This can be a list of PlanInput objects, a list
+              of dicts with keys "name", "description" (optional) and "value", or a dict of
+              plan run input name to value.
 
         Returns:
             PlanRun: The resulting PlanRun object.

--- a/portia/storage.py
+++ b/portia/storage.py
@@ -846,7 +846,11 @@ class PortiaCloudStorage(Storage, AgentMemory):
                     "query": plan.plan_context.query,
                     "tool_ids": plan.plan_context.tool_ids,
                     "steps": [step.model_dump(mode="json") for step in plan.steps],
-                    "inputs": [input_.model_dump(mode="json") for input_ in plan.inputs],
+                    "plan_inputs": [
+                        # TODO (RH): Remove this once backend is updated to make description optional
+                        {**input_.model_dump(mode="json"), "description": input_.description or ""}
+                        for input_ in plan.plan_inputs
+                    ],
                 },
             )
         except Exception as e:
@@ -1019,7 +1023,7 @@ class PortiaCloudStorage(Storage, AgentMemory):
                     "latency_seconds": tool_call.latency_seconds,
                 },
             )
-        except Exception as e: # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
             logger().error(f"Error saving tool call to Portia Cloud: {e}")
         else:
             # Don't raise an error if the response is not successful, just log it

--- a/portia/storage.py
+++ b/portia/storage.py
@@ -856,7 +856,7 @@ class PortiaCloudStorage(Storage, AgentMemory):
                     "tool_ids": plan.plan_context.tool_ids,
                     "steps": [step.model_dump(mode="json") for step in plan.steps],
                     "plan_inputs": [
-                        # TODO (RH): Remove this once backend is updated to make description optional
+                        # TODO (RH): Remove this once backend is updated to make description optional  # noqa: E501, FIX002, TD003
                         {**input_.model_dump(mode="json"), "description": input_.description or ""}
                         for input_ in plan.plan_inputs
                     ],

--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -12,7 +12,7 @@
      - DO NOT mention the tool you will use in the task description, but MAKE SURE to use it in the tool_id field.
      - Additional information about the caller is provided in the EndUser section. You can use this if the query refers to the end user, i.e. Send me an email.
      - IMPORTANT: MAKE SURE to not provide examples or assumptions in the task description.
-    IMPORTANT: If you can't come up with a plan provide a descriptive error instead - DO NOT create a plan with zero steps. When returning an error, return only only the JSON object with the error message filled in - DO NOT include text (explaining the error or otherwise) outside of the JSON object.
+    IMPORTANT: If you can't come up with a plan provide a descriptive error instead - DO NOT create a plan with zero steps. When returning an error, return only the JSON object with the error message filled in - DO NOT include text (explaining the error or otherwise) outside the JSON object.
     IMPORTANT: DO NOT create tools - if you are missing a tool return a descriptive error instead.
     {% if plan_inputs %}IMPORTANT: Values for plan inputs will be provided when the plan is executed, so make sure to use them in your steps appropriately.{% endif %}
 </Instructions>

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -578,15 +578,19 @@ def test_portia_plan_steps_inputs_dependencies(
     assert "100" in str(plan.steps[3].condition), "Fourth step condition does not contain 100"
 
 
-def test_plan_input_with_schema_validation() -> None:
-    """Test running a plan with schema-validated plan inputs."""
+def test_plan_inputs() -> None:
+    """Test running a plan with plan inputs."""
 
     class AdditionNumbers(BaseModel):
         num_a: int = Field(description="First number to add")
         num_b: int = Field(description="Second number to add")
 
-    numbers_input = PlanInput(name="$numbers", description="Numbers to add")
-    plan_inputs = {numbers_input: AdditionNumbers(num_a=5, num_b=7)}
+    numbers_input = PlanInput(
+        name="$numbers",
+        description="Numbers to add",
+        value=AdditionNumbers(num_a=5, num_b=7),
+    )
+    plan_inputs = [numbers_input]
 
     config = Config.from_default(
         default_log_level=LogLevel.DEBUG,
@@ -595,7 +599,7 @@ def test_plan_input_with_schema_validation() -> None:
     portia = Portia(config=config, tools=ToolRegistry([AdditionTool()]))
     plan = portia.plan(
         "Use the addition tool to add together the two provided numbers",
-        plan_inputs=[numbers_input],
+        plan_inputs=plan_inputs,
     )
     plan_run = portia.run_plan(plan, plan_run_inputs=plan_inputs)
 

--- a/tests/unit/planning_agents/test_default_planning_agent.py
+++ b/tests/unit/planning_agents/test_default_planning_agent.py
@@ -114,7 +114,7 @@ def test_render_prompt() -> None:
                     output="$plan_output1",
                 ),
             ],
-            inputs=[plan_input],
+            plan_inputs=[plan_input],
         ),
     ]
     rendered_prompt = render_prompt_insert_defaults(

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -21,7 +21,7 @@ def test_plan_serialization() -> None:
     plan, _ = get_test_plan_run()
     assert str(plan) == (
         f"PlanModel(id={plan.id!r},plan_context={plan.plan_context!r}, steps={plan.steps!r}, "
-        f"inputs={plan.inputs!r}"
+        f"inputs={plan.plan_inputs!r}"
     )
     # check we can also serialize to JSON
     plan.model_dump_json()
@@ -143,7 +143,7 @@ def test_pretty_print() -> None:
                 condition="x > 10",
             ),
         ],
-        inputs=[PlanInput(name="$input", description="test input")],
+        plan_inputs=[PlanInput(name="$input", description="test input")],
     )
     output = plan.pretty_print()
     assert isinstance(output, str)
@@ -161,9 +161,9 @@ def test_plan_builder_with_plan_input() -> None:
         .build()
     )
 
-    assert len(plan.inputs) == 1
-    assert plan.inputs[0].name == "$person"
-    assert plan.inputs[0].description == "Person's information"
+    assert len(plan.plan_inputs) == 1
+    assert plan.plan_inputs[0].name == "$person"
+    assert plan.plan_inputs[0].description == "Person's information"
 
 
 def test_plan_inputs_must_be_unique() -> None:
@@ -172,7 +172,7 @@ def test_plan_inputs_must_be_unique() -> None:
         Plan(
             plan_context=PlanContext(query="test query", tool_ids=["tool1"]),
             steps=[Step(task="test task", output="$output")],
-            inputs=[
+            plan_inputs=[
                 PlanInput(name="$duplicate", description="First input"),
                 PlanInput(name="$duplicate", description="Second input with same name"),
             ],

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -1315,6 +1315,7 @@ def test_portia_initialize_end_user(portia: Portia) -> None:
         [
             {"incorrect_key": "$num_a", "error": "Error"},
         ],
+        "error",
     ],
 )
 def test_portia_run_with_plan_run_inputs(
@@ -1342,7 +1343,7 @@ def test_portia_run_with_plan_run_inputs(
     mock_summarizer_agent = mock.MagicMock()
     mock_summarizer_agent.create_summary.side_effect = "Summary"
 
-    if (
+    if plan_run_inputs == "error" or (
         isinstance(plan_run_inputs, list)
         and isinstance(plan_run_inputs[0], dict)
         and "error" in plan_run_inputs[0]
@@ -1388,6 +1389,7 @@ def test_portia_run_with_plan_run_inputs(
         [
             {"incorrect_key": "$num_a", "error": "Error"},
         ],
+        "error",
     ],
 )
 def test_portia_plan_with_plan_inputs(
@@ -1411,7 +1413,11 @@ def test_portia_plan_with_plan_inputs(
         error=None,
     )
 
-    if isinstance(plan_inputs[0], dict) and "error" in plan_inputs[0]:
+    if plan_inputs == "error" or (
+        isinstance(plan_inputs, list)
+        and isinstance(plan_inputs[0], dict)
+        and "error" in plan_inputs[0]
+    ):
         with pytest.raises(ValueError):  # noqa: PT011
             portia.plan(
                 query="Use these inputs to do something",
@@ -1452,6 +1458,7 @@ def test_portia_plan_with_plan_inputs(
         [
             {"incorrect_key": "$num_a", "error": "Error"},
         ],
+        "error",
     ],
 )
 def test_portia_run_plan_with_plan_run_inputs(
@@ -1481,7 +1488,7 @@ def test_portia_run_plan_with_plan_run_inputs(
     mock_agent = MagicMock()
     mock_agent.execute_sync.return_value = LocalDataValue(value=3)
 
-    if (
+    if plan_run_inputs == "error" or (
         isinstance(plan_run_inputs, list)
         and isinstance(plan_run_inputs[0], dict)
         and "error" in plan_run_inputs[0]

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -1291,11 +1291,32 @@ def test_portia_initialize_end_user(portia: Portia) -> None:
     assert storage_end_user.name == "Bob Smith"
 
 
-def test_portia_run_with_plan_run_inputs(portia: Portia, planning_model: MagicMock) -> None:
-    """Test that Portia.run handles plan inputs correctly."""
-    num_a_input = PlanInput(name="$num_a", description="Number A")
-    num_b_input = PlanInput(name="$num_b", description="Number B")
-
+@pytest.mark.parametrize(
+    "plan_run_inputs",
+    [
+        [
+            PlanInput(name="$num_a", description="Number A", value=1),
+            PlanInput(name="$num_b", value=2),
+        ],
+        [
+            {"name": "$num_a", "description": "Number A", "value": 1},
+            {"name": "$num_b", "value": 2},
+        ],
+        {
+            "$num_a": 1,
+            "$num_b": 2,
+        },
+        [
+            {"incorrect_key": "$num_a", "error": "Error"},
+        ],
+    ],
+)
+def test_portia_run_with_plan_run_inputs(
+    portia: Portia,
+    planning_model: MagicMock,
+    plan_run_inputs,
+) -> None:
+    """Test that Portia.run handles plan inputs correctly in different formats."""
     planning_model.get_structured_response.return_value = StepsOrError(
         steps=[
             Step(
@@ -1303,7 +1324,7 @@ def test_portia_run_with_plan_run_inputs(portia: Portia, planning_model: MagicMo
                 tool_id="add_tool",
                 inputs=[
                     Variable(name="$num_a", description="Number A"),
-                    Variable(name="$num_b", description="Number B"),
+                    Variable(name="$num_b", description=""),
                 ],
                 output="$output",
             ),
@@ -1315,6 +1336,14 @@ def test_portia_run_with_plan_run_inputs(portia: Portia, planning_model: MagicMo
     mock_summarizer_agent = mock.MagicMock()
     mock_summarizer_agent.create_summary.side_effect = "Summary"
 
+    if isinstance(plan_run_inputs, list) and "error" in plan_run_inputs[0]:
+        with pytest.raises(ValueError):
+            portia.run(
+                query="Add the two numbers together",
+                plan_run_inputs=plan_run_inputs,
+            )
+        return
+
     with (
         mock.patch(
             "portia.portia.FinalOutputSummarizer",
@@ -1324,10 +1353,7 @@ def test_portia_run_with_plan_run_inputs(portia: Portia, planning_model: MagicMo
     ):
         plan_run = portia.run(
             query="Add the two numbers together",
-            plan_run_inputs={
-                num_a_input: 1,
-                num_b_input: 2,
-            },
+            plan_run_inputs=plan_run_inputs,
         )
 
     planning_model.get_structured_response.assert_called_once()
@@ -1337,11 +1363,29 @@ def test_portia_run_with_plan_run_inputs(portia: Portia, planning_model: MagicMo
     assert plan_run.outputs.final_output.get_value() == 3
 
 
-def test_portia_plan_with_plan_inputs(portia: Portia, planning_model: MagicMock) -> None:
-    """Test that Portia.plan handles plan inputs correctly."""
-    num_a_input = PlanInput(name="$num_a", description="Number A")
-    num_b_input = PlanInput(name="$num_b", description="Number B")
-
+@pytest.mark.parametrize(
+    "plan_inputs",
+    [
+        [
+            PlanInput(name="$num_a", description="Number A"),
+            PlanInput(name="$num_b", description="Number B"),
+        ],
+        [
+            {"name": "$num_a", "description": "Number A"},
+            {"name": "$num_b"},
+        ],
+        ["$num_a", "$num_b"],
+        [
+            {"incorrect_key": "$num_a", "error": "Error"},
+        ],
+    ],
+)
+def test_portia_plan_with_plan_inputs(
+    portia: Portia,
+    planning_model: MagicMock,
+    plan_inputs,
+) -> None:
+    """Test that Portia.plan handles plan inputs correctly in different formats."""
     planning_model.get_structured_response.return_value = StepsOrError(
         steps=[
             Step(
@@ -1357,25 +1401,51 @@ def test_portia_plan_with_plan_inputs(portia: Portia, planning_model: MagicMock)
         error=None,
     )
 
+    if "error" in plan_inputs[0]:
+        with pytest.raises(ValueError):
+            portia.plan(
+                query="Use these inputs to do something",
+                plan_inputs=plan_inputs,
+                tools=[AdditionTool()],
+            )
+        return
+
     plan = portia.plan(
         query="Use these inputs to do something",
-        plan_inputs=[num_a_input, num_b_input],
+        plan_inputs=plan_inputs,
         tools=[AdditionTool()],
     )
 
-    assert len(plan.inputs) == 2
-    assert any(input_.name == "$num_a" for input_ in plan.inputs)
-    assert any(input_.name == "$num_b" for input_ in plan.inputs)
+    assert len(plan.plan_inputs) == 2
+    assert any(input_.name == "$num_a" for input_ in plan.plan_inputs)
+    assert any(input_.name == "$num_b" for input_ in plan.plan_inputs)
     assert len(plan.steps) == 1
     assert any(input_.name == "$num_a" for input_ in plan.steps[0].inputs)
     assert any(input_.name == "$num_b" for input_ in plan.steps[0].inputs)
 
 
-def test_portia_run_plan_with_plan_run_inputs(portia: Portia) -> None:
-    """Test that run_plan correctly handles plan inputs."""
-    num_a_input = PlanInput(name="$num_a", description="First number to add")
-    num_b_input = PlanInput(name="$num_b", description="Second number to add")
-
+@pytest.mark.parametrize(
+    "plan_run_inputs",
+    [
+        [
+            PlanInput(name="$num_a", description="First number to add", value=1),
+            PlanInput(name="$num_b", description="Second number to add", value=2),
+        ],
+        [
+            {"name": "$num_a", "description": "First number to add", "value": 1},
+            {"name": "$num_b", "description": "Second number to add", "value": 2},
+        ],
+        {
+            "$num_a": 1,
+            "$num_b": 2,
+        },
+        [
+            {"incorrect_key": "$num_a", "error": "Error"},
+        ],
+    ],
+)
+def test_portia_run_plan_with_plan_run_inputs(portia: Portia, plan_run_inputs) -> None:
+    """Test that run_plan correctly handles plan inputs in different formats."""
     plan = Plan(
         plan_context=PlanContext(query="Add two numbers", tool_ids=["add_tool"]),
         steps=[
@@ -1389,13 +1459,19 @@ def test_portia_run_plan_with_plan_run_inputs(portia: Portia) -> None:
                 output="$result",
             ),
         ],
-        inputs=[num_a_input, num_b_input],
+        plan_inputs=[
+            PlanInput(name="$num_a", description="First number to add"),
+            PlanInput(name="$num_b", description="Second number to add"),
+        ],
     )
-
-    plan_run_inputs = {num_a_input: 1, num_b_input: 2}
 
     mock_agent = MagicMock()
     mock_agent.execute_sync.return_value = LocalDataValue(value=3)
+
+    if isinstance(plan_run_inputs, list) and "error" in plan_run_inputs[0]:
+        with pytest.raises(ValueError):
+            portia.run_plan(plan, plan_run_inputs=plan_run_inputs)
+        return
 
     # Mock the get_agent_for_step method to return our mock agent
     with mock.patch.object(portia, "_get_agent_for_step", return_value=mock_agent):
@@ -1411,8 +1487,8 @@ def test_portia_run_plan_with_plan_run_inputs(portia: Portia) -> None:
 
 def test_portia_run_plan_with_missing_inputs(portia: Portia) -> None:
     """Test that run_plan raises error when required inputs are missing."""
-    required_input1 = PlanInput(name="$required1", description="Required input 1")
-    required_input2 = PlanInput(name="$required2", description="Required input 2")
+    required_input1 = PlanInput(name="$required1", description="Required input 1", value="value 1")
+    required_input2 = PlanInput(name="$required2", description="Required input 2", value="value 2")
 
     plan = Plan(
         plan_context=PlanContext(query="Plan requiring inputs", tool_ids=["add_tool"]),
@@ -1427,25 +1503,22 @@ def test_portia_run_plan_with_missing_inputs(portia: Portia) -> None:
                 output="$result",
             ),
         ],
-        inputs=[required_input1, required_input2],
+        plan_inputs=[required_input1, required_input2],
     )
 
     # Try to run the plan without providing required inputs
     with pytest.raises(ValueError):  # noqa: PT011
-        portia.run_plan(plan, plan_run_inputs={})
+        portia.run_plan(plan, plan_run_inputs=[])
 
     # Should fail with just one of the two required
     with pytest.raises(ValueError):  # noqa: PT011
-        portia.run_plan(plan, plan_run_inputs={required_input1: "value"})
+        portia.run_plan(plan, plan_run_inputs=[required_input1])
 
     # Should work if we provide both required inputs
     with mock.patch.object(portia, "resume") as mock_resume:
         portia.run_plan(
             plan,
-            plan_run_inputs={
-                required_input1: "value 1",
-                required_input2: "value 2",
-            },
+            plan_run_inputs=[required_input1, required_input2],
         )
         mock_resume.assert_called_once()
 
@@ -1456,18 +1529,20 @@ def test_portia_run_plan_with_extra_input_when_expecting_none(portia: Portia) ->
     plan = Plan(
         plan_context=PlanContext(query="Plan with no inputs", tool_ids=["add_tool"]),
         steps=[],
-        inputs=[],  # No inputs required
+        plan_inputs=[],  # No inputs required
     )
 
     # Run with input that isn't in the plan's inputs
-    extra_input = PlanInput(name="$extra", description="Extra unused input")
-    plan_run = portia.run_plan(plan, plan_run_inputs={extra_input: "value"})
+    extra_input = PlanInput(name="$extra", description="Extra unused input", value="value")
+    plan_run = portia.run_plan(plan, plan_run_inputs=[extra_input])
     assert plan_run.plan_run_inputs == {}
 
 
 def test_portia_run_plan_with_additional_extra_input(portia: Portia) -> None:
     """Test that run_plan ignores unknown inputs."""
-    expected_input = PlanInput(name="$expected", description="Expected input")
+    expected_input = PlanInput(
+        name="$expected", description="Expected input", value="expected_value"
+    )
 
     plan = Plan(
         plan_context=PlanContext(query="Plan with specific input", tool_ids=["add_tool"]),
@@ -1481,24 +1556,20 @@ def test_portia_run_plan_with_additional_extra_input(portia: Portia) -> None:
                 output="$result",
             ),
         ],
-        inputs=[expected_input],
+        plan_inputs=[expected_input],
     )
 
-    unknown_input = PlanInput(name="$unknown", description="Unknown input")
+    unknown_input = PlanInput(name="$unknown", description="Unknown input", value="unknown_value")
 
     with mock.patch.object(portia, "resume") as mock_resume:
         mock_resume.side_effect = lambda x: x
         plan_run = portia.run_plan(
             plan,
-            plan_run_inputs={
-                expected_input: "expected_value",
-                unknown_input: "unknown_value",
-            },
+            plan_run_inputs=[expected_input, unknown_input],
         )
 
-        assert "$expected" in plan_run.plan_run_inputs
+        assert len(plan_run.plan_run_inputs) == 1
         assert plan_run.plan_run_inputs["$expected"].get_value() == "expected_value"
-        assert "$unknown" not in plan_run.plan_run_inputs
         mock_resume.assert_called_once()
 
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -226,7 +226,7 @@ def test_portia_cloud_storage() -> None:
         id=PlanUUID(uuid=UUID("12345678-1234-5678-1234-567812345678")),
         plan_context=PlanContext(query="", tool_ids=[]),
         steps=[],
-        inputs=[
+        plan_inputs=[
             PlanInput(name="key1", description="Test input 1"),
             PlanInput(name="key2", description="Test input 2"),
         ],
@@ -263,9 +263,9 @@ def test_portia_cloud_storage() -> None:
                 "steps": [],
                 "query": plan.plan_context.query,
                 "tool_ids": plan.plan_context.tool_ids,
-                "inputs": [
-                    {"name": "key1", "description": "Test input 1"},
-                    {"name": "key2", "description": "Test input 2"},
+                "plan_inputs": [
+                    {"name": "key1", "description": "Test input 1", "value": None},
+                    {"name": "key2", "description": "Test input 2", "value": None},
                 ],
             },
         )
@@ -411,7 +411,7 @@ def test_portia_cloud_storage_errors() -> None:
                 "steps": [],
                 "query": plan.plan_context.query,
                 "tool_ids": plan.plan_context.tool_ids,
-                "inputs": [],
+                "plan_inputs": [],
             },
         )
     with (


### PR DESCRIPTION
# Description

Changes after our plan inputs dogfooding session:
* Allow calling public methods with dicts
* Change PlanInput to have an optional value and use lists of them
* A few spelling tweaks in prompts
* Change plan field from `inputs` to `plan_inputs`
* Add an indent to plan pretty printing

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
