### PR TITLE
Prevent logging errors

### DIFF
--- a/portia/logger.py
+++ b/portia/logger.py
@@ -120,10 +120,10 @@ class Formatter:
 
     def _sanitize_message_(self, msg: str) -> str:
         """Sanitize a message to be used in a log record."""
-        # doubles opening curly braces in a string { -> {{
-        msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
-        # doubles closing curly braces in a string } -> }}
-        msg = re.sub(r"(?<!\})\}(?!\})", "}}", msg)
+        # doubles any single opening curly braces in a string { -> {{
+        msg = re.sub(r"\{", "{{", msg)
+        # doubles any single closing curly braces in a string } -> }}
+        msg = re.sub(r"\}", "}}", msg)
         # escapes < and > in a string
         msg = msg.replace("<", r"\<").replace(">", r"\>")
 

--- a/portia/tool_wrapper.py
+++ b/portia/tool_wrapper.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from portia.plan_run import PlanRun
 
 
+MAX_OUTPUT_LOG_LENGTH = 1000
+
+
 class ToolCallWrapper(Tool):
     """Tool Wrapper that records calls to its child tool and sends them to the AdditionalStorage.
 
@@ -103,8 +106,14 @@ class ToolCallWrapper(Tool):
             end_user_id=ctx.end_user.external_id,
             status=ToolCallStatus.IN_PROGRESS,
         )
+        input_str = repr(record.input)
+        truncated_input = (
+            input_str[:MAX_OUTPUT_LOG_LENGTH] + "...[truncated - only first 1000 characters shown]"
+            if len(input_str) > MAX_OUTPUT_LOG_LENGTH
+            else input_str
+        )
         logger().info(
-            f"Invoking {record.tool_name} with args: {record.input}",
+            f"Invoking {record.tool_name!s} with args: {truncated_input}",
         )
         start_time = datetime.now(tz=UTC)
         try:


### PR DESCRIPTION
# Description

Without this, I was seeing loguru errors with e.g.

```
Traceback (most recent call last):
  File "/Users/robbieheywood/Library/Caches/pypoetry/virtualenvs/portia-sdk-python-Dp6bM8CF-py3.13/lib/python3.13/site-packages/loguru/_handler.py", line 164, in emit
    _, precomputed_format = self._memoize_dynamic_format(dynamic_format, ansi_level)
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/robbieheywood/Library/Caches/pypoetry/virtualenvs/portia-sdk-python-Dp6bM8CF-py3.13/lib/python3.13/site-packages/loguru/_handler.py", line 14, in prepare_colored_format
    colored = Colorizer.prepare_format(format_)
  File "/Users/robbieheywood/Library/Caches/pypoetry/virtualenvs/portia-sdk-python-Dp6bM8CF-py3.13/lib/python3.13/site-packages/loguru/_colorizer.py", line 367, in prepare_format
    tokens, messages_color_tokens = Colorizer._parse_without_formatting(string)
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/robbieheywood/Library/Caches/pypoetry/virtualenvs/portia-sdk-python-Dp6bM8CF-py3.13/lib/python3.13/site-packages/loguru/_colorizer.py", line 455, in _parse_without_formatting
    for literal_text, field_name, format_spec, conversion in formatter.parse(string):
                                                             ~~~~~~~~~~~~~~~^^^^^^^^
ValueError: Single '}' encountered in format string
```

I'm not sure why as I thought we were meant to catch errors now. This was the only way I could find to fix it.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
