### PR TITLE
Only show end-user info to planning agent if it exists

### DIFF
--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -69,8 +69,8 @@ IMPORTANT GUIDELINES:
  error or otherwise) outside the JSON object.
 - Information provided in the EndUser block will also be provided at execution so you do not need to
  add inputs for this information. However if information about the EndUser is not available now
- it will NOT be available later and you should return an error. For example if a plan requires
- using EndUser.Email but no email is provided please return an error.
+ it will also NOT be available later and you should return an error if it is required and there is
+ no other way to retrieve the information.
 - For EVERY tool that requires an id as an input, make sure to check
  if there's a corresponding tool call that provides the id from natural language if possible.
  For example, if a tool asks for a user ID check if there's a tool call that provides

--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -45,10 +45,18 @@
 </Tools>
 
 <EndUser>
+    {% if end_user.email %}
     <EndUser.Email>{{ end_user.email }}</EndUser.Email>
+    {% endif %}
+    {% if end_user.name %}
     <EndUser.Name>{{ end_user.name }}</EndUser.Name>
+    {% endif %}
+    {% if end_user.phone_number %}
     <EndUser.PhoneNumber>{{ end_user.phone_number }}</EndUser.PhoneNumber>
+    {% endif %}
+    {% if end_user.additional_data %}
     <EndUser.AdditionalData>{{ end_user.additional_data }}</EndUser.AdditionalData>
+    {% endif %}
 </EndUser>
 
 {% if plan_inputs %}


### PR DESCRIPTION
# Description

In the evals (example: https://smith.langchain.com/o/e2eb5117-7ff4-446a-b9ac-b768f33886e1/datasets/819a5146-d5e9-42a0-a585-f95d02e37460/compare?selectedSessions=664a6204-950f-47ed-b1d0-3e4c15ce482b&baseline=undefined&sort_by=is_plan_generated&sort_order=ASC), we're seeing a few responses like:

`{"steps":[],"error":"Missing required end user email. The query requires scheduling a calendar event which needs the user's email address to check availability and create the event, but no email address was provided in the EndUser section."}`

This is because we don't set this info for the end user the evals are running with. I think this should fix that.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
