### PR TITLE
Fix tool registry for remote tools

### DIFF
--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -219,7 +219,7 @@ class ToolRegistry:
             new_description = (
                 updated_description if overwrite else f"{tool.description}. {updated_description}"
             )
-            self.replace_tool(tool.model_copy(update={"description": new_description}, deep=True))
+            self.replace_tool(tool.model_copy(update={"description": new_description}, deep=False))
         except ToolNotFoundError:
             logger().warning(f"Unknown tool ID: {tool_id}. Description was not edited.")
         return self


### PR DESCRIPTION
# Description

Deep copy was causing an issue due to lack of ability to deepcopy threadlocks

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
