### PR TITLE
[RUN-44] Update llm_tool to handle variaty of inputs to make use of memory agent

### DIFF
--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -95,7 +95,11 @@ class LLMTool(Tool[str]):
             "tasks"
         )
 
-        task_data_str = "\n".join(task_data_list)
+        task_data_str = (
+            "\n".join(task_data_list)
+            if isinstance(task_data_list, list)
+            else str(task_data_list)
+        )
 
         task_str = task
         if task_data_str:

--- a/tests/unit/open_source_tools/test_llm_tool.py
+++ b/tests/unit/open_source_tools/test_llm_tool.py
@@ -99,7 +99,7 @@ def test_task_data_validator_with_list() -> None:
 
 def test_task_data_validator_with_dict() -> None:
     """Test that task_data validator correctly handles dictionary input."""
-    schema = LLMToolSchema(task="Test task", task_data={"key": "value"})
+    schema = LLMToolSchema(task="Test task", task_data={"key": "value"}) # type: ignore reportArgumentType
     assert schema.task_data == ["{'key': 'value'}"]
 
 

--- a/tests/unit/open_source_tools/test_llm_tool.py
+++ b/tests/unit/open_source_tools/test_llm_tool.py
@@ -39,10 +39,11 @@ def test_llm_tool_plan_run(
 
 def test_llm_tool_schema_valid_input() -> None:
     """Test that the LLMToolSchema correctly validates the input."""
-    schema_data = {"task": "Solve a math problem", "input_data": ["1 + 1 = 2"]}
+    schema_data = {"task": "Solve a math problem", "task_data": ["1 + 1 = 2"]}
     schema = LLMToolSchema(**schema_data)
 
     assert schema.task == "Solve a math problem"
+    assert schema.task_data == ["1 + 1 = 2"]
 
 
 def test_llm_tool_schema_missing_task() -> None:
@@ -82,3 +83,38 @@ def test_llm_tool_run_with_context(
     assert task in called_with[1].content
     # Assert the result is the expected response
     assert result == "Test response content"
+
+
+def test_task_data_validator_with_string() -> None:
+    """Test that task_data validator correctly handles string input."""
+    schema = LLMToolSchema(task="Test task", task_data="String data")
+    assert schema.task_data == ["String data"]
+
+
+def test_task_data_validator_with_list() -> None:
+    """Test that task_data validator correctly handles list input."""
+    schema = LLMToolSchema(task="Test task", task_data=["Item 1", "Item 2"])
+    assert schema.task_data == ["Item 1", "Item 2"]
+
+
+def test_task_data_validator_with_dict() -> None:
+    """Test that task_data validator correctly handles dictionary input."""
+    schema = LLMToolSchema(task="Test task", task_data={"key": "value"})
+    assert schema.task_data == ["{'key': 'value'}"]
+
+
+def test_task_data_validator_with_none() -> None:
+    """Test that task_data validator correctly handles None input."""
+    schema = LLMToolSchema(task="Test task", task_data=None)
+    assert schema.task_data == []
+
+
+def test_task_data_validator_with_complex_objects() -> None:
+    """Test that task_data validator correctly handles complex objects."""
+    class TestObject:
+        def __str__(self) -> str:
+            return "TestObject"
+
+    schema = LLMToolSchema(task="Test task", task_data=[TestObject(), {"nested": "value"}])
+    assert schema.task_data == ["TestObject", "{'nested': 'value'}"]
+

--- a/tests/unit/open_source_tools/test_llm_tool.py
+++ b/tests/unit/open_source_tools/test_llm_tool.py
@@ -85,36 +85,28 @@ def test_llm_tool_run_with_context(
     assert result == "Test response content"
 
 
-def test_task_data_validator_with_string() -> None:
-    """Test that task_data validator correctly handles string input."""
-    schema = LLMToolSchema(task="Test task", task_data="String data")
-    assert schema.task_data == ["String data"]
+def test_process_task_data_with_string() -> None:
+    """Test that process_task_data correctly handles string input."""
+    result = LLMTool.process_task_data("String data")
+    assert result == "String data"
 
 
-def test_task_data_validator_with_list() -> None:
-    """Test that task_data validator correctly handles list input."""
-    schema = LLMToolSchema(task="Test task", task_data=["Item 1", "Item 2"])
-    assert schema.task_data == ["Item 1", "Item 2"]
+def test_process_task_data_with_list() -> None:
+    """Test that process_task_data correctly handles list input."""
+    result = LLMTool.process_task_data(["Item 1", "Item 2"])
+    assert result == "Item 1\nItem 2"
+
+def test_process_task_data_with_none() -> None:
+    """Test that process_task_data correctly handles None input."""
+    result = LLMTool.process_task_data(None)
+    assert result == ""
 
 
-def test_task_data_validator_with_dict() -> None:
-    """Test that task_data validator correctly handles dictionary input."""
-    schema = LLMToolSchema(task="Test task", task_data={"key": "value"}) # type: ignore reportArgumentType
-    assert schema.task_data == ["{'key': 'value'}"]
-
-
-def test_task_data_validator_with_none() -> None:
-    """Test that task_data validator correctly handles None input."""
-    schema = LLMToolSchema(task="Test task", task_data=None)
-    assert schema.task_data == []
-
-
-def test_task_data_validator_with_complex_objects() -> None:
-    """Test that task_data validator correctly handles complex objects."""
+def test_process_task_data_with_complex_objects() -> None:
+    """Test that process_task_data correctly handles complex objects."""
     class TestObject:
         def __str__(self) -> str:
             return "TestObject"
 
-    schema = LLMToolSchema(task="Test task", task_data=[TestObject(), {"nested": "value"}])
-    assert schema.task_data == ["TestObject", "{'nested': 'value'}"]
-
+    result = LLMTool.process_task_data([TestObject(), {"nested": "value"}])
+    assert result == "TestObject\n{'nested': 'value'}"


### PR DESCRIPTION
# Description

The current input for the `llm_tool` is forcing gemini model (2.0 flash) to try to parse the big input (search results) into list of str in tool agent node, which is causing `MALFORMED_FUNCTION_CALL` ([example](https://smith.langchain.com/o/e2eb5117-7ff4-446a-b9ac-b768f33886e1/projects/p/500223c8-b833-4853-9ef6-0016c236461a?timeModel=%7B%22duration%22%3A%227d%22%7D&peek=236f0c1b-0a8f-4471-851a-25fb629ba829&peeked_trace=ff9fa307-5d94-475e-a15a-01ee89d90c59)) for a lot of cases because of tavily search results. We need to fix this for 2.0 flash because they can't upgrade to gemini 2.5 atm.

### Fix 
I relaxed the input types for `llm_tool` to accept it as `List[Any] | str | None` instead of `List[str]` only, then handle casting it back internally to list of str in the tool itself. 

This has forced the gemini model (2.0 flash) to use input_variable name from agent memory and avoid parsing the input itself when producing tool calling for llm_tool ([example](https://smith.langchain.com/o/e2eb5117-7ff4-446a-b9ac-b768f33886e1/projects/p/500223c8-b833-4853-9ef6-0016c236461a?timeModel=%7B%22duration%22%3A%227d%22%7D&peek=f4d265cc-f0d5-4cfb-878b-2497fe8afc78&peeked_trace=c6877734-7d2b-49b8-a1e2-f9eaf10990a5)). 

1) The response is much faster for the tool calling agent node (thanks to agent memory) and ;
2) Reducing the chance of getting `MALFORMED_FUNCTION_CALL` (got 100% accuracy for couple for runs consecutively). Also tested with openai models and got the same results.
 

Ticket Link:  https://linear.app/portialabs/issue/RUN-44/tunic-issues-with-running-long-plan
## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
