### PR TITLE
Fixing the default config to be ONE_SHOT agent

### DIFF
--- a/portia/config.py
+++ b/portia/config.py
@@ -145,7 +145,7 @@ class LLMModel(Enum):
     )
     GEMINI_2_5_PRO = Model(
         provider=LLMProvider.GOOGLE,
-        model_name="google/gemini-2.5-pro",
+        model_name="gemini-2.5-pro",
     )
     GEMINI_2_0_FLASH = Model(
         provider=LLMProvider.GOOGLE,

--- a/portia/config.py
+++ b/portia/config.py
@@ -145,7 +145,7 @@ class LLMModel(Enum):
     )
     GEMINI_2_5_PRO = Model(
         provider=LLMProvider.GOOGLE,
-        model_name="gemini-2.5-pro-preview-03-25",
+        model_name="google/gemini-2.5-pro",
     )
     GEMINI_2_0_FLASH = Model(
         provider=LLMProvider.GOOGLE,
@@ -1035,6 +1035,6 @@ def default_config(**kwargs) -> Config:  # noqa: ANN003
         feature_flags=kwargs.pop("feature_flags", {}),
         storage_class=kwargs.pop("storage_class", default_storage_class),
         planning_agent_type=kwargs.pop("planning_agent_type", PlanningAgentType.DEFAULT),
-        execution_agent_type=kwargs.pop("execution_agent_type", ExecutionAgentType.DEFAULT),
+        execution_agent_type=kwargs.pop("execution_agent_type", ExecutionAgentType.ONE_SHOT),
         **kwargs,
     )

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1441,13 +1441,8 @@ class Portia:
     def _persist_step_state(self, plan_run: PlanRun, step: Step) -> None:
         """Ensure the plan run state is persisted to storage."""
         step_output = plan_run.outputs.step_outputs[step.output]
-        if (
-            isinstance(step_output, LocalDataValue)
-            and self.config.exceeds_output_threshold(
-                step_output.serialize_value(),
-            )
-            # One-shot agent does not support pulling outputs from agent memory
-            and self.config.execution_agent_type != ExecutionAgentType.ONE_SHOT
+        if isinstance(step_output, LocalDataValue) and self.config.exceeds_output_threshold(
+            step_output.serialize_value(),
         ):
             step_output = self.storage.save_plan_run_output(step.output, step_output, plan_run.id)
             plan_run.outputs.step_outputs[step.output] = step_output

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,6 @@
 """Tests for portia classes."""
 
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,6 +59,11 @@ def test_from_default(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert c.default_log_level == LogLevel.CRITICAL
     assert c.execution_agent_type == ExecutionAgentType.ONE_SHOT
+    assert c.planning_agent_type == PlanningAgentType.DEFAULT
+    if os.getenv("PORTIA_API_KEY"):
+        assert c.storage_class == StorageClass.CLOUD
+    else:
+        assert c.storage_class == StorageClass.MEMORY
     assert c.llm_redis_cache_url is None
     assert _llm_cache.get() is None
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,6 +57,7 @@ def test_from_default(monkeypatch: pytest.MonkeyPatch) -> None:
         openai_api_key=SecretStr("123"),
     )
     assert c.default_log_level == LogLevel.CRITICAL
+    assert c.execution_agent_type == ExecutionAgentType.ONE_SHOT
     assert c.llm_redis_cache_url is None
     assert _llm_cache.get() is None
 

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -871,7 +871,6 @@ def test_portia_run_query_with_memory(
 
         # Verify run completed successfully
         assert plan_run.state == PlanRunState.COMPLETE
-
         # Verify step outputs were stored correctly
         assert plan_run.outputs.step_outputs["$weather"] == AgentMemoryValue(
             output_name="$weather",


### PR DESCRIPTION
# Description

- Fixing the default config to be ONE_SHOT agent to be the default from config.
- Update `GEMINI_2_5_PRO` model and remove `preview`.
Ticket Link: N/A 

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
