### PR TITLE
Fix CLI tool list serialisation error and improve descriptions

### DIFF
--- a/portia/cli.py
+++ b/portia/cli.py
@@ -225,7 +225,7 @@ def list_tools(
     cli_config, config = _get_config(**kwargs)
 
     for tool in DefaultToolRegistry(config).get_tools():
-        click.echo(tool.model_dump_json(indent=4))
+        click.echo(tool.pretty() + "\n")
 
 
 def _get_config(

--- a/portia/templates/tool_description.xml.jinja
+++ b/portia/templates/tool_description.xml.jinja
@@ -1,8 +1,8 @@
 ---
-{{tool.overview_description}}
+{{tool.overview_description | safe}}
+
 Args:{% for arg in tool.args %}
-    {{arg.name}} ({{arg.type}}) {% if arg.examples %}Sample inputs: {{arg.examples}}{% endif %} {% if arg.enum %}Enum: {{arg.enum}}{% endif %} {% if arg.default %}Default Value: {{arg.default}}{% endif %}
-{% endfor %}
+- {{arg.name}} ({{arg.type}}) {% if arg.examples %}Sample inputs: {{arg.examples}}{% endif %} {% if arg.enum %}Enum: {{arg.enum}}{% endif %} {% if arg.default %}Default Value: {{arg.default}}{% endif %}{% endfor %}
+
 Returns: {% if tool.output_description %}{{tool.output_description}}{% endif %}
-"""
 ---

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -412,6 +412,14 @@ class Tool(BaseModel, Generic[SERIALIZABLE_TYPE_VAR]):
         """
         return value.__name__
 
+    def pretty(self) -> str:
+        """Return a pretty string representation of the tool."""
+        title = f"| {self.name} ({self.id}) |"
+        return (
+            f"{'-' * len(title)}\n{title}\n{'-' * len(title)}"
+            f"\n{self._generate_tool_description()}"
+        )
+
 
 class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
     """Tool that passes run execution to Portia Cloud."""


### PR DESCRIPTION
# Description


⚠️ This impacts the main planner prompt slightly since I've changed the jinja template: I've added `| safe` on descriptions to remove the HTML escapes for e.g. apostrophes (no more `&amp;#39;&amp;#39;`). Also improved the args list by removing extra newlines and adding dash in front.

Fix bug in serialising Tool by replacing model-dump with pretty format

Sample from `portia-cli list-tools`:

```
-----------------------------------------------------------------------------------------------------------
| Portia Google Calendar Get Events By Properties Tool (portia:google:gcalendar:get_events_by_properties) |
-----------------------------------------------------------------------------------------------------------
---
Gets Google Calendar events by properties, returning the matching event details. You do not need to provide all the properties, only the ones you have provided with.

Args:
- event_title (None)   
- start_time (string)   Default Value: 1970-01-01T00:00:00
- end_time (string)   Default Value: 2100-01-01T00:00:00
- event_description (None)   
- attendees (array)   
- max_results (integer)   Default Value: 10

Returns: A list of dictionaries containing information about matching calendar events
---

-----------------------------------------------------------------------------------
| Portia Google Calendar Modify Event Tool (portia:google:gcalendar:modify_event) |
-----------------------------------------------------------------------------------
---
Modifies an existing Google Calendar event. You must provide the event ID to modify, and can optionally provide new values if desired for the title, start time, end time, description, and attendees.

Args:
- event_id (string)   
- event_title (None)   
- start_time (None)   
- end_time (None)   
- event_description (None)   
- attendees (None)   

Returns: dict: Output of the tool
---
```

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
