### PR TITLE
Fix tool clarification exec hook handling

### DIFF
--- a/portia/execution_hooks.py
+++ b/portia/execution_hooks.py
@@ -209,8 +209,8 @@ def _clarify_on_tool_call_hook(
         )
 
     if (
-        isinstance(previous_clarification, UserVerificationClarification)
-        and not previous_clarification.user_confirmed
+        previous_clarification.category == ClarificationCategory.USER_VERIFICATION
+        and previous_clarification.response is False
     ):
         raise ToolHardError("User rejected tool call to {tool.name} with args {args}")
 


### PR DESCRIPTION
# Description

At runtime, clarification objects loose their type so you cannot do `isinstance` or use type-specific methods.

This can probably be fixed fairly easily but getting a fix in first.

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
