### PR TITLE
Log the stack trace when exiting plan run with error

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1034,7 +1034,7 @@ class Portia:
                 )
                 last_executed_step_output = agent.execute_sync()
             except Exception as e:  # noqa: BLE001 - We want to capture all failures here
-                logger().error(f"Error executing step {index}: {e}")
+                logger().exception(f"Error executing step {index}: {e}")
                 error_output = LocalDataValue(value=str(e))
                 self._set_step_output(error_output, plan_run, step)
                 plan_run.outputs.final_output = error_output

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -146,6 +146,12 @@ def _create_args_schema(sig: inspect.Signature, func_name: str, func: Callable) 
 
         # First try to get annotation with extras (for Annotated support)
         param_annotation = type_hints_with_extras.get(param_name)
+        if param_annotation == ToolRunContext and param_name not in ("ctx", "context"):
+            raise ValueError(
+                f"Tool {func_name} has a ToolRunContext parameter that is not named 'ctx' "
+                f"or 'context'. This is not allowed as it causes errors when the tool the tool "
+                "inputs are validated."
+            )
 
         # Fall back to raw annotation from signature
         if param_annotation is None:

--- a/portia/tool_decorator.py
+++ b/portia/tool_decorator.py
@@ -149,7 +149,7 @@ def _create_args_schema(sig: inspect.Signature, func_name: str, func: Callable) 
         if param_annotation == ToolRunContext and param_name not in ("ctx", "context"):
             raise ValueError(
                 f"Tool {func_name} has a ToolRunContext parameter that is not named 'ctx' "
-                f"or 'context'. This is not allowed as it causes errors when the tool the tool "
+                f"or 'context'. This is not allowed as it causes errors when the tool "
                 "inputs are validated."
             )
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -160,6 +160,7 @@ def test_safe_logger_successful_logs() -> None:
     safe_logger.warning("warning message", "arg1", kwarg1="value1")  # noqa: PLE1205
     safe_logger.error("error message", "arg1", kwarg1="value1")  # noqa: PLE1205
     safe_logger.critical("critical message", "arg1", kwarg1="value1")  # noqa: PLE1205
+    safe_logger.exception("exception message", "arg1", kwarg1="value1")  # noqa: PLE1205
 
     # Verify each method was called with correct arguments
     mock_logger.debug.assert_called_once_with("debug message", "arg1", kwarg1="value1")
@@ -167,6 +168,7 @@ def test_safe_logger_successful_logs() -> None:
     mock_logger.warning.assert_called_once_with("warning message", "arg1", kwarg1="value1")
     mock_logger.error.assert_called_once_with("error message", "arg1", kwarg1="value1")
     mock_logger.critical.assert_called_once_with("critical message", "arg1", kwarg1="value1")
+    mock_logger.exception.assert_called_once_with("exception message", "arg1", kwarg1="value1")
 
 
 def test_safe_logger_error_handling() -> None:
@@ -179,6 +181,7 @@ def test_safe_logger_error_handling() -> None:
     mock_logger.info.side_effect = Exception("info error")
     mock_logger.warning.side_effect = Exception("warning error")
     mock_logger.critical.side_effect = Exception("critical error")
+    mock_logger.exception.side_effect = Exception("exception error")
     # Test error log separately as all the other methods call the error log on exception
     mock_logger.error.side_effect = None
 
@@ -186,6 +189,7 @@ def test_safe_logger_error_handling() -> None:
     safe_logger.info("info message")
     safe_logger.warning("warning message")
     safe_logger.critical("critical message")
+    safe_logger.exception("exception message")
 
     mock_logger.error.side_effect = [Exception("error error"), None]
     safe_logger.error("error message")
@@ -194,10 +198,12 @@ def test_safe_logger_error_handling() -> None:
     assert mock_logger.info.call_count == 1
     assert mock_logger.warning.call_count == 1
     assert mock_logger.critical.call_count == 1
-    assert mock_logger.error.call_count == 6
+    assert mock_logger.exception.call_count == 1
+    assert mock_logger.error.call_count == 7
 
     mock_logger.error.assert_any_call("Failed to log: debug error")
     mock_logger.error.assert_any_call("Failed to log: info error")
     mock_logger.error.assert_any_call("Failed to log: warning error")
     mock_logger.error.assert_any_call("Failed to log: error error")
     mock_logger.error.assert_any_call("Failed to log: critical error")
+    mock_logger.error.assert_any_call("Failed to log: exception error")

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -568,11 +568,13 @@ def test_tool_with_context_parameter_name_invalid() -> None:
         ValueError,
         match="Tool tool_with_context_parameter_name_invalid has a ToolRunContext parameter that "
         "is not named 'ctx' or 'context'. This is not allowed as it causes errors when the tool "
-        "inputs are validated."
+        "inputs are validated.",
     ):
+
         @tool
         def tool_with_context_parameter_name_invalid(
-            tool_context: ToolRunContext, arg1: str  # noqa: ARG001
+            tool_context: ToolRunContext,  # noqa: ARG001
+            arg1: str,  # noqa: ARG001
         ) -> str:
             """Tool with context parameter name invalid."""
             return "test"

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -560,3 +560,19 @@ def test_tool_description_length_validation() -> None:
     # The error should be raised when we instantiate the tool
     with pytest.raises(InvalidToolDescriptionError):
         tool_class()  # pyright: ignore[reportCallIssue]
+
+
+def test_tool_with_context_parameter_name_invalid() -> None:
+    """Test that tool with context parameter name invalid raises an error."""
+    with pytest.raises(
+        ValueError,
+        match="Tool tool_with_context_parameter_name_invalid has a ToolRunContext parameter that "
+        "is not named 'ctx' or 'context'. This is not allowed as it causes errors when the tool "
+        "inputs are validated."
+    ):
+        @tool
+        def tool_with_context_parameter_name_invalid(
+            tool_context: ToolRunContext, arg1: str  # noqa: ARG001
+        ) -> str:
+            """Tool with context parameter name invalid."""
+            return "test"


### PR DESCRIPTION
# Description

Without stack traces its hard to find the root cause of issues. It also makes every problem look like it comes from Portia, when the errors might be upstream.

Also added a validation on the tool decorator as I hit an issue that was non obvious.

Sample logs:

```
2025-07-11 16:14:12.840 | ERROR | portia.storage:log_tool_call:352 - Tool returned error | {'output': 'test'}
2025-07-11 16:14:12.921 | ERROR | portia.portia:_execute_plan_run:1023 - Error executing step 0: Tool llm_tool failed after retries: Error: ToolSoftError(Exception('test'))
 Please fix your mistakes.
Traceback (most recent call last):
  File "/Users/samstephens/dev/portia-sdk-python/portia/portia.py", line 1021, in _execute_plan_run
    last_executed_step_output = agent.execute_sync()
  File "/Users/samstephens/dev/portia-sdk-python/portia/execution_agents/one_shot_agent.py", line 318, in execute_sync
    return process_output(invocation_result["messages"], self.tool, self.new_clarifications)
  File "/Users/samstephens/dev/portia-sdk-python/portia/execution_agents/execution_utils.py", line 172, in process_output
    raise ToolRetryError(tool.id, str(message.content))
portia.errors.ToolRetryError: Tool llm_tool failed after retries: Error: ToolSoftError(Exception('test'))
 Please fix your mistakes.

2025-07-11 16:14:13.094 | ERROR | portia.portia:_execute_plan_run:1028 - error: Tool llm_tool failed after retries: Error: ToolSoftError(Exception('test'))
 Please fix your mistakes. | {'error': ToolRetryError("Tool llm_tool failed after retries: Error: ToolSoftError(Exception('test'))\n Please fix your mistakes."), 'plan': 'plan-46ac85cb-40ab-4cb4-b563-dd84f0398ea6', 'plan_run': 'prun-6e6e42bc-5265-4757-b414-7515b0f30490'}
2025-07-11 16:14:13.095 | DEBUG | portia.portia:_execute_plan_run:1034 - Final run status: PlanRunState.FAILED | {'plan': 'plan-46ac85cb-40ab-4cb4-b563-dd84f0398ea6', 'plan_run': 'prun-6e6e42bc-5265-4757-b414-7515b0f30490'}
```

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [x] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
