### PR TITLE
Fix CLI for azure and google providers, rename enum `GOOGLE_GENERATIVE_AI` to `GOOGLE`

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -137,15 +137,15 @@ class LLMModel(Enum):
 
     # Google Generative AI
     GEMINI_2_0_FLASH = Model(
-        provider=LLMProvider.GOOGLE_GENERATIVE_AI,
+        provider=LLMProvider.GOOGLE,
         model_name="gemini-2.0-flash",
     )
     GEMINI_2_0_FLASH_LITE = Model(
-        provider=LLMProvider.GOOGLE_GENERATIVE_AI,
+        provider=LLMProvider.GOOGLE,
         model_name="gemini-2.0-flash-lite",
     )
     GEMINI_1_5_FLASH = Model(
-        provider=LLMProvider.GOOGLE_GENERATIVE_AI,
+        provider=LLMProvider.GOOGLE,
         model_name="gemini-1.5-flash",
     )
 
@@ -269,7 +269,7 @@ def parse_str_to_enum(value: str | E, enum_type: type[E]) -> E:
     """
     if isinstance(value, str):
         try:
-            return enum_type[value.upper()]
+            return enum_type[value.upper().replace("-", "_")]
         except KeyError as e:
             raise InvalidConfigError(
                 value=value,
@@ -296,21 +296,21 @@ PROVIDER_DEFAULT_MODELS = {
         LLMProvider.OPENAI: "openai/o3-mini",
         LLMProvider.ANTHROPIC: "anthropic/claude-3-7-sonnet-latest",
         LLMProvider.MISTRALAI: "mistralai/mistral-large-latest",
-        LLMProvider.GOOGLE_GENERATIVE_AI: "google/gemini-2.0-flash",
+        LLMProvider.GOOGLE: "google/gemini-2.0-flash",
         LLMProvider.AZURE_OPENAI: "azure-openai/o3-mini",
     },
     "introspection_model": {
         LLMProvider.OPENAI: "openai/o3-mini",
         LLMProvider.ANTHROPIC: "anthropic/claude-3-7-sonnet-latest",
         LLMProvider.MISTRALAI: "mistralai/mistral-large-latest",
-        LLMProvider.GOOGLE_GENERATIVE_AI: "google/gemini-2.0-flash",
+        LLMProvider.GOOGLE: "google/gemini-2.0-flash",
         LLMProvider.AZURE_OPENAI: "azure-openai/o3-mini",
     },
     "default_model": {
         LLMProvider.OPENAI: "openai/gpt-4o",
         LLMProvider.ANTHROPIC: "anthropic/claude-3-7-sonnet-latest",
         LLMProvider.MISTRALAI: "mistralai/mistral-large-latest",
-        LLMProvider.GOOGLE_GENERATIVE_AI: "google/gemini-2.0-flash",
+        LLMProvider.GOOGLE: "google/gemini-2.0-flash",
         LLMProvider.AZURE_OPENAI: "azure-openai/gpt-4o",
     },
 }
@@ -812,7 +812,7 @@ class Config(BaseModel):
                     model_name=model_name,
                     api_key=self.must_get_api_key("mistralai_api_key"),
                 )
-            case LLMProvider.GOOGLE_GENERATIVE_AI:
+            case LLMProvider.GOOGLE | LLMProvider.GOOGLE_GENERATIVE_AI:
                 validate_extras_dependencies("google")
                 from portia.model import GoogleGenAiGenerativeModel
 
@@ -853,7 +853,7 @@ def llm_provider_default_from_api_keys(**kwargs) -> LLMProvider | None:  # noqa:
     if os.getenv("MISTRAL_API_KEY") or kwargs.get("mistralai_api_key"):
         return LLMProvider.MISTRALAI
     if os.getenv("GOOGLE_API_KEY") or kwargs.get("google_api_key"):
-        return LLMProvider.GOOGLE_GENERATIVE_AI
+        return LLMProvider.GOOGLE
     if (os.getenv("AZURE_OPENAI_API_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT")) or (
         kwargs.get("azure_openai_api_key") and kwargs.get("azure_openai_endpoint")
     ):

--- a/portia/model.py
+++ b/portia/model.py
@@ -77,7 +77,7 @@ class LLMProvider(Enum):
         OPENAI: OpenAI provider.
         ANTHROPIC: Anthropic provider.
         MISTRALAI: MistralAI provider.
-        GOOGLE_GENERATIVE_AI: Google Generative AI provider.
+        GOOGLE: Google Generative AI provider.
         AZURE_OPENAI: Azure OpenAI provider.
 
     """
@@ -85,10 +85,11 @@ class LLMProvider(Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     MISTRALAI = "mistralai"
-    GOOGLE_GENERATIVE_AI = "google"
+    GOOGLE = "google"
     AZURE_OPENAI = "azure-openai"
     CUSTOM = "custom"
     OLLAMA = "ollama"
+    GOOGLE_GENERATIVE_AI = "google"  # noqa: PIE796 - Alias for GOOGLE member
 
 
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
@@ -578,7 +579,7 @@ if validate_extras_dependencies("google", raise_error=False):
     class GoogleGenAiGenerativeModel(LangChainGenerativeModel):
         """Google Generative AI (Gemini)model implementation."""
 
-        provider: LLMProvider = LLMProvider.GOOGLE_GENERATIVE_AI
+        provider: LLMProvider = LLMProvider.GOOGLE
 
         def __init__(
             self,

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -62,7 +62,7 @@ PROVIDER_MODELS = [
         "mistralai/mistral-large-latest",
     ),
     (
-        LLMProvider.GOOGLE_GENERATIVE_AI,
+        LLMProvider.GOOGLE,
         "google/gemini-2.0-flash",
     ),
 ]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -126,7 +126,7 @@ def test_get_structured_response_steps_or_error(model_str: str, messages: list[M
 
 def test_google_gemini_temperature(messages: list[Message]) -> None:
     """Test that GoogleGenAiGenerativeModel supports setting temperature."""
-    config = Config.from_default(llm_provider=LLMProvider.GOOGLE_GENERATIVE_AI)
+    config = Config.from_default(llm_provider=LLMProvider.GOOGLE)
     model = GoogleGenAiGenerativeModel(
         model_name="gemini-2.0-flash",
         api_key=config.google_api_key,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,7 @@ from portia.config import (
     LogLevel,
     PlanningAgentType,
     StorageClass,
+    parse_str_to_enum,
 )
 from portia.errors import ConfigNotFoundError, InvalidConfigError
 from portia.model import (
@@ -528,7 +529,7 @@ def test_get_model(monkeypatch: pytest.MonkeyPatch) -> None:
         ({"OPENAI_API_KEY": "test-openai-api-key"}, LLMProvider.OPENAI),
         ({"ANTHROPIC_API_KEY": "test-anthropic-api-key"}, LLMProvider.ANTHROPIC),
         ({"MISTRAL_API_KEY": "test-mistral-api-key"}, LLMProvider.MISTRALAI),
-        ({"GOOGLE_API_KEY": "test-google-api-key"}, LLMProvider.GOOGLE_GENERATIVE_AI),
+        ({"GOOGLE_API_KEY": "test-google-api-key"}, LLMProvider.GOOGLE),
         (
             {
                 "AZURE_OPENAI_API_KEY": "test-azure-openai-api-key",
@@ -557,7 +558,7 @@ def test_llm_provider_default_from_api_keys_env_vars(
         ({"openai_api_key": "test-openai-api-key"}, LLMProvider.OPENAI),
         ({"anthropic_api_key": "test-anthropic-api-key"}, LLMProvider.ANTHROPIC),
         ({"mistralai_api_key": "test-mistral-api-key"}, LLMProvider.MISTRALAI),
-        ({"google_api_key": "test-google-api-key"}, LLMProvider.GOOGLE_GENERATIVE_AI),
+        ({"google_api_key": "test-google-api-key"}, LLMProvider.GOOGLE),
         (
             {
                 "azure_openai_api_key": "test-azure-openai-api-key",
@@ -580,3 +581,21 @@ def test_deprecated_llm_model_cannot_instantiate_from_string() -> None:
     """Test deprecated LLMModel cannot be instantiated from a string."""
     with pytest.raises(ValueError, match="Invalid LLM model"):
         _ = LLMModel("adijabisfbgiwjebr")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("google", LLMProvider.GOOGLE),
+        ("google_generative_ai", LLMProvider.GOOGLE),
+        ("google-generative-ai", LLMProvider.GOOGLE),
+        ("azure-openai", LLMProvider.AZURE_OPENAI),
+        ("azure_openai", LLMProvider.AZURE_OPENAI),
+        ("anthropic", LLMProvider.ANTHROPIC),
+        ("mistralai", LLMProvider.MISTRALAI),
+        ("openai", LLMProvider.OPENAI),
+    ],
+)
+def test_parse_str_to_enum(value: str, expected: LLMProvider) -> None:
+    """Test parse_str_to_enum works."""
+    assert parse_str_to_enum(value, LLMProvider) is expected

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -404,9 +404,7 @@ def test_portia_set_run_state_to_fail_if_keyboard_interrupt_when_resume(
     plan_run.state = PlanRunState.IN_PROGRESS
     plan_run.current_step_index = 1
 
-    with mock.patch.object(
-        portia, "_execute_plan_run", side_effect=KeyboardInterrupt
-    ):
+    with mock.patch.object(portia, "_execute_plan_run", side_effect=KeyboardInterrupt):
         portia.resume(plan_run)
 
     assert plan_run.state == PlanRunState.FAILED


### PR DESCRIPTION
# Description

The CLI was broken for Azure OpenAI and Google:
- For azure, because the name has a hyphen in it instead of an underscore, which `parse_str_to_enum` couldn't handle
- For Google, because the enum value and name are different, even accounting for case and hyphen vs underscore

The fact that the Google provider is called `GOOGLE_GENERATIVE_AI` in some places and `google` in others is confusing, so I've standardised around `google` - this change is backwards compatible (alias in enum)

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor (rename)
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
