### PR TITLE
POR-1480: Streamable HTTP transport for MCP

### DIFF
--- a/portia/mcp_session.py
+++ b/portia/mcp_session.py
@@ -1,7 +1,7 @@
 """Configuration and client code for interactions with Model Context Protocol (MCP) servers.
 
 This module provides a context manager for creating MCP ClientSessions, which are used to
-interact with MCP servers. It supports both the SSE and stdio transports.
+interact with MCP servers. It supports SSE, stdio, and StreamableHTTP transports.
 
 NB. The MCP Python SDK is asynchronous, so care must be taken when using MCP functionality
 from this module in an async context.
@@ -9,17 +9,21 @@ from this module in an async context.
 Classes:
     SseMcpClientConfig: Configuration for an MCP client that connects via SSE.
     StdioMcpClientConfig: Configuration for an MCP client that connects via stdio.
+    StreamableHttpMcpClientConfig: Configuration for an MCP client that connects via StreamableHTTP.
     McpClientConfig: The configuration to connect to an MCP server.
 """
 
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
+import httpx
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.client.sse import sse_client
-from pydantic import BaseModel, Field
+from mcp.client.streamable_http import streamablehttp_client
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -46,7 +50,21 @@ class StdioMcpClientConfig(BaseModel):
     encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
 
 
-McpClientConfig = SseMcpClientConfig | StdioMcpClientConfig
+class StreamableHttpMcpClientConfig(BaseModel):
+    """Configuration for an MCP client that connects via StreamableHTTP."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    server_name: str
+    url: str
+    headers: dict[str, Any] | None = None
+    timeout: float = 30
+    sse_read_timeout: float = 60 * 5
+    terminate_on_close: bool = True
+    auth: httpx.Auth | None = None
+
+
+McpClientConfig = SseMcpClientConfig | StdioMcpClientConfig | StreamableHttpMcpClientConfig
 
 
 @asynccontextmanager
@@ -84,6 +102,20 @@ async def get_mcp_session(mcp_client_config: McpClientConfig) -> AsyncIterator[C
                 sse_read_timeout=mcp_client_config.sse_read_timeout,
             ) as sse_transport,
             ClientSession(*sse_transport) as session,
+        ):
+            await session.initialize()
+            yield session
+    elif isinstance(mcp_client_config, StreamableHttpMcpClientConfig):
+        async with (
+            streamablehttp_client(
+                url=mcp_client_config.url,
+                headers=mcp_client_config.headers,
+                timeout=timedelta(seconds=mcp_client_config.timeout),
+                sse_read_timeout=timedelta(seconds=mcp_client_config.sse_read_timeout),
+                terminate_on_close=mcp_client_config.terminate_on_close,
+                auth=mcp_client_config.auth,
+            ) as streamablehttp_transport,
+            ClientSession(streamablehttp_transport[0], streamablehttp_transport[1]) as session,
         ):
             await session.initialize()
             yield session

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -32,6 +32,7 @@ from portia.mcp_session import (
     McpClientConfig,
     SseMcpClientConfig,
     StdioMcpClientConfig,
+    StreamableHttpMcpClientConfig,
     get_mcp_session,
 )
 from portia.open_source_tools.calculator_tool import CalculatorTool
@@ -412,6 +413,56 @@ class McpToolRegistry(ToolRegistry):
             env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
+        )
+        tools = await cls._load_tools_async(config)
+        return cls(tools)
+
+    @classmethod
+    def from_streamable_http_connection(  # noqa: PLR0913
+        cls,
+        server_name: str,
+        url: str,
+        headers: dict[str, Any] | None = None,
+        timeout: float = 30,
+        sse_read_timeout: float = 60 * 5,
+        *,
+        terminate_on_close: bool = True,
+        auth: httpx.Auth | None = None,
+    ) -> McpToolRegistry:
+        """Create a new MCPToolRegistry using a StreamableHTTP connection (Sync version)."""
+        config = StreamableHttpMcpClientConfig(
+            server_name=server_name,
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            terminate_on_close=terminate_on_close,
+            auth=auth,
+        )
+        tools = cls._load_tools(config)
+        return cls(tools)
+
+    @classmethod
+    async def from_streamable_http_connection_async(  # noqa: PLR0913
+        cls,
+        server_name: str,
+        url: str,
+        headers: dict[str, Any] | None = None,
+        timeout: float = 30,  # noqa: ASYNC109
+        sse_read_timeout: float = 60 * 5,
+        *,
+        terminate_on_close: bool = True,
+        auth: httpx.Auth | None = None,
+    ) -> McpToolRegistry:
+        """Create a new MCPToolRegistry using a StreamableHTTP connection (Async version)."""
+        config = StreamableHttpMcpClientConfig(
+            server_name=server_name,
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            terminate_on_close=terminate_on_close,
+            auth=auth,
         )
         tools = await cls._load_tools_async(config)
         return cls(tools)

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -653,7 +653,7 @@ def _map_pydantic_type(field_name: str, field: dict[str, Any]) -> type | Any:  #
             types = [
                 _map_single_pydantic_type(field_name, t, allow_nonetype=True) for t in union_types
             ]
-            return Union[*types]
+            return Union[*types]  # pyright: ignore[reportInvalidTypeForm, reportInvalidTypeArguments]
         case _:
             logger().debug(f"Unsupported JSON schema type: {field.get('type')}: {field}")
             return Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pandas>=2.2.3,<3",
     "pytest-mock>=3.14.0,<4",
     "openpyxl>=3.1.5,<4",
-    "mcp>=1.6.0,<2",
+    "mcp>=1.9.2,<2",
     "langsmith>=0.3.15,<0.4 ; python_version >= '3.11' and python_version < '4.0'",
     "tiktoken>=0.9.0,<0.10",
     "jsonref>=1.1.0,<2",

--- a/tests/integration/mcp_server.py
+++ b/tests/integration/mcp_server.py
@@ -31,6 +31,6 @@ if __name__ == "__main__":
     logger.info("Starting MCP server with args: %s", sys.argv)
     server.run(
         transport=sys.argv[1]  # type: ignore[arg-type]
-        if len(sys.argv) > 1 and sys.argv[1] in ["stdio", "sse"]
+        if len(sys.argv) > 1 and sys.argv[1] in ["stdio", "sse", "streamable-http"]
         else "stdio",
     )

--- a/tests/integration/test_mcp_session.py
+++ b/tests/integration/test_mcp_session.py
@@ -9,7 +9,12 @@ from pathlib import Path
 import mcp
 import pytest
 
-from portia.mcp_session import SseMcpClientConfig, StdioMcpClientConfig, get_mcp_session
+from portia.mcp_session import (
+    SseMcpClientConfig,
+    StdioMcpClientConfig,
+    StreamableHttpMcpClientConfig,
+    get_mcp_session,
+)
 
 SERVER_FILE_PATH = Path(__file__).parent / "mcp_server.py"
 
@@ -66,6 +71,52 @@ async def test_mcp_session_sse() -> None:
             url="http://localhost:11385/sse",
             sse_read_timeout=5,
             timeout=5,
+        ),
+    ) as session:
+        tools = await session.list_tools()
+        assert isinstance(tools, mcp.ListToolsResult)
+        assert len(tools.tools) == 1
+
+
+@pytest.fixture
+def streamable_http_background_server() -> Iterator[None]:
+    """Start the MCP server in StreamableHTTP mode in the background."""
+    process = subprocess.Popen(  # noqa: S603
+        [  # noqa: S607
+            "uv",
+            "run",
+            "python",
+            str(SERVER_FILE_PATH.absolute()),
+            "streamable-http",
+        ]
+    )
+    try:
+        # Wait for server to start
+        time.sleep(3)
+
+        # Check if process is still running
+        if process.poll() is not None:
+            raise Exception(f"Server process exited with code {process.poll()}")  # noqa: TRY002
+
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("streamable_http_background_server")
+async def test_mcp_session_streamable_http() -> None:
+    """Test the MCP session with StreamableHTTP."""
+    async with get_mcp_session(
+        StreamableHttpMcpClientConfig(
+            server_name="test_server",
+            url="http://localhost:11385/mcp",
+            timeout=5,
+            sse_read_timeout=5,
         ),
     ) as session:
         tools = await session.list_tools()

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -530,3 +530,23 @@ def test_generate_pydantic_model_from_json_schema_handles_omissible_fields() -> 
     assert deserialized.email is None  # pyright: ignore[reportAttributeAccessIssue]
     assert deserialized.phone is None  # pyright: ignore[reportAttributeAccessIssue]
     assert deserialized.model_dump() == {"name": "John", "phone": None}
+
+
+@pytest.mark.usefixtures("mock_get_mcp_session")
+def test_mcp_tool_registry_from_streamable_http_connection() -> None:
+    """Test constructing a McpToolRegistry from a StreamableHTTP connection."""
+    mcp_registry_streamable_http = McpToolRegistry.from_streamable_http_connection(
+        server_name="mock_mcp",
+        url="http://localhost:8000/mcp",
+    )
+    assert isinstance(mcp_registry_streamable_http, McpToolRegistry)
+
+
+@pytest.mark.usefixtures("mock_get_mcp_session")
+async def test_mcp_tool_registry_from_streamable_http_connection_async() -> None:
+    """Test constructing a McpToolRegistry from a StreamableHTTP connection (async)."""
+    mcp_registry_streamable_http = await McpToolRegistry.from_streamable_http_connection_async(
+        server_name="mock_mcp",
+        url="http://localhost:8000/mcp",
+    )
+    assert isinstance(mcp_registry_streamable_http, McpToolRegistry)

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ requires-dist = [
     { name = "langgraph", marker = "python_full_version >= '3.11' and python_full_version < '4.0'", specifier = ">=0.2.59,<0.3" },
     { name = "langsmith", marker = "python_full_version >= '3.11' and python_full_version < '4.0'", specifier = ">=0.3.15,<0.4" },
     { name = "loguru", marker = "python_full_version >= '3.11' and python_full_version < '4.0'", specifier = ">=0.7.3,<0.8" },
-    { name = "mcp", specifier = ">=1.6.0,<2" },
+    { name = "mcp", specifier = ">=1.9.2,<2" },
     { name = "mistralai", marker = "extra == 'all'", specifier = ">=1.2.5,<2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.2.5,<2" },
     { name = "mistralai", marker = "extra == 'mistralai'", specifier = ">=1.2.5,<2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1307,13 +1307,14 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031, upload-time = "2025-03-27T16:46:32.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/03/77c49cce3ace96e6787af624611b627b2828f0dca0f8df6f330a10eea51e/mcp-1.9.2.tar.gz", hash = "sha256:3c7651c053d635fd235990a12e84509fe32780cd359a5bbef352e20d4d963c05", size = 333066, upload-time = "2025-05-29T14:42:17.76Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077, upload-time = "2025-03-27T16:46:29.919Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a6/8f5ee9da9f67c0fd8933f63d6105f02eabdac8a8c0926728368ffbb6744d/mcp-1.9.2-py3-none-any.whl", hash = "sha256:bc29f7fd67d157fef378f89a4210384f5fecf1168d0feb12d22929818723f978", size = 131083, upload-time = "2025-05-29T14:42:16.211Z" },
 ]
 
 [[package]]
@@ -2356,6 +2357,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Updates MCP SDK and adds support for streamable MCP

https://linear.app/portialabs/issue/POR-1480/support-streamable-http-mcp-transport


## Type of change

(select all that apply)

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
