### PR TITLE
Use backport typing @override for python < 3.12

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 from unittest.mock import MagicMock
 
 from langchain_core.language_models.chat_models import BaseChatModel

--- a/uv.lock
+++ b/uv.lock
@@ -1641,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.3.6a0"
+version = "0.3.7a0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Fixes bug in tests for python 3.11 

```
Traceback:
tests/unit/test_tool.py:23: in <module>
    from tests.utils import (
tests/utils.py:6: in <module>
    from typing import TYPE_CHECKING, Any, override
E   ImportError: cannot import name 'override' from 'typing' (/Users/samstephens/.local/share/uv/python/cpython-3.11.11-macos-aarch64-none/lib/python3.11/typing.py)
```

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
