### PR TITLE
Sort execution agent email fussiness

### DIFF
--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -118,6 +118,10 @@ class VerifiedToolArgument(BaseModel):
         "Should be false if the value was provided by the user, even if in a different format."
         "User provided values can be in the context, in the goal or the result of previous steps.",
     )
+    explanation: str | None = Field(
+        default=None,
+        description="The reason the value was judged to be made up or not.",
+    )
 
     schema_invalid: bool = Field(
         default=False,
@@ -345,6 +349,7 @@ class VerifierModel:
                 "  name: str  # Name of the argument requested by the tool.\n"
                 "  value: Any | None  # Value of the argument from the goal or context. "
                 "USE EXACTLY the type of the argument provided in the list of arguments provided.\n"
+                "  explanation: str # The reason the value was judged to be made up or not\n"
                 "  made_up: bool  # if the value is made_up based on the given rules.\n\n"
                 "class VerifiedToolInputs:\n"
                 "  args: List[VerifiedToolArgument]  # List of tool arguments.\n\n"
@@ -355,7 +360,8 @@ class VerifierModel:
                 "\n\n----------\n\n"
                 "Context for user input and past steps:"
                 "\n{context}\n"
-                "The system has a tool available named '{tool_name}'.\n"
+                "The system has a tool available named '{tool_name}' "
+                "with description: {tool_description}.\n"
                 "Argument schema for the tool:\n{tool_args}\n"
                 "\n\n----------\n\n"
                 "Label the following arguments as made up or not using the goal and context provided: {arguments}\n",  # noqa: E501
@@ -406,6 +412,7 @@ class VerifierModel:
             arguments=tool_args,
             tool_name=self.agent.tool.name,
             tool_args=self.agent.tool.args_json_schema(),
+            tool_description=self.agent.tool.description,
         )
         response = self.model.get_structured_response(
             messages=[Message.from_langchain(m) for m in formatted_messages],

--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -67,10 +67,10 @@ IMPORTANT GUIDELINES:
  create a plan with zero steps. When returning an error, return only the JSON object with
  the error message filled in plus an empty list of steps - DO NOT include text (explaining the
  error or otherwise) outside the JSON object.
-- Information provided in the EndUser block will also be provided at execution so you do not need to
- add inputs for this information. However if information about the EndUser is not available now
- it will also NOT be available later and you should return an error if it is required and there is
- no other way to retrieve the information.
+- If information is provided in the EndUser block, it will also be provided at execution so you do
+ not need to add inputs for this information. However if information about the EndUser is not
+ available now it will also NOT be available later and you should return an error if it is required
+ and there is no other way to retrieve the information.
 - For EVERY tool that requires an id as an input, make sure to check
  if there's a corresponding tool call that provides the id from natural language if possible.
  For example, if a tool asks for a user ID check if there's a tool call that provides

--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -10,7 +10,7 @@
      - Make sure all IDs and URLs from the query are included in the task description as they are, and do not calculate/assume any data yourself.
      - give a name to the variable for the output of the step if it is successful.
      - DO NOT mention the tool you will use in the task description, but MAKE SURE to use it in the tool_id field.
-     - Additional information about the caller is provided in the EndUser section. You can use this if the query refers to the end user, i.e. Send me an email.
+     - Additional information about the caller can be provided in the EndUser section. You can use this if the query refers to the end user, i.e. Send me an email.
      - IMPORTANT: MAKE SURE to not provide examples or assumptions in the task description.
     IMPORTANT: If you can't come up with a plan provide a descriptive error instead - DO NOT create a plan with zero steps. When returning an error, return only the JSON object with the error message filled in plus an empty list of steps - DO NOT include text (explaining the error or otherwise) outside the JSON object.
     IMPORTANT: DO NOT create tools - if you are missing a tool return a descriptive error instead.
@@ -44,6 +44,7 @@
     </Tool>{% endfor %}
 </Tools>
 
+{% if end_user.email or end_user.name or end_user.phone_number or end_user.additional_data %}
 <EndUser>
     {% if end_user.email %}
     <EndUser.Email>{{ end_user.email }}</EndUser.Email>
@@ -58,6 +59,7 @@
     <EndUser.AdditionalData>{{ end_user.additional_data }}</EndUser.AdditionalData>
     {% endif %}
 </EndUser>
+{% endif %}
 
 {% if plan_inputs %}
 <PlanInputs>{% for input in plan_inputs %}

--- a/tests/unit/execution_agents/test_default_execution_agent.py
+++ b/tests/unit/execution_agents/test_default_execution_agent.py
@@ -444,7 +444,7 @@ def test_verifier_model() -> None:
     assert "CONTEXT_STRING" in messages[1].content  # type: ignore  # noqa: PGH003
     assert "DESCRIPTION_STRING" in messages[1].content  # type: ignore  # noqa: PGH003
     assert "TOOL_NAME" in messages[1].content  # type: ignore  # noqa: PGH003
-    assert "TOOL_DESCRIPTION" not in messages[1].content  # type: ignore  # noqa: PGH003
+    assert "TOOL_DESCRIPTION" in messages[1].content  # type: ignore  # noqa: PGH003
     assert "INPUT_DESCRIPTION" in messages[1].content  # type: ignore  # noqa: PGH003
     assert mock_model.with_structured_output.called
     assert mock_model.with_structured_output.call_args[0][0] == VerifiedToolInputs


### PR DESCRIPTION
# Description

Interestingly, adding explanation before it chooses the made_up field essentially works as a chain of thought, which helps it get the right answer. Adding the tool description also helps.
I've also included a couple of end user fixes - these are what is needed to get https://github.com/portiaAI/platform/pull/462 in (occasionally things break because the agent thinks there is an issue when it is passed an empty end user bock).

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
