### PR TITLE
Add feature tool decorator

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,3 +11,4 @@ jobs:
       - uses: astral-sh/ruff-action@v1
         with:
           args: check
+          version: "0.8.6"

--- a/portia/__init__.py
+++ b/portia/__init__.py
@@ -82,6 +82,7 @@ from portia.portia import ExecutionHooks, Portia
 
 # Tool related classes
 from portia.tool import Tool, ToolRunContext
+from portia.tool_decorator import tool
 from portia.tool_registry import (
     DefaultToolRegistry,
     InMemoryToolRegistry,
@@ -163,4 +164,5 @@ __all__ = [
     "example_tool_registry",
     "logger",
     "open_source_tool_registry",
+    "tool",
 ]

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -206,7 +206,7 @@ def _process_annotated_type(
         # Malformed Annotated, treat as Any
         param_type = Any
         description = _form_param_description(param_name, func_name)
-        field_info = cast(FieldInfo, Field(default=default, description=description))
+        field_info = cast("FieldInfo", Field(default=default, description=description))
         return param_type, field_info
 
     # First arg is the actual type
@@ -218,9 +218,9 @@ def _process_annotated_type(
     field_info: FieldInfo
     match annotation_metadata:
         case str():
-            field_info = cast(FieldInfo, Field(default=default, description=annotation_metadata))
+            field_info = cast("FieldInfo", Field(default=default, description=annotation_metadata))
         case FieldInfo():
-            field_info = cast(FieldInfo, annotation_metadata)
+            field_info = cast("FieldInfo", annotation_metadata)
             field_info.default = default
         case _:
             raise ValueError(f"Unsupported annotation metadata: {annotation_metadata}")
@@ -236,7 +236,7 @@ def _process_regular_type(
     """Process regular type annotations without metadata."""
     param_type = param_annotation
     description = _form_param_description(param_name, func_name)
-    field_info = cast(FieldInfo, Field(default=default, description=description))
+    field_info = cast("FieldInfo", Field(default=default, description=description))
     return param_type, field_info
 
 

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -16,7 +16,7 @@ from typing import (
 from pydantic import BaseModel, Field, create_model
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Callable
 
     from pydantic.fields import FieldInfo
 
@@ -27,7 +27,7 @@ P = inspect.Parameter
 T = TypeVar("T")
 
 
-def tool(fn: Callable[..., T] | Callable[..., Awaitable[T]]) -> type[Tool[T]]:
+def tool(fn: Callable[..., T]) -> type[Tool[T]]:
     """Convert a function into a Tool class.
 
     This decorator automatically creates a Tool subclass from a function by:
@@ -90,7 +90,7 @@ def tool(fn: Callable[..., T] | Callable[..., Awaitable[T]]) -> type[Tool[T]]:
 
         return run
 
-    class FunctionTool(Tool[T]):
+    class FunctionTool(Tool[T]):  # type: ignore[misc]
         """Dynamically created tool from function."""
 
         def __init__(self, **data: Any) -> None:

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -1,0 +1,267 @@
+"""Tool decorator for creating tools from functions."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from typing import TYPE_CHECKING, Any, TypeVar, get_origin, get_args, get_type_hints
+
+from pydantic import BaseModel, Field, create_model
+
+from portia.tool import Tool, ToolRunContext
+
+# Import Annotated from appropriate module based on Python version
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+else:
+    from collections.abc import Callable
+
+# Type variables for the decorator
+P = inspect.Parameter
+T = TypeVar("T")
+
+
+def tool(fn: Callable[..., T] | Callable[..., Awaitable[T]]) -> type[Tool[T]]:
+    """Convert a function into a Tool class.
+
+    This decorator automatically creates a Tool subclass from a function by:
+    - Using the function's docstring as the tool description
+    - Creating an ID and name based on the function name
+    - Generating input schema from function parameters and type hints
+    - Determining output schema from return type annotation
+
+    Example:
+        @tool
+        def add_numbers(a: int, b: int) -> int:
+            \"\"\"Add two numbers together.\"\"\"
+            return a + b
+
+    Args:
+        fn: The function to convert to a Tool class
+
+    Returns:
+        A Tool subclass that wraps the original function
+
+    Raises:
+        ValueError: If the function has invalid signature or return type
+
+    """
+    # Validate function
+    _validate_function(fn)
+
+    # Extract function metadata
+    func_name = fn.__name__
+    description = (fn.__doc__ or "").strip()
+
+    # Generate tool properties
+    tool_id = func_name
+    tool_name = _snake_to_title_case(func_name)
+
+    # Get function signature and type hints
+    sig = inspect.signature(fn)
+    type_hints = get_type_hints(fn)
+
+    # Create args schema from function parameters
+    args_schema = _create_args_schema(sig, type_hints, func_name, fn)
+
+    # Determine output schema from return type
+    output_schema = _create_output_schema(type_hints, func_name)
+
+    # Create the Tool class dynamically
+    def make_run_method() -> Callable:
+        def run(self: Tool[T], ctx: ToolRunContext, **kwargs: Any) -> T:  # noqa: ARG001
+            """Execute the original function."""
+            # Filter out 'ctx' parameter if the function doesn't expect it
+            func_params = set(sig.parameters.keys())
+            if "ctx" in func_params:
+                kwargs["ctx"] = ctx
+            elif "context" in func_params:
+                kwargs["context"] = ctx
+
+            # Call the original function with filtered kwargs
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k in func_params}
+            return fn(**filtered_kwargs)
+        return run
+
+    class FunctionTool(Tool[T]):
+        """Dynamically created tool from function."""
+
+        def __init__(self, **data: Any) -> None:
+            # Set all the class attributes from the closure
+            super().__init__(
+                id=tool_id,
+                name=tool_name,
+                description=description,
+                args_schema=args_schema,
+                output_schema=output_schema,
+                **data
+            )
+
+        run = make_run_method()
+
+    # Set class name for better debugging
+    FunctionTool.__name__ = f"{_snake_to_title_case(func_name).replace(' ', '')}Tool"
+    FunctionTool.__qualname__ = FunctionTool.__name__
+
+    return FunctionTool
+
+
+def _validate_function(fn: Callable) -> None:
+    """Validate that the function is suitable for conversion to a tool."""
+    if not callable(fn):
+        raise TypeError("Decorated object must be callable")
+
+    # Check that function has type hints for return type
+    type_hints = get_type_hints(fn)
+    if "return" not in type_hints:
+        raise ValueError(
+            f"Function '{fn.__name__}' must have a return type annotation"
+        )
+
+
+def _snake_to_title_case(snake_str: str) -> str:
+    """Convert snake_case to Title Case."""
+    return " ".join(word.capitalize() for word in snake_str.split("_"))
+
+
+def _create_args_schema(
+    sig: inspect.Signature,
+    type_hints: dict[str, Any],
+    func_name: str,
+    func: Callable
+) -> type[BaseModel]:
+    """Create a Pydantic schema from function parameters."""
+    fields = {}
+    
+    # Try to get type hints with extras to preserve Annotated metadata
+    try:
+        type_hints_with_extras = get_type_hints(func, include_extras=True)
+    except (TypeError, AttributeError, NameError):
+        type_hints_with_extras = {}
+
+    for param_name, param in sig.parameters.items():
+        # Skip context parameters
+        if param_name in ("ctx", "context"):
+            continue
+
+        # First try to get annotation with extras (for Annotated support)
+        param_annotation = type_hints_with_extras.get(param_name)
+        
+        # Fall back to raw annotation from signature
+        if param_annotation is None:
+            param_annotation = param.annotation if param.annotation != inspect.Parameter.empty else Any
+        
+        # Extract type and field info from annotation
+        param_type, field_info = _extract_type_and_field_info(
+            param_annotation, param, param_name, func_name
+        )
+
+        fields[param_name] = (param_type, field_info)
+
+    # Create the schema class
+    schema_class_name = f"{_snake_to_title_case(func_name).replace(' ', '')}Schema"
+    return create_model(
+        schema_class_name,
+        **fields,
+        __base__=BaseModel,
+    )
+
+
+def _extract_type_and_field_info(
+    param_annotation: Any,
+    param: inspect.Parameter,
+    param_name: str,
+    func_name: str,
+) -> tuple[Any, Field]:
+    """Extract type and field information from parameter annotation.
+    
+    Supports:
+    - Annotated with string: name: Annotated[str, "description"]
+    - Annotated with Field: name: Annotated[str, Field(description="...")]
+    - Regular type hints: name: str
+    """
+    # Determine default value
+    default = ... if param.default == inspect.Parameter.empty else param.default
+    
+    # Check if annotation is Annotated type
+    origin = get_origin(param_annotation)
+    if origin is Annotated:
+        args = get_args(param_annotation)
+        if not args:
+            # Malformed Annotated, treat as Any
+            param_type = Any
+            description = _extract_param_description(None, param_name, func_name)
+            field_info = Field(default=default, description=description)
+        else:
+            # First arg is the actual type
+            param_type = args[0]
+            
+            # Look for description in metadata
+            description = None
+            field_kwargs = {}
+            
+            for metadata in args[1:]:
+                if isinstance(metadata, str):
+                    # Annotated[str, "description"]
+                    description = metadata
+                elif hasattr(metadata, 'description') and hasattr(metadata, 'default'):
+                    # Annotated[str, Field(description="...")]
+                    description = metadata.description
+                    # Copy specific field validation properties we care about
+                    validation_attrs = ['gt', 'ge', 'lt', 'le', 'min_length', 'max_length', 'regex', 'allow_inf_nan']
+                    for attr in validation_attrs:
+                        if hasattr(metadata, attr):
+                            value = getattr(metadata, attr)
+                            if value is not None:
+                                field_kwargs[attr] = value
+                    # Use Field's default if specified and param has no default
+                    if metadata.default is not ... and param.default == inspect.Parameter.empty:
+                        default = metadata.default
+            
+            # Use extracted description or fallback
+            if description is None:
+                description = _extract_param_description(None, param_name, func_name)
+            
+            field_info = Field(default=default, description=description, **field_kwargs)
+        
+        return param_type, field_info
+    
+    # Regular type annotation without special metadata
+    param_type = param_annotation
+    description = _extract_param_description(None, param_name, func_name)
+    field_info = Field(default=default, description=description)
+    
+    return param_type, field_info
+
+
+def _create_output_schema(type_hints: dict[str, Any], func_name: str) -> tuple[str, str]:
+    """Create output schema tuple from return type annotation."""
+    return_type = type_hints.get("return", Any)
+
+    # Convert type to string representation
+    type_str = return_type.__name__ if hasattr(return_type, "__name__") else str(return_type)
+
+    # Create description
+    description = f"Output from {func_name} function"
+
+    return (type_str, description)
+
+
+def _extract_param_description(
+    sig: inspect.Signature | None,  # noqa: ARG001
+    param_name: str,
+    func_name: str,
+) -> str:
+    """Extract parameter description from function docstring.
+
+    This is a simple implementation that looks for basic patterns.
+    Could be enhanced to parse more sophisticated docstring formats.
+    """
+    # For now, return a basic description
+    # In a real implementation, you might parse docstrings more thoroughly
+    return f"Parameter {param_name} for {func_name}"

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, TypeVar, get_origin, get_args, get_type_hints
-from pydantic import BaseModel, Field, create_model
-from portia.tool import Tool, ToolRunContext
-from typing import Annotated
 from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, TypeVar, get_args, get_origin, get_type_hints
+
+from pydantic import BaseModel, Field, create_model
+
+from portia.tool import Tool, ToolRunContext
 
 # Type variables for the decorator
 P = inspect.Parameter
@@ -232,10 +233,7 @@ def _extract_type_and_field_info(
                                 field_kwargs["le"] = constraint.le
 
                     # Use Field's default if specified and param has no default
-                    if (
-                        metadata.default is not ...
-                        and param.default == inspect.Parameter.empty
-                    ):
+                    if metadata.default is not ... and param.default == inspect.Parameter.empty:
                         default = metadata.default
 
             # Use extracted description or fallback
@@ -254,16 +252,12 @@ def _extract_type_and_field_info(
     return param_type, field_info
 
 
-def _create_output_schema(
-    type_hints: dict[str, Any], func_name: str
-) -> tuple[str, str]:
+def _create_output_schema(type_hints: dict[str, Any], func_name: str) -> tuple[str, str]:
     """Create output schema tuple from return type annotation."""
     return_type = type_hints.get("return", Any)
 
     # Convert type to string representation
-    type_str = (
-        return_type.__name__ if hasattr(return_type, "__name__") else str(return_type)
-    )
+    type_str = return_type.__name__ if hasattr(return_type, "__name__") else str(return_type)
 
     # Create description
     description = f"Output from {func_name} function"

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -3,23 +3,11 @@
 from __future__ import annotations
 
 import inspect
-import sys
-from typing import TYPE_CHECKING, Any, TypeVar, get_origin, get_args, get_type_hints
-
+from typing import Any, TypeVar, get_origin, get_args, get_type_hints
 from pydantic import BaseModel, Field, create_model
-
 from portia.tool import Tool, ToolRunContext
-
-# Import Annotated from appropriate module based on Python version
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-else:
-    from collections.abc import Callable
+from typing import Annotated
+from collections.abc import Awaitable, Callable
 
 # Type variables for the decorator
 P = inspect.Parameter

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -101,7 +101,9 @@ def test_tool_with_mixed_parameters() -> None:
     """Test tool decorator with both regular and context parameters."""
 
     @tool
-    def personalized_message(message: str, ctx: ToolRunContext, prefix: str = "Message") -> str:
+    def personalized_message(
+        message: str, ctx: ToolRunContext, prefix: str = "Message"
+    ) -> str:
         """Create a personalized message for the current user."""
         return f"{prefix} for {ctx.end_user.external_id}: {message}"
 
@@ -261,10 +263,18 @@ def test_tool_args_schema_generation() -> None:
         required_str="test",
         required_float=3.14,
     )
-    assert schema_instance.required_str == "test"  # pyright: ignore[reportAttributeAccessIssue]
-    assert schema_instance.optional_int == 42  # pyright: ignore[reportAttributeAccessIssue]
-    assert schema_instance.optional_bool is True  # pyright: ignore[reportAttributeAccessIssue]
-    assert schema_instance.required_float == 3.14  # pyright: ignore[reportAttributeAccessIssue]
+    assert (
+        schema_instance.required_str == "test"
+    )  # pyright: ignore[reportAttributeAccessIssue]
+    assert (
+        schema_instance.optional_int == 42
+    )  # pyright: ignore[reportAttributeAccessIssue]
+    assert (
+        schema_instance.optional_bool is True
+    )  # pyright: ignore[reportAttributeAccessIssue]
+    assert (
+        schema_instance.required_float == 3.14
+    )  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def test_tool_to_langchain() -> None:
@@ -399,7 +409,10 @@ def test_mixed_annotation_patterns() -> None:
     # Check required_annotated
     assert "required_annotated" in fields
     assert fields["required_annotated"].annotation is str
-    assert fields["required_annotated"].description == "A required parameter with annotation"
+    assert (
+        fields["required_annotated"].description
+        == "A required parameter with annotation"
+    )
 
     # Check required_regular (should get fallback description)
     assert "required_regular" in fields
@@ -452,9 +465,8 @@ def test_get_type_hints_exception_handling() -> None:
         return "test"
 
     sig = inspect.signature(problematic_function)
-    type_hints = {"return": str}
 
-    schema = _create_args_schema(sig, type_hints, "test_func", problematic_function)
+    schema = _create_args_schema(sig, "test_func", problematic_function)
 
     # Should still create a valid schema
     assert issubclass(schema, BaseModel)
@@ -470,9 +482,8 @@ def test_empty_parameter_annotation_fallback() -> None:
         return "test"
 
     sig = inspect.signature(test_func)
-    type_hints = {"return": str}
 
-    schema = _create_args_schema(sig, type_hints, "test_func", test_func)
+    schema = _create_args_schema(sig, "test_func", test_func)
 
     # Should still create a valid schema with Any type
     assert issubclass(schema, BaseModel)

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -1,0 +1,415 @@
+"""Tests for the tool decorator."""
+
+import os
+from typing import Optional, Annotated
+
+import pytest
+from pydantic import BaseModel, Field
+
+from portia.errors import ToolHardError, ToolSoftError
+from portia.tool import ToolRunContext
+from portia.tool_decorator import tool
+from tests.utils import get_test_tool_context
+
+
+def test_basic_tool_decorator() -> None:
+    """Test basic usage of the tool decorator."""
+    
+    @tool
+    def add_numbers(a: int, b: int) -> int:
+        """Add two numbers together."""
+        return a + b
+    
+    # Create an instance of the tool
+    tool_instance = add_numbers()
+    
+    # Check basic properties
+    assert tool_instance.id == "add_numbers"
+    assert tool_instance.name == "Add Numbers"
+    assert tool_instance.description == "Add two numbers together."
+    assert tool_instance.output_schema == ("int", "Output from add_numbers function")
+    
+    # Test args schema
+    schema = tool_instance.args_schema
+    assert issubclass(schema, BaseModel)
+    assert hasattr(schema, "model_fields")
+    assert "a" in schema.model_fields
+    assert "b" in schema.model_fields
+    
+    # Test running the tool
+    ctx = get_test_tool_context()
+    result = tool_instance.run(ctx, a=3, b=4)
+    assert result == 7
+
+
+def test_tool_with_optional_parameters() -> None:
+    """Test tool decorator with optional parameters."""
+    
+    @tool
+    def greet_user(name: str, greeting: str = "Hello") -> str:
+        """Greet a user with a custom greeting."""
+        return f"{greeting}, {name}!"
+    
+    tool_instance = greet_user()
+    ctx = get_test_tool_context()
+    
+    # Test with default parameter
+    result = tool_instance.run(ctx, name="Alice")
+    assert result == "Hello, Alice!"
+    
+    # Test with custom parameter
+    result = tool_instance.run(ctx, name="Bob", greeting="Hi")
+    assert result == "Hi, Bob!"
+
+
+def test_tool_with_context_parameter() -> None:
+    """Test tool decorator with context parameter."""
+    
+    @tool
+    def get_user_id(ctx: ToolRunContext) -> str:
+        """Get the current user ID from context."""
+        return ctx.end_user.external_id
+    
+    tool_instance = get_user_id()
+    ctx = get_test_tool_context()
+    
+    result = tool_instance.run(ctx)
+    assert result == "test_user"
+
+
+def test_tool_with_context_named_context() -> None:
+    """Test tool decorator with context parameter named 'context'."""
+    
+    @tool
+    def get_plan_id(context: ToolRunContext) -> str:
+        """Get the current plan ID from context."""
+        return str(context.plan_run.plan_id)
+    
+    tool_instance = get_plan_id()
+    ctx = get_test_tool_context()
+    
+    result = tool_instance.run(ctx)
+    assert result == str(ctx.plan_run.plan_id)
+
+
+def test_tool_with_mixed_parameters() -> None:
+    """Test tool decorator with both regular and context parameters."""
+    
+    @tool
+    def personalized_message(message: str, ctx: ToolRunContext, prefix: str = "Message") -> str:
+        """Create a personalized message for the current user."""
+        return f"{prefix} for {ctx.end_user.external_id}: {message}"
+    
+    tool_instance = personalized_message()
+    ctx = get_test_tool_context()
+    
+    result = tool_instance.run(ctx, message="Hello World")
+    assert result == "Message for test_user: Hello World"
+    
+    result = tool_instance.run(ctx, message="Test", prefix="Alert")
+    assert result == "Alert for test_user: Test"
+
+
+def test_tool_with_complex_types() -> None:
+    """Test tool decorator with complex type annotations."""
+    
+    @tool
+    def process_data(items: list[str], count: Optional[int] = None) -> dict[str, int]:
+        """Process a list of items and return counts."""
+        if count is None:
+            count = len(items)
+        return {"total_items": len(items), "requested_count": count}
+    
+    tool_instance = process_data()
+    ctx = get_test_tool_context()
+    
+    result = tool_instance.run(ctx, items=["a", "b", "c"])
+    assert result == {"total_items": 3, "requested_count": 3}
+    
+    result = tool_instance.run(ctx, items=["x", "y"], count=5)
+    assert result == {"total_items": 2, "requested_count": 5}
+
+
+def test_tool_raises_errors() -> None:
+    """Test that decorated tools can raise Tool errors."""
+    
+    @tool
+    def failing_tool(should_fail: bool, error_type: str = "soft") -> str:
+        """A tool that can fail in different ways."""
+        if should_fail:
+            if error_type == "hard":
+                raise ToolHardError("Hard error occurred")
+            elif error_type == "soft":
+                raise ToolSoftError("Soft error occurred")
+            else:
+                raise ValueError("Unknown error")
+        return "Success"
+    
+    tool_instance = failing_tool()
+    ctx = get_test_tool_context()
+    
+    # Test successful execution
+    result = tool_instance.run(ctx, should_fail=False)
+    assert result == "Success"
+    
+    # Test soft error
+    with pytest.raises(ToolSoftError):
+        tool_instance.run(ctx, should_fail=True, error_type="soft")
+    
+    # Test hard error
+    with pytest.raises(ToolHardError):
+        tool_instance.run(ctx, should_fail=True, error_type="hard")
+
+
+def test_weather_tool_example() -> None:
+    """Test the weather tool example from the requirement."""
+    
+    @tool
+    def weather_tool(city: str) -> str:
+        """Retrieves the weather of the provided city."""
+        # Mock implementation for testing
+        api_key = os.getenv("OPENWEATHERMAP_API_KEY")
+        if not api_key or api_key == "":
+            raise ToolHardError("OPENWEATHERMAP_API_KEY is required")
+        
+        # Mock weather data for testing
+        return f"The current weather in {city} is sunny with a temperature of 22°C."
+    
+    # Create tool instance
+    tool_instance = weather_tool()
+    
+    # Check properties match expected format
+    assert tool_instance.id == "weather_tool"
+    assert tool_instance.name == "Weather Tool"
+    assert tool_instance.description == "Retrieves the weather of the provided city."
+    assert tool_instance.output_schema == ("str", "Output from weather_tool function")
+    
+    # Check args schema has city parameter
+    schema = tool_instance.args_schema
+    assert "city" in schema.model_fields
+    city_field = schema.model_fields["city"]
+    assert city_field.annotation == str
+    
+    # Test without API key (should raise error)
+    ctx = get_test_tool_context()
+    with pytest.raises(ToolHardError, match="OPENWEATHERMAP_API_KEY is required"):
+        tool_instance.run(ctx, city="London")
+
+
+def test_tool_class_naming() -> None:
+    """Test that tool classes get proper names."""
+    
+    @tool
+    def my_custom_tool(value: str) -> str:
+        """A custom tool for testing."""
+        return value.upper()
+    
+    tool_instance = my_custom_tool()
+    
+    # Check the class name
+    assert tool_instance.__class__.__name__ == "MyCustomToolTool"
+    assert tool_instance.__class__.__qualname__ == "MyCustomToolTool"
+
+
+def test_tool_validation_missing_return_type() -> None:
+    """Test that tools without return type annotations are rejected."""
+    
+    with pytest.raises(ValueError, match="must have a return type annotation"):
+        @tool
+        def invalid_tool(a: int, b: int):  # Missing return type
+            """This tool is invalid."""
+            return a + b
+
+
+def test_tool_validation_non_callable() -> None:
+    """Test that non-callable objects are rejected."""
+    
+    with pytest.raises(TypeError, match="must be callable"):
+        tool("not a function")  # type: ignore
+
+
+def test_tool_args_schema_generation() -> None:
+    """Test detailed args schema generation."""
+    
+    @tool
+    def complex_tool(
+        required_str: str,
+        required_float: float,
+        optional_int: int = 42,
+        optional_bool: bool = True,
+    ) -> str:
+        """A tool with various parameter types."""
+        return f"{required_str}-{optional_int}-{optional_bool}-{required_float}"
+    
+    tool_instance = complex_tool()
+    schema = tool_instance.args_schema
+    
+    # Check required fields
+    assert "required_str" in schema.model_fields
+    assert "required_float" in schema.model_fields
+    
+    # Check optional fields with defaults
+    assert "optional_int" in schema.model_fields
+    assert "optional_bool" in schema.model_fields
+    
+    # Test schema instantiation
+    schema_instance = schema(
+        required_str="test",
+        required_float=3.14,
+    )
+    assert schema_instance.required_str == "test"
+    assert schema_instance.optional_int == 42
+    assert schema_instance.optional_bool is True
+    assert schema_instance.required_float == 3.14
+
+
+def test_tool_to_langchain() -> None:
+    """Test that decorated tools can be converted to LangChain tools."""
+    
+    @tool
+    def simple_tool(text: str) -> str:
+        """A simple tool for LangChain testing."""
+        return text.upper()
+    
+    tool_instance = simple_tool()
+    ctx = get_test_tool_context()
+    
+    # Convert to LangChain tool
+    lc_tool = tool_instance.to_langchain(ctx)
+    
+    # Check properties
+    assert lc_tool.name == "Simple_Tool"
+    assert "simple tool for langchain testing" in lc_tool.description.lower()
+    assert lc_tool.args_schema == tool_instance.args_schema
+
+
+def test_tool_serialization() -> None:
+    """Test that decorated tools can be serialized."""
+    
+    @tool
+    def serializable_tool(data: str) -> str:
+        """A tool that can be serialized."""
+        return data
+    
+    tool_instance = serializable_tool()
+    
+    # Test string representation
+    str_repr = str(tool_instance)
+    assert "serializable_tool" in str_repr
+    assert "Serializable Tool" in str_repr
+    
+    # Test JSON serialization
+    json_data = tool_instance.model_dump_json()
+    assert isinstance(json_data, str)
+    assert "serializable_tool" in json_data
+
+
+def test_annotated_string_description() -> None:
+    """Test Annotated[Type, "description"] pattern."""
+    
+    @tool
+    def say_hello(name: Annotated[str, "The name of the person to say hello to"]) -> str:
+        """Say hello to someone."""
+        return f"Hello, {name}!"
+    
+    tool_instance = say_hello()
+    
+    # Check that the tool was created properly
+    assert tool_instance.id == "say_hello"
+    assert tool_instance.name == "Say Hello"
+    assert tool_instance.description == "Say hello to someone."
+    
+    # Check the args schema
+    schema = tool_instance.args_schema
+    assert "name" in schema.model_fields
+    name_field = schema.model_fields["name"]
+    assert name_field.annotation == str
+    assert name_field.description == "The name of the person to say hello to"
+    
+    # Test execution
+    ctx = get_test_tool_context()
+    result = tool_instance.run(ctx, name="Alice")
+    assert result == "Hello, Alice!"
+
+
+def test_annotated_field_description() -> None:
+    """Test Annotated[Type, Field(description="...")] pattern."""
+    
+    @tool
+    def calculate_area(
+        length: Annotated[float, Field(description="The length of the rectangle")],
+        width: Annotated[float, Field(description="The width of the rectangle", gt=0)]
+    ) -> float:
+        """Calculate the area of a rectangle."""
+        return length * width
+    
+    tool_instance = calculate_area()
+    
+    # Check that the tool was created properly
+    assert tool_instance.id == "calculate_area"
+    assert tool_instance.name == "Calculate Area"
+    
+    # Check the args schema
+    schema = tool_instance.args_schema
+    assert "length" in schema.model_fields
+    assert "width" in schema.model_fields
+    
+    length_field = schema.model_fields["length"]
+    width_field = schema.model_fields["width"]
+    
+    assert length_field.annotation == float
+    assert length_field.description == "The length of the rectangle"
+    
+    assert width_field.annotation == float
+    assert width_field.description == "The width of the rectangle"
+    
+    # Test execution
+    ctx = get_test_tool_context()
+    result = tool_instance.run(ctx, length=5.0, width=3.0)
+    assert result == 15.0
+
+
+def test_mixed_annotation_patterns() -> None:
+    """Test mixing different annotation patterns."""
+    
+    @tool
+    def mixed_function(
+        required_annotated: Annotated[str, "A required parameter with annotation"],
+        required_regular: int,
+        optional_annotated: Annotated[str, Field(description="An optional parameter", min_length=1)] = "default",
+        optional_regular: bool = True
+    ) -> str:
+        """Function with mixed annotation patterns."""
+        return f"{required_annotated}-{required_regular}-{optional_annotated}-{optional_regular}"
+    
+    tool_instance = mixed_function()
+    
+    # Check the args schema
+    schema = tool_instance.args_schema
+    fields = schema.model_fields
+    
+    # Check required_annotated
+    assert "required_annotated" in fields
+    assert fields["required_annotated"].annotation == str
+    assert fields["required_annotated"].description == "A required parameter with annotation"
+    
+    # Check required_regular (should get fallback description)
+    assert "required_regular" in fields
+    assert fields["required_regular"].annotation == int
+    assert "Parameter required_regular for mixed_function" in fields["required_regular"].description
+    
+    # Check optional_annotated
+    assert "optional_annotated" in fields
+    assert fields["optional_annotated"].annotation == str
+    assert fields["optional_annotated"].description == "An optional parameter"
+    assert fields["optional_annotated"].default == "default"
+    
+    # Check optional_regular
+    assert "optional_regular" in fields
+    assert fields["optional_regular"].annotation == bool
+    assert fields["optional_regular"].default == True
+    
+    # Test execution
+    ctx = get_test_tool_context()
+    result = tool_instance.run(ctx, required_annotated="test", required_regular=42)
+    assert result == "test-42-default-True"

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -528,40 +528,6 @@ def test_validation_attribute_none_values() -> None:
     assert param_type is str
     assert field_info.description == "test description"
 
-
-def test_pydantic_v2_constraint_metadata() -> None:
-    """Test pydantic v2 constraint metadata handling."""
-    import inspect
-
-    # Create a mock Field with metadata attribute containing constraints
-    class MockConstraint:
-        def __init__(self, **kwargs: Any) -> None:
-            for key, value in kwargs.items():
-                setattr(self, key, value)
-
-    class MockField:
-        description = "test description"
-        default = ...
-        metadata: list[MockConstraint] = [  # noqa: RUF012
-            MockConstraint(min_length=5),
-            MockConstraint(max_length=10),
-            MockConstraint(gt=0),
-            MockConstraint(ge=1),
-            MockConstraint(lt=100),
-            MockConstraint(le=99),
-        ]
-
-    annotated_type = Annotated[str, MockField()]
-    param = inspect.Parameter("test_param", inspect.Parameter.POSITIONAL_OR_KEYWORD)
-
-    param_type, field_info = _extract_type_and_field_info(
-        annotated_type, param, "test_param", "test_func"
-    )
-
-    assert param_type is str
-    assert field_info.description == "test description"
-
-
 def test_description_fallback_in_annotated() -> None:
     """Test description fallback when no description is found in Annotated metadata."""
     import inspect
@@ -624,19 +590,3 @@ def test_extract_constraints_metadata_none() -> None:
 
     result = _extract_constraints_from_metadata(MockMetadata())
     assert result == {}
-
-
-def test_create_output_schema_no_name_attribute() -> None:
-    """Test _create_output_schema when return type has no __name__ attribute."""
-    from portia.tool_decorator import _create_output_schema
-
-    # Create a type-like object without __name__ attribute
-    class TypeWithoutName:
-        def __str__(self) -> str:
-            return "CustomType"
-
-    type_hints = {"return": TypeWithoutName()}
-    type_str, description = _create_output_schema(type_hints, "test_function")
-
-    assert type_str == "CustomType"
-    assert description == "Output from test_function function"

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 import pytest
 from pydantic import BaseModel, Field
 
-from portia.errors import ToolHardError, ToolSoftError
+from portia.errors import InvalidToolDescriptionError, ToolHardError, ToolSoftError
 from portia.tool import ToolRunContext
 from portia.tool_decorator import (
     _create_args_schema,
@@ -544,3 +544,16 @@ def test_tool_with_invalid_annotation_metadata() -> None:
         ) -> str:
             """Tool with invalid annotation metadata."""
             return f"Hello, {name}!"
+
+
+def test_tool_description_length_validation() -> None:
+    """Test that tool descriptions exceeding MAX_TOOL_DESCRIPTION_LENGTH raise error."""
+
+    def tool_with_long_description() -> str:
+        return "result"
+    tool_with_long_description.__doc__ = "x" * 4097
+    tool_class = tool(tool_with_long_description)
+
+    # The error should be raised when we instantiate the tool
+    with pytest.raises(InvalidToolDescriptionError):
+        tool_class() # pyright: ignore[reportCallIssue]

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -14,28 +14,28 @@ from tests.utils import get_test_tool_context
 
 def test_basic_tool_decorator() -> None:
     """Test basic usage of the tool decorator."""
-    
+
     @tool
     def add_numbers(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b
-    
+
     # Create an instance of the tool
     tool_instance = add_numbers()
-    
+
     # Check basic properties
     assert tool_instance.id == "add_numbers"
     assert tool_instance.name == "Add Numbers"
     assert tool_instance.description == "Add two numbers together."
     assert tool_instance.output_schema == ("int", "Output from add_numbers function")
-    
+
     # Test args schema
     schema = tool_instance.args_schema
     assert issubclass(schema, BaseModel)
     assert hasattr(schema, "model_fields")
     assert "a" in schema.model_fields
     assert "b" in schema.model_fields
-    
+
     # Test running the tool
     ctx = get_test_tool_context()
     result = tool_instance.run(ctx, a=3, b=4)
@@ -44,19 +44,19 @@ def test_basic_tool_decorator() -> None:
 
 def test_tool_with_optional_parameters() -> None:
     """Test tool decorator with optional parameters."""
-    
+
     @tool
     def greet_user(name: str, greeting: str = "Hello") -> str:
         """Greet a user with a custom greeting."""
         return f"{greeting}, {name}!"
-    
+
     tool_instance = greet_user()
     ctx = get_test_tool_context()
-    
+
     # Test with default parameter
     result = tool_instance.run(ctx, name="Alice")
     assert result == "Hello, Alice!"
-    
+
     # Test with custom parameter
     result = tool_instance.run(ctx, name="Bob", greeting="Hi")
     assert result == "Hi, Bob!"
@@ -64,75 +64,77 @@ def test_tool_with_optional_parameters() -> None:
 
 def test_tool_with_context_parameter() -> None:
     """Test tool decorator with context parameter."""
-    
+
     @tool
     def get_user_id(ctx: ToolRunContext) -> str:
         """Get the current user ID from context."""
         return ctx.end_user.external_id
-    
+
     tool_instance = get_user_id()
     ctx = get_test_tool_context()
-    
+
     result = tool_instance.run(ctx)
     assert result == "test_user"
 
 
 def test_tool_with_context_named_context() -> None:
     """Test tool decorator with context parameter named 'context'."""
-    
+
     @tool
     def get_plan_id(context: ToolRunContext) -> str:
         """Get the current plan ID from context."""
         return str(context.plan_run.plan_id)
-    
+
     tool_instance = get_plan_id()
     ctx = get_test_tool_context()
-    
+
     result = tool_instance.run(ctx)
     assert result == str(ctx.plan_run.plan_id)
 
 
 def test_tool_with_mixed_parameters() -> None:
     """Test tool decorator with both regular and context parameters."""
-    
+
     @tool
-    def personalized_message(message: str, ctx: ToolRunContext, prefix: str = "Message") -> str:
+    def personalized_message(
+        message: str, ctx: ToolRunContext, prefix: str = "Message"
+    ) -> str:
         """Create a personalized message for the current user."""
         return f"{prefix} for {ctx.end_user.external_id}: {message}"
-    
+
     tool_instance = personalized_message()
     ctx = get_test_tool_context()
-    
+
     result = tool_instance.run(ctx, message="Hello World")
     assert result == "Message for test_user: Hello World"
-    
+
     result = tool_instance.run(ctx, message="Test", prefix="Alert")
     assert result == "Alert for test_user: Test"
 
 
 def test_tool_with_complex_types() -> None:
     """Test tool decorator with complex type annotations."""
-    
+
     @tool
     def process_data(items: list[str], count: Optional[int] = None) -> dict[str, int]:
         """Process a list of items and return counts."""
         if count is None:
             count = len(items)
         return {"total_items": len(items), "requested_count": count}
-    
+
     tool_instance = process_data()
     ctx = get_test_tool_context()
-    
+
     result = tool_instance.run(ctx, items=["a", "b", "c"])
     assert result == {"total_items": 3, "requested_count": 3}
-    
+
     result = tool_instance.run(ctx, items=["x", "y"], count=5)
     assert result == {"total_items": 2, "requested_count": 5}
 
 
 def test_tool_raises_errors() -> None:
     """Test that decorated tools can raise Tool errors."""
-    
+
     @tool
     def failing_tool(should_fail: bool, error_type: str = "soft") -> str:
         """A tool that can fail in different ways."""
@@ -144,18 +146,18 @@ def test_tool_raises_errors() -> None:
             else:
                 raise ValueError("Unknown error")
         return "Success"
-    
+
     tool_instance = failing_tool()
     ctx = get_test_tool_context()
-    
+
     # Test successful execution
     result = tool_instance.run(ctx, should_fail=False)
     assert result == "Success"
-    
+
     # Test soft error
     with pytest.raises(ToolSoftError):
         tool_instance.run(ctx, should_fail=True, error_type="soft")
-    
+
     # Test hard error
     with pytest.raises(ToolHardError):
         tool_instance.run(ctx, should_fail=True, error_type="hard")
@@ -163,7 +165,7 @@ def test_tool_raises_errors() -> None:
 
 def test_weather_tool_example() -> None:
     """Test the weather tool example from the requirement."""
-    
+
     @tool
     def weather_tool(city: str) -> str:
         """Retrieves the weather of the provided city."""
@@ -171,25 +173,25 @@ def test_weather_tool_example() -> None:
         api_key = os.getenv("OPENWEATHERMAP_API_KEY")
         if not api_key or api_key == "":
             raise ToolHardError("OPENWEATHERMAP_API_KEY is required")
-        
+
         # Mock weather data for testing
         return f"The current weather in {city} is sunny with a temperature of 22°C."
-    
+
     # Create tool instance
     tool_instance = weather_tool()
-    
+
     # Check properties match expected format
     assert tool_instance.id == "weather_tool"
     assert tool_instance.name == "Weather Tool"
     assert tool_instance.description == "Retrieves the weather of the provided city."
     assert tool_instance.output_schema == ("str", "Output from weather_tool function")
-    
+
     # Check args schema has city parameter
     schema = tool_instance.args_schema
     assert "city" in schema.model_fields
     city_field = schema.model_fields["city"]
     assert city_field.annotation == str
-    
+
     # Test without API key (should raise error)
     ctx = get_test_tool_context()
     with pytest.raises(ToolHardError, match="OPENWEATHERMAP_API_KEY is required"):
@@ -198,14 +200,14 @@ def test_weather_tool_example() -> None:
 
 def test_tool_class_naming() -> None:
     """Test that tool classes get proper names."""
-    
+
     @tool
     def my_custom_tool(value: str) -> str:
         """A custom tool for testing."""
         return value.upper()
-    
+
     tool_instance = my_custom_tool()
-    
+
     # Check the class name
     assert tool_instance.__class__.__name__ == "MyCustomToolTool"
     assert tool_instance.__class__.__qualname__ == "MyCustomToolTool"
@@ -213,8 +215,9 @@ def test_tool_class_naming() -> None:
 
 def test_tool_validation_missing_return_type() -> None:
     """Test that tools without return type annotations are rejected."""
-    
+
     with pytest.raises(ValueError, match="must have a return type annotation"):
+
         @tool
         def invalid_tool(a: int, b: int):  # Missing return type
             """This tool is invalid."""
@@ -223,14 +226,14 @@ def test_tool_validation_missing_return_type() -> None:
 
 def test_tool_validation_non_callable() -> None:
     """Test that non-callable objects are rejected."""
-    
+
     with pytest.raises(TypeError, match="must be callable"):
         tool("not a function")  # type: ignore
 
 
 def test_tool_args_schema_generation() -> None:
     """Test detailed args schema generation."""
-    
+
     @tool
     def complex_tool(
         required_str: str,
@@ -240,18 +243,18 @@ def test_tool_args_schema_generation() -> None:
     ) -> str:
         """A tool with various parameter types."""
         return f"{required_str}-{optional_int}-{optional_bool}-{required_float}"
-    
+
     tool_instance = complex_tool()
     schema = tool_instance.args_schema
-    
+
     # Check required fields
     assert "required_str" in schema.model_fields
     assert "required_float" in schema.model_fields
-    
+
     # Check optional fields with defaults
     assert "optional_int" in schema.model_fields
     assert "optional_bool" in schema.model_fields
-    
+
     # Test schema instantiation
     schema_instance = schema(
         required_str="test",
@@ -265,18 +268,18 @@ def test_tool_args_schema_generation() -> None:
 
 def test_tool_to_langchain() -> None:
     """Test that decorated tools can be converted to LangChain tools."""
-    
+
     @tool
     def simple_tool(text: str) -> str:
         """A simple tool for LangChain testing."""
         return text.upper()
-    
+
     tool_instance = simple_tool()
     ctx = get_test_tool_context()
-    
+
     # Convert to LangChain tool
     lc_tool = tool_instance.to_langchain(ctx)
-    
+
     # Check properties
     assert lc_tool.name == "Simple_Tool"
     assert "simple tool for langchain testing" in lc_tool.description.lower()
@@ -285,19 +288,19 @@ def test_tool_to_langchain() -> None:
 
 def test_tool_serialization() -> None:
     """Test that decorated tools can be serialized."""
-    
+
     @tool
     def serializable_tool(data: str) -> str:
         """A tool that can be serialized."""
         return data
-    
+
     tool_instance = serializable_tool()
-    
+
     # Test string representation
     str_repr = str(tool_instance)
     assert "serializable_tool" in str_repr
     assert "Serializable Tool" in str_repr
-    
+
     # Test JSON serialization
     json_data = tool_instance.model_dump_json()
     assert isinstance(json_data, str)
@@ -306,26 +309,28 @@ def test_tool_serialization() -> None:
 
 def test_annotated_string_description() -> None:
     """Test Annotated[Type, "description"] pattern."""
-    
+
     @tool
-    def say_hello(name: Annotated[str, "The name of the person to say hello to"]) -> str:
+    def say_hello(
+        name: Annotated[str, "The name of the person to say hello to"],
+    ) -> str:
         """Say hello to someone."""
         return f"Hello, {name}!"
-    
+
     tool_instance = say_hello()
-    
+
     # Check that the tool was created properly
     assert tool_instance.id == "say_hello"
     assert tool_instance.name == "Say Hello"
     assert tool_instance.description == "Say hello to someone."
-    
+
     # Check the args schema
     schema = tool_instance.args_schema
     assert "name" in schema.model_fields
     name_field = schema.model_fields["name"]
     assert name_field.annotation == str
     assert name_field.description == "The name of the person to say hello to"
-    
+
     # Test execution
     ctx = get_test_tool_context()
     result = tool_instance.run(ctx, name="Alice")
@@ -334,35 +339,35 @@ def test_annotated_string_description() -> None:
 
 def test_annotated_field_description() -> None:
     """Test Annotated[Type, Field(description="...")] pattern."""
-    
+
     @tool
     def calculate_area(
         length: Annotated[float, Field(description="The length of the rectangle")],
-        width: Annotated[float, Field(description="The width of the rectangle", gt=0)]
+        width: Annotated[float, Field(description="The width of the rectangle", gt=0)],
     ) -> float:
         """Calculate the area of a rectangle."""
         return length * width
-    
+
     tool_instance = calculate_area()
-    
+
     # Check that the tool was created properly
     assert tool_instance.id == "calculate_area"
     assert tool_instance.name == "Calculate Area"
-    
+
     # Check the args schema
     schema = tool_instance.args_schema
     assert "length" in schema.model_fields
     assert "width" in schema.model_fields
-    
+
     length_field = schema.model_fields["length"]
     width_field = schema.model_fields["width"]
-    
+
     assert length_field.annotation == float
     assert length_field.description == "The length of the rectangle"
-    
+
     assert width_field.annotation == float
     assert width_field.description == "The width of the rectangle"
-    
+
     # Test execution
     ctx = get_test_tool_context()
     result = tool_instance.run(ctx, length=5.0, width=3.0)
@@ -371,44 +376,70 @@ def test_annotated_field_description() -> None:
 
 def test_mixed_annotation_patterns() -> None:
     """Test mixing different annotation patterns."""
-    
+
     @tool
     def mixed_function(
         required_annotated: Annotated[str, "A required parameter with annotation"],
         required_regular: int,
-        optional_annotated: Annotated[str, Field(description="An optional parameter", min_length=1)] = "default",
-        optional_regular: bool = True
+        optional_annotated: Annotated[
+            str, Field(description="An optional parameter", min_length=1)
+        ] = "default",
+        optional_regular: bool = True,
     ) -> str:
         """Function with mixed annotation patterns."""
         return f"{required_annotated}-{required_regular}-{optional_annotated}-{optional_regular}"
-    
+
     tool_instance = mixed_function()
-    
+
     # Check the args schema
     schema = tool_instance.args_schema
     fields = schema.model_fields
-    
+
     # Check required_annotated
     assert "required_annotated" in fields
     assert fields["required_annotated"].annotation == str
-    assert fields["required_annotated"].description == "A required parameter with annotation"
-    
+    assert (
+        fields["required_annotated"].description
+        == "A required parameter with annotation"
+    )
+
     # Check required_regular (should get fallback description)
     assert "required_regular" in fields
     assert fields["required_regular"].annotation == int
-    assert "Parameter required_regular for mixed_function" in fields["required_regular"].description
-    
+    assert (
+        "Parameter required_regular for mixed_function"
+        in fields["required_regular"].description
+    )
+
     # Check optional_annotated
     assert "optional_annotated" in fields
     assert fields["optional_annotated"].annotation == str
     assert fields["optional_annotated"].description == "An optional parameter"
     assert fields["optional_annotated"].default == "default"
-    
+    # Validate that min_length constraint is present
+    optional_field = fields["optional_annotated"]
+    # Check if the min_length constraint is in the field metadata
+    assert hasattr(optional_field, "metadata")
+    # Extract field constraints from metadata - look for MinLen object
+    min_len_constraint = None
+    for meta in optional_field.metadata:
+        if hasattr(meta, "min_length") and str(type(meta).__name__) == "MinLen":
+            min_len_constraint = meta
+            break
+    assert min_len_constraint is not None
+    assert min_len_constraint.min_length == 1
+
+    # Test that the schema rejects empty strings (min_length=1 constraint)
+    with pytest.raises(ValueError, match="String should have at least 1 character"):
+        schema_instance = schema(
+            required_annotated="test", required_regular=42, optional_annotated=""
+        )
+
     # Check optional_regular
     assert "optional_regular" in fields
     assert fields["optional_regular"].annotation == bool
     assert fields["optional_regular"].default == True
-    
+
     # Test execution
     ctx = get_test_tool_context()
     result = tool_instance.run(ctx, required_annotated="test", required_regular=42)

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -26,7 +26,7 @@ def test_basic_tool_decorator() -> None:
         return a + b
 
     # Create an instance of the tool
-    tool_instance = add_numbers()
+    tool_instance = add_numbers()  # pyright: ignore[reportCallIssue]
 
     # Check basic properties
     assert tool_instance.id == "add_numbers"
@@ -55,7 +55,7 @@ def test_tool_with_optional_parameters() -> None:
         """Greet a user with a custom greeting."""
         return f"{greeting}, {name}!"
 
-    tool_instance = greet_user()
+    tool_instance = greet_user()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     # Test with default parameter
@@ -75,7 +75,7 @@ def test_tool_with_context_parameter() -> None:
         """Get the current user ID from context."""
         return ctx.end_user.external_id
 
-    tool_instance = get_user_id()
+    tool_instance = get_user_id()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     result = tool_instance.run(ctx)
@@ -90,7 +90,7 @@ def test_tool_with_context_named_context() -> None:
         """Get the current plan ID from context."""
         return str(context.plan_run.plan_id)
 
-    tool_instance = get_plan_id()
+    tool_instance = get_plan_id()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     result = tool_instance.run(ctx)
@@ -105,7 +105,7 @@ def test_tool_with_mixed_parameters() -> None:
         """Create a personalized message for the current user."""
         return f"{prefix} for {ctx.end_user.external_id}: {message}"
 
-    tool_instance = personalized_message()
+    tool_instance = personalized_message()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     result = tool_instance.run(ctx, message="Hello World")
@@ -125,7 +125,7 @@ def test_tool_with_complex_types() -> None:
             count = len(items)
         return {"total_items": len(items), "requested_count": count}
 
-    tool_instance = process_data()
+    tool_instance = process_data()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     result = tool_instance.run(ctx, items=["a", "b", "c"])
@@ -149,7 +149,7 @@ def test_tool_raises_errors() -> None:
             raise ValueError("Unknown error")
         return "Success"
 
-    tool_instance = failing_tool()
+    tool_instance = failing_tool()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     # Test successful execution
@@ -180,7 +180,7 @@ def test_weather_tool_example() -> None:
         return f"The current weather in {city} is sunny with a temperature of 22°C."
 
     # Create tool instance
-    tool_instance = weather_tool()
+    tool_instance = weather_tool()  # pyright: ignore[reportCallIssue]
 
     # Check properties match expected format
     assert tool_instance.id == "weather_tool"
@@ -208,7 +208,7 @@ def test_tool_class_naming() -> None:
         """A custom tool for testing."""
         return value.upper()
 
-    tool_instance = my_custom_tool()
+    tool_instance = my_custom_tool()  # pyright: ignore[reportCallIssue]
 
     # Check the class name
     assert tool_instance.__class__.__name__ == "MyCustomToolTool"
@@ -244,7 +244,7 @@ def test_tool_args_schema_generation() -> None:
         """A tool with various parameter types."""
         return f"{required_str}-{optional_int}-{optional_bool}-{required_float}"
 
-    tool_instance = complex_tool()
+    tool_instance = complex_tool()  # pyright: ignore[reportCallIssue]
     schema = tool_instance.args_schema
 
     # Check required fields
@@ -260,10 +260,10 @@ def test_tool_args_schema_generation() -> None:
         required_str="test",
         required_float=3.14,
     )
-    assert schema_instance.required_str == "test"
-    assert schema_instance.optional_int == 42
-    assert schema_instance.optional_bool is True
-    assert schema_instance.required_float == 3.14
+    assert schema_instance.required_str == "test"  # pyright: ignore[reportAttributeAccessIssue]
+    assert schema_instance.optional_int == 42  # pyright: ignore[reportAttributeAccessIssue]
+    assert schema_instance.optional_bool is True  # pyright: ignore[reportAttributeAccessIssue]
+    assert schema_instance.required_float == 3.14  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def test_tool_to_langchain() -> None:
@@ -274,7 +274,7 @@ def test_tool_to_langchain() -> None:
         """A simple tool for LangChain testing."""
         return text.upper()
 
-    tool_instance = simple_tool()
+    tool_instance = simple_tool()  # pyright: ignore[reportCallIssue]
     ctx = get_test_tool_context()
 
     # Convert to LangChain tool
@@ -294,7 +294,7 @@ def test_tool_serialization() -> None:
         """A tool that can be serialized."""
         return data
 
-    tool_instance = serializable_tool()
+    tool_instance = serializable_tool()  # pyright: ignore[reportCallIssue]
 
     # Test string representation
     str_repr = str(tool_instance)
@@ -317,7 +317,7 @@ def test_annotated_string_description() -> None:
         """Say hello to someone."""
         return f"Hello, {name}!"
 
-    tool_instance = say_hello()
+    tool_instance = say_hello()  # pyright: ignore[reportCallIssue]
 
     # Check that the tool was created properly
     assert tool_instance.id == "say_hello"
@@ -348,7 +348,7 @@ def test_annotated_field_description() -> None:
         """Calculate the area of a rectangle."""
         return length * width
 
-    tool_instance = calculate_area()
+    tool_instance = calculate_area()  # pyright: ignore[reportCallIssue]
 
     # Check that the tool was created properly
     assert tool_instance.id == "calculate_area"
@@ -389,7 +389,7 @@ def test_mixed_annotation_patterns() -> None:
         """Function with mixed annotation patterns."""
         return f"{required_annotated}-{required_regular}-{optional_annotated}-{optional_regular}"
 
-    tool_instance = mixed_function()
+    tool_instance = mixed_function()  # pyright: ignore[reportCallIssue]
 
     # Check the args schema
     schema = tool_instance.args_schema
@@ -403,7 +403,9 @@ def test_mixed_annotation_patterns() -> None:
     # Check required_regular (should get fallback description)
     assert "required_regular" in fields
     assert fields["required_regular"].annotation == int
-    assert "Parameter required_regular for mixed_function" in fields["required_regular"].description
+    description = fields["required_regular"].description
+    assert description is not None
+    assert "Parameter required_regular for mixed_function" in description
 
     # Check optional_annotated
     assert "optional_annotated" in fields
@@ -446,7 +448,7 @@ def test_get_type_hints_exception_handling() -> None:
 
     # Create a function that will cause get_type_hints to fail
     def problematic_function(
-        param: "NonExistentType",
+        param: "NonExistentType",  # pyright: ignore[reportUndefinedVariable]
     ) -> str:  # Forward reference to non-existent type
         return "test"
 
@@ -500,6 +502,7 @@ def test_malformed_annotated_type() -> None:
             )
 
             assert param_type == Any
+            assert field_info.description is not None
             assert "Parameter test_param for test_func" in field_info.description
 
 
@@ -576,6 +579,7 @@ def test_description_fallback_in_annotated() -> None:
     )
 
     assert param_type == str
+    assert field_info.description is not None
     assert "Parameter test_param for test_func" in field_info.description
 
 
@@ -591,7 +595,7 @@ def test_field_with_custom_default() -> None:
         """Tool with Field default."""
         return f"Hello, {name}!"
 
-    tool_instance = tool_with_field_default()
+    tool_instance = tool_with_field_default()  # pyright: ignore[reportCallIssue]
 
     # Check the args schema
     schema = tool_instance.args_schema

--- a/uv.lock
+++ b/uv.lock
@@ -2211,15 +2211,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.401"
+version = "1.1.402"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/9a/7ab2b333b921b2d6bfcffe05a0e0a0bbeff884bd6fb5ed50cd68e2898e53/pyright-1.1.401.tar.gz", hash = "sha256:788a82b6611fa5e34a326a921d86d898768cddf59edde8e93e56087d277cc6f1", size = 3894193 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/04/ce0c132d00e20f2d2fb3b3e7c125264ca8b909e693841210534b1ea1752f/pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683", size = 3888207 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e6/1f908fce68b0401d41580e0f9acc4c3d1b248adcff00dfaad75cd21a1370/pyright-1.1.401-py3-none-any.whl", hash = "sha256:6fde30492ba5b0d7667c16ecaf6c699fab8d7a1263f6a18549e0b00bf7724c06", size = 5629193 },
+    { url = "https://files.pythonhosted.org/packages/fe/37/1a1c62d955e82adae588be8e374c7f77b165b6cb4203f7d581269959abbc/pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982", size = 5624004 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '4.0'",
@@ -1894,7 +1893,6 @@ requires-dist = [
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.2.1,<6" },
     { name = "testcontainers", extras = ["redis"], specifier = ">=4.10.0" },
 ]
-provides-extras = ["mistral", "mistralai", "google", "ollama", "tools-browser-local", "tools-browser-browserbase", "tools-pdf-reader", "cache", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2211,15 +2209,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.402"
+version = "1.1.401"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/04/ce0c132d00e20f2d2fb3b3e7c125264ca8b909e693841210534b1ea1752f/pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683", size = 3888207 }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9a/7ab2b333b921b2d6bfcffe05a0e0a0bbeff884bd6fb5ed50cd68e2898e53/pyright-1.1.401.tar.gz", hash = "sha256:788a82b6611fa5e34a326a921d86d898768cddf59edde8e93e56087d277cc6f1", size = 3894193 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/37/1a1c62d955e82adae588be8e374c7f77b165b6cb4203f7d581269959abbc/pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982", size = 5624004 },
+    { url = "https://files.pythonhosted.org/packages/0d/e6/1f908fce68b0401d41580e0f9acc4c3d1b248adcff00dfaad75cd21a1370/pyright-1.1.401-py3-none-any.whl", hash = "sha256:6fde30492ba5b0d7667c16ecaf6c699fab8d7a1263f6a18549e0b00bf7724c06", size = 5629193 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '4.0'",
@@ -1759,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1893,6 +1894,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.2.1,<6" },
     { name = "testcontainers", extras = ["redis"], specifier = ">=4.10.0" },
 ]
+provides-extras = ["mistral", "mistralai", "google", "ollama", "tools-browser-local", "tools-browser-browserbase", "tools-pdf-reader", "cache", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

add tool decorator for creating tools from functions

now you can create tool via

```python
# basic
@tool
def multiply_numbers(a: float, b: float) -> float:
    """Multiply two numbers together."""
    return a * b

# with python annotations + pydantic
@tool
def calculate_area(
    length: Annotated[float, Field(description="The length of the rectangle")],
    width: Annotated[float, Field(description="The width of the rectangle", gt=0)]
) -> float:
    """Calculate the area of a rectangle."""
    return length * width
```


Ticket Link: https://github.com/portiaAI/portia-sdk-python/issues/466

## Type of change

(select all that apply)

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

No screenshots taken but here is an example run and its output - https://gist.github.com/jingkaihe/99cf7db3f5fa8e5e40f9e1bead30dab2

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
