### PR TITLE
Improve timeout handling to handle SSE issues

### DIFF
--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel, Field, ValidationError, create_model, model_seri
 from pydantic_core import PydanticUndefined
 
 from portia.cloud import PortiaCloudClient
-from portia.errors import DuplicateToolError, ToolNotFoundError
+from portia.errors import DuplicateToolError, InvalidToolDescriptionError, ToolNotFoundError
 from portia.logger import logger
 from portia.mcp_session import (
     McpClientConfig,
@@ -639,7 +639,7 @@ class McpToolRegistry(ToolRegistry):
                 output_schema=("str", "The response from the tool formatted as a JSON string"),
                 mcp_client_config=mcp_client_config,
             )
-        except ValidationError as e:
+        except (ValidationError, InvalidToolDescriptionError) as e:
             logger().warning(
                 f"Error creating Portia Tool object for tool from {mcp_client_config.server_name} "
                 f"with name {mcp_tool.name}: {e}"

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -501,7 +501,7 @@ def test_tool_registry_reconfigure_llm_tool() -> None:
 def mock_get_mcp_session() -> Iterator[None]:
     """Fixture to mock the get_mcp_session function."""
     mock_session = MagicMock(spec=ClientSession)
-    mock_session.send_request = AsyncMock(
+    mock_session.list_tools = AsyncMock(
         return_value=mcp.ListToolsResult(
             tools=[
                 mcp.Tool(

--- a/uv.lock
+++ b/uv.lock
@@ -1295,7 +1295,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.9.3"
+version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1308,9 +1308,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/df/8fefc0c6c7a5c66914763e3ff3893f9a03435628f6625d5e3b0dc45d73db/mcp-1.9.3.tar.gz", hash = "sha256:587ba38448e81885e5d1b84055cfcc0ca56d35cd0c58f50941cab01109405388", size = 333045, upload-time = "2025-06-05T15:48:25.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f2/dc2450e566eeccf92d89a00c3e813234ad58e2ba1e31d11467a09ac4f3b9/mcp-1.9.4.tar.gz", hash = "sha256:cfb0bcd1a9535b42edaef89947b9e18a8feb49362e1cc059d6e7fc636f2cb09f", size = 333294, upload-time = "2025-06-12T08:20:30.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/45/823ad05504bea55cb0feb7470387f151252127ad5c72f8882e8fe6cf5c0e/mcp-1.9.3-py3-none-any.whl", hash = "sha256:69b0136d1ac9927402ed4cf221d4b8ff875e7132b0b06edd446448766f34f9b9", size = 131063, upload-time = "2025-06-05T15:48:24.171Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fc/80e655c955137393c443842ffcc4feccab5b12fa7cb8de9ced90f90e6998/mcp-1.9.4-py3-none-any.whl", hash = "sha256:7fcf36b62936adb8e63f89346bccca1268eeca9bf6dfb562ee10b1dfbda9dac0", size = 130232, upload-time = "2025-06-12T08:20:28.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Using the MCP SDK to connect to a bad SSE url leads to a very long / permanent hang, which the various timeout settings to no help with. 

This PR using `asyncio.wait_for` to work around this.

Also other small fixes:
- Handle tool description validation problems by filtering them out with a warning (not perfect, but better than failing entire server)
- Bump MCP version - noticed some issues with twilio mcp on current version

Related PR https://github.com/portiaAI/platform/pull/647

Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
