### PR TITLE
Don't run before_step_execution after a clarification

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -983,7 +983,12 @@ class Portia:
                     plan_run=str(plan_run.id),
                 )
 
-                if self.execution_hooks.before_step_execution:
+                if (
+                    self.execution_hooks.before_step_execution
+                    # Don't call before_step_execution if we've already executed the step and
+                    # raised a clarification
+                    and len(plan_run.get_clarifications_for_step()) == 0
+                ):
                     outcome = self.execution_hooks.before_step_execution(
                         ReadOnlyPlan.from_plan(plan),
                         ReadOnlyPlanRun.from_plan_run(plan_run),

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -1122,6 +1122,7 @@ def test_portia_handle_clarification(planning_model: MagicMock) -> None:
             clarification_handler=clarification_handler,
             after_step_execution=MagicMock(),
             after_plan_run=MagicMock(),
+            before_step_execution=MagicMock(),
         ),
     )
     planning_model.get_structured_response.return_value = StepsOrError(
@@ -1167,6 +1168,7 @@ def test_portia_handle_clarification(planning_model: MagicMock) -> None:
             clarification_handler.received_clarification.user_guidance
             == "Handle this clarification"
         )
+        assert portia.execution_hooks.before_step_execution.call_count == 1  # pyright: ignore[reportFunctionMemberAccess, reportOptionalMemberAccess]
         assert portia.execution_hooks.after_step_execution.call_count == 1  # pyright: ignore[reportFunctionMemberAccess, reportOptionalMemberAccess]
         assert portia.execution_hooks.after_plan_run.call_count == 1  # pyright: ignore[reportFunctionMemberAccess, reportOptionalMemberAccess]
 


### PR DESCRIPTION
# Description

As discussed on slack, this stops us running before_step_execution after a clarification

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [X] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
