### PR TITLE
Add debug logs around execution hooks

### DIFF
--- a/portia/execution_agents/base_execution_agent.py
+++ b/portia/execution_agents/base_execution_agent.py
@@ -13,6 +13,7 @@ from langgraph.graph import END, MessagesState
 
 from portia.execution_agents.context import StepInput, build_context
 from portia.execution_agents.execution_utils import MAX_RETRIES, AgentNode, is_clarification
+from portia.logger import logger
 from portia.plan import Plan, ReadOnlyStep, Step
 from portia.plan_run import PlanRun, ReadOnlyPlanRun
 from portia.telemetry.telemetry_service import ProductTelemetry
@@ -152,12 +153,14 @@ class BaseExecutionAgent:
                 continue
 
             if tool and self.execution_hooks and self.execution_hooks.after_tool_call:
+                logger().debug("Calling after_tool_call execution hook")
                 clarification = self.execution_hooks.after_tool_call(
                     tool,
                     message.content,
                     ReadOnlyPlanRun.from_plan_run(self.plan_run),
                     ReadOnlyStep.from_step(self.step),
                 )
+                logger().debug("Finished after_tool_call execution hook")
                 if clarification:
                     self.new_clarifications.append(clarification)
                     return END

--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -31,6 +31,7 @@ from portia.execution_agents.execution_utils import (
 )
 from portia.execution_agents.memory_extraction import MemoryExtractionStep
 from portia.execution_agents.utils.step_summarizer import StepSummarizer
+from portia.logger import logger
 from portia.model import GenerativeModel, Message
 from portia.plan import Plan, ReadOnlyStep
 from portia.plan_run import PlanRun, ReadOnlyPlanRun
@@ -564,12 +565,14 @@ class ToolCallingModel:
             and self.agent.tool
         ):
             for tool_call in response.tool_calls:  # pyright: ignore[reportAttributeAccessIssue]
+                logger().debug("Calling before_tool_call execution hook")
                 clarification = self.agent.execution_hooks.before_tool_call(
                     self.agent.tool,
                     tool_call.get("args"),
                     ReadOnlyPlanRun.from_plan_run(self.agent.plan_run),
                     ReadOnlyStep.from_step(self.agent.step),
                 )
+                logger().debug("Finished before_tool_call execution hook")
                 if clarification:
                     self.agent.new_clarifications.append(clarification)
                     return {"messages": []}

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -31,6 +31,7 @@ from portia.execution_agents.execution_utils import (
 )
 from portia.execution_agents.memory_extraction import MemoryExtractionStep
 from portia.execution_agents.utils.step_summarizer import StepSummarizer
+from portia.logger import logger
 from portia.plan import Plan, ReadOnlyStep
 from portia.plan_run import PlanRun, ReadOnlyPlanRun
 from portia.telemetry.views import ToolCallTelemetryEvent
@@ -196,12 +197,14 @@ class OneShotToolCallingModel:
             and self.agent.tool
         ):
             for tool_call in response.tool_calls:  # pyright: ignore[reportAttributeAccessIssue]
+                logger().debug("Calling before_tool_call execution hook")
                 clarification = self.agent.execution_hooks.before_tool_call(
                     self.agent.tool,
                     tool_call.get("args"),
                     ReadOnlyPlanRun.from_plan_run(self.agent.plan_run),
                     ReadOnlyStep.from_step(self.agent.step),
                 )
+                logger().debug("Finished before_tool_call execution hook")
                 if clarification:
                     self.agent.new_clarifications.append(clarification)
                     return {"messages": []}

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -684,11 +684,13 @@ class Portia:
                 if clarification.source
                 else ""
             )
+            logger().debug("Calling clarification_handler execution hook")
             self.execution_hooks.clarification_handler.handle(
                 clarification=clarification,
                 on_resolution=lambda c, r: self.resolve_clarification(c, r) and None,
                 on_error=lambda c, r: self.error_clarification(c, r) and None,
             )
+            logger().debug("Finished clarification_handler execution hook")
 
         if len(clarifications) > 0:
             # If clarifications are handled synchronously,
@@ -947,9 +949,12 @@ class Portia:
         )
 
         if self.execution_hooks.before_plan_run and plan_run.current_step_index == 0:
+            logger().debug("Calling before_plan_run execution hook")
             self.execution_hooks.before_plan_run(
-                ReadOnlyPlan.from_plan(plan), ReadOnlyPlanRun.from_plan_run(plan_run)
+                ReadOnlyPlan.from_plan(plan),
+                ReadOnlyPlanRun.from_plan_run(plan_run),
             )
+            logger().debug("Finished before_plan_run execution hook")
 
         last_executed_step_output = self._get_last_executed_step_output(plan, plan_run)
         introspection_agent = self._get_introspection_agent()
@@ -970,11 +975,13 @@ class Portia:
                 if pre_step_outcome.outcome != PreStepIntrospectionOutcome.CONTINUE:
                     self._log_final_output(plan_run, plan)
                     if self.execution_hooks.after_plan_run and plan_run.outputs.final_output:
+                        logger().debug("Calling after_plan_run execution hook")
                         self.execution_hooks.after_plan_run(
                             ReadOnlyPlan.from_plan(plan),
                             ReadOnlyPlanRun.from_plan_run(plan_run),
                             plan_run.outputs.final_output,
                         )
+                        logger().debug("Finished after_plan_run execution hook")
                     return plan_run
 
                 logger().info(
@@ -989,11 +996,13 @@ class Portia:
                     # raised a clarification
                     and len(plan_run.get_clarifications_for_step()) == 0
                 ):
+                    logger().debug("Calling before_step_execution execution hook")
                     outcome = self.execution_hooks.before_step_execution(
                         ReadOnlyPlan.from_plan(plan),
                         ReadOnlyPlanRun.from_plan_run(plan_run),
                         ReadOnlyStep.from_step(step),
                     )
+                    logger().debug("Finished before_step_execution execution hook")
                     if outcome == BeforeStepExecutionOutcome.SKIP:
                         continue
 
@@ -1029,19 +1038,23 @@ class Portia:
                 )
 
                 if self.execution_hooks.after_step_execution:
+                    logger().debug("Calling after_step_execution execution hook")
                     self.execution_hooks.after_step_execution(
                         ReadOnlyPlan.from_plan(plan),
                         ReadOnlyPlanRun.from_plan_run(plan_run),
                         ReadOnlyStep.from_step(step),
                         error_output,
                     )
+                    logger().debug("Finished after_step_execution execution hook")
 
                 if self.execution_hooks.after_plan_run:
+                    logger().debug("Calling after_plan_run execution hook")
                     self.execution_hooks.after_plan_run(
                         ReadOnlyPlan.from_plan(plan),
                         ReadOnlyPlanRun.from_plan_run(plan_run),
                         plan_run.outputs.final_output,
                     )
+                    logger().debug("Finished after_plan_run execution hook")
 
                 return plan_run
             else:
@@ -1088,12 +1101,14 @@ class Portia:
                 return self._raise_clarifications(combined_clarifications, plan_run)
 
             if self.execution_hooks.after_step_execution:
+                logger().debug("Calling after_step_execution execution hook")
                 self.execution_hooks.after_step_execution(
                     ReadOnlyPlan.from_plan(plan),
                     ReadOnlyPlanRun.from_plan_run(plan_run),
                     ReadOnlyStep.from_step(step),
                     last_executed_step_output,
                 )
+                logger().debug("Finished after_step_execution execution hook")
 
             # persist at the end of each step
             self.storage.save_plan_run(plan_run)
@@ -1111,11 +1126,13 @@ class Portia:
         self._log_final_output(plan_run, plan)
 
         if self.execution_hooks.after_plan_run and plan_run.outputs.final_output:
+            logger().debug("Calling after_plan_run execution hook")
             self.execution_hooks.after_plan_run(
                 ReadOnlyPlan.from_plan(plan),
                 ReadOnlyPlanRun.from_plan_run(plan_run),
                 plan_run.outputs.final_output,
             )
+            logger().debug("Finished after_plan_run execution hook")
 
         return plan_run
 


### PR DESCRIPTION
## Summary
- add debug logs before and after each execution hook call

## Testing
- `ruff format portia/portia.py portia/execution_agents/default_execution_agent.py portia/execution_agents/one_shot_agent.py portia/execution_agents/base_execution_agent.py`
- `ruff check portia/portia.py portia/execution_agents/default_execution_agent.py portia/execution_agents/one_shot_agent.py portia/execution_agents/base_execution_agent.py --fix`
- `ruff check portia/portia.py portia/execution_agents/default_execution_agent.py portia/execution_agents/one_shot_agent.py portia/execution_agents/base_execution_agent.py`
- `pyright portia/portia.py portia/execution_agents/default_execution_agent.py portia/execution_agents/one_shot_agent.py portia/execution_agents/base_execution_agent.py` *(fails: Import errors)*

------
https://chatgpt.com/codex/tasks/task_b_6840a6de70fc8323b4db9ad21ebc3c1e