### PR TITLE
[POR-1442] Fix parsing params for tools and update daily runs thresholds

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -86,7 +86,7 @@ jobs:
           PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_EVAL_API_ENDPOINT }}
           LLM_REDIS_CACHE_URL: ${{ secrets.LLM_REDIS_CACHE_URL }}
         run: |
-          EVAL_OUTPUT=$(uv run cli.py query-planner eval --provider=anthropic --threshold_file=query_planner/thresholds/claude-3-5-sonnet-latest/thresholds_local.yaml --reps 1 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=${{ github.event_name == 'push' && 'main' || 'pr' }},env=local,repo=sdk" --slice_name main  --max_concurrency 32)
+          EVAL_OUTPUT=$(uv run cli.py query-planner eval --provider=anthropic --threshold_file=query_planner/thresholds/claude-3-7-sonnet-latest/thresholds_local.yaml --reps 1 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=${{ github.event_name == 'push' && 'main' || 'pr' }},env=local,repo=sdk" --slice_name main  --max_concurrency 32)
           echo "eval_url=$(echo "$EVAL_OUTPUT" | grep -o '${LANGCHAIN_ENDPOINT}/.*')" >> $GITHUB_OUTPUT
           echo "eval_name=$(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")" >> $GITHUB_OUTPUT
           if echo "$EVAL_OUTPUT" | grep -q "EVAL BREACH"; then
@@ -109,7 +109,7 @@ jobs:
           PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_EVAL_API_ENDPOINT }}
           LLM_REDIS_CACHE_URL: ${{ secrets.LLM_REDIS_CACHE_URL }}
         run: |
-          EVAL_OUTPUT=$(uv run cli.py agent eval --slice_name=main --provider=anthropic --threshold_file=execution/thresholds/claude-3-5-sonnet-latest/thresholds_local.yaml --reps 1 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=${{ github.event_name == 'push' && 'main' || 'pr' }},env=local,repo=sdk"  --max_concurrency 32)
+          EVAL_OUTPUT=$(uv run cli.py agent eval --slice_name=main --provider=anthropic --threshold_file=execution/thresholds/claude-3-7-sonnet-latest/thresholds_local.yaml --reps 1 --metadata "pr=${{ github.event.pull_request.number }},author=${{ github.event.pull_request.user.login || github.actor }},run=${{ github.event_name == 'push' && 'main' || 'pr' }},env=local,repo=sdk"  --max_concurrency 32)
           echo $EVAL_OUTPUT
           echo "eval_url=$(echo "$EVAL_OUTPUT" | grep -o 'https://smith.langchain.com/.*')" >> $GITHUB_OUTPUT
           echo "eval_name=$(echo "$EVAL_OUTPUT" | grep -oP "experiment:\s*'\K[^']+")" >> $GITHUB_OUTPUT

--- a/portia/common.py
+++ b/portia/common.py
@@ -11,6 +11,8 @@ import importlib.util
 from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -39,12 +41,30 @@ class PortiaEnum(str, Enum):
         return tuple((x.name, x.value) for x in cls)
 
 
+def _serialize_for_json(value: Any) -> Any:  # noqa: ANN401
+    """Serialize a value to be JSON-compatible.
+
+    This function serializes Pydantic models to dictionaries to ensure
+    they can be JSON serialized.
+
+    Args:
+        value: The value to serialize.
+
+    Returns:
+        A JSON-serializable version of the value.
+
+    """
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return value
+
+
 def combine_args_kwargs(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
     """Combine Args + Kwargs into a single dictionary.
 
     This function takes arbitrary positional and keyword arguments and combines them into a single
     dictionary. Positional arguments are indexed as string keys (e.g., "0", "1", ...) while keyword
-    arguments retain their names.
+    arguments retain their names. Pydantic models are automatically serialized to dictionaries.
 
     Args:
         *args: Positional arguments to be included in the dictionary.
@@ -54,8 +74,9 @@ def combine_args_kwargs(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         dict: A dictionary combining both positional and keyword arguments.
 
     """
-    args_dict = {f"{i}": arg for i, arg in enumerate(args)}
-    return {**args_dict, **kwargs}
+    args_dict = {f"{i}": _serialize_for_json(arg) for i, arg in enumerate(args)}
+    kwargs_dict = {k: _serialize_for_json(v) for k, v in kwargs.items()}
+    return {**args_dict, **kwargs_dict}
 
 
 EXTRAS_GROUPS_DEPENDENCIES = {

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -28,8 +28,31 @@ def test_portia_enum() -> None:
 
 def test_combine_args_kwargs() -> None:
     """Test combining args and kwargs into a single dictionary."""
-    result = combine_args_kwargs(1, 2, three=3, four=4)
-    assert result == {"0": 1, "1": 2, "three": 3, "four": 4}
+
+    class Comment(BaseModel):
+        """Test comment model."""
+
+        body: str
+        public: bool
+
+    comment = Comment(body="The issue is being reviewed.", public=True)
+    result = combine_args_kwargs(
+        98765,  # ticket_id as positional arg
+        comment,  # comment as positional arg
+        subject="Updated ticket subject",
+        priority="high",
+        status="in_progress",
+        assignee_id=12345,
+    )
+
+    assert result == {
+        "0": 98765,
+        "1": {"body": "The issue is being reviewed.", "public": True},
+        "subject": "Updated ticket subject",
+        "priority": "high",
+        "status": "in_progress",
+        "assignee_id": 12345,
+    }
 
 
 class TestPrefixedUUID:


### PR DESCRIPTION
# Description

- Fix the zendesk eval issue where sometimes models gets passed as pydantic base models and we need to transform it to jsons in constructing the args.
- Update the daily runs for evals to reference the new threshold folders.

**NOTE**: This PR should be merged after the platform one https://github.com/portiaAI/platform/pull/503 

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [x] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
