### PR TITLE
Allow a default storage dir

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -606,11 +606,6 @@ class Config(BaseModel):
                 "https://docs.portialabs.ai/setup-account to obtain one if you don't already "
                 "have one",
             )
-        if self.storage_class == StorageClass.DISK and not self.storage_dir:
-            raise InvalidConfigError(
-                "storage_dir",
-                "A storage directory must be provided if using disk storage",
-            )
 
         # Check that all models passed as strings are instantiable, i.e. they have the
         # right API keys and other required configuration.

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -141,7 +141,7 @@ class Portia:
             case StorageClass.MEMORY:
                 self.storage = InMemoryStorage()
             case StorageClass.DISK:
-                self.storage = DiskFileStorage(storage_dir=self.config.must_get("storage_dir", str))
+                self.storage = DiskFileStorage(storage_dir=self.config.storage_dir)
             case StorageClass.CLOUD:
                 self.storage = PortiaCloudStorage(config=self.config)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -79,6 +79,10 @@ def test_set_with_strings(monkeypatch: pytest.MonkeyPatch) -> None:
     assert c.storage_class == StorageClass.DISK
     assert c.storage_dir == "/test"
 
+    c = Config.from_default(storage_class="DISK", storage_dir="/test")
+    assert c.storage_class == StorageClass.DISK
+    assert c.storage_dir == ".portia"
+
     # Need to specify storage_dir if using DISK
     with pytest.raises(InvalidConfigError):
         c = Config.from_default(storage_class="DISK")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -79,13 +79,9 @@ def test_set_with_strings(monkeypatch: pytest.MonkeyPatch) -> None:
     assert c.storage_class == StorageClass.DISK
     assert c.storage_dir == "/test"
 
-    c = Config.from_default(storage_class="DISK", storage_dir="/test")
+    c = Config.from_default(storage_class="DISK")
     assert c.storage_class == StorageClass.DISK
-    assert c.storage_dir == ".portia"
-
-    # Need to specify storage_dir if using DISK
-    with pytest.raises(InvalidConfigError):
-        c = Config.from_default(storage_class="DISK")
+    assert c.storage_dir is None  # Will default to .portia in DiskFileStorage
 
     with pytest.raises(InvalidConfigError):
         c = Config.from_default(storage_class="OTHER")


### PR DESCRIPTION
# Description

Allow using `.portia` as the default storage directory

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [X] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
