### PR TITLE
Protect imports with extras-group check in browser_tool.py

### DIFF
--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -45,8 +45,6 @@ from portia.model import (
     AnthropicGenerativeModel,
     AzureOpenAIGenerativeModel,
     GenerativeModel,
-    GoogleGenAiGenerativeModel,
-    OllamaGenerativeModel,
     OpenAIGenerativeModel,
 )
 from portia.tool import Tool, ToolRunContext
@@ -71,10 +69,16 @@ def convert_model_to_browser_use_model(model: GenerativeModel) -> BaseChatModel:
         return ChatAnthropic(model=model.model_name, api_key=model.api_key)
     if isinstance(model, AzureOpenAIGenerativeModel):
         return ChatAzureOpenAI(model=model.model_name, api_key=model.api_key)
-    if isinstance(model, OllamaGenerativeModel):
-        return ChatOllama(model=model.model_name)
-    if isinstance(model, GoogleGenAiGenerativeModel):
-        return ChatGoogle(model=model.model_name, api_key=model.api_key)
+    if validate_extras_dependencies("ollama", raise_error=False):
+        from portia.model import OllamaGenerativeModel
+
+        if isinstance(model, OllamaGenerativeModel):
+            return ChatOllama(model=model.model_name)
+    if validate_extras_dependencies("google", raise_error=False):
+        from portia.model import GoogleGenAiGenerativeModel
+
+        if isinstance(model, GoogleGenAiGenerativeModel):
+            return ChatGoogle(model=model.model_name, api_key=model.api_key)
 
     raise TypeError("Model must be a supported model type.")
 

--- a/portia/open_source_tools/crawl_tool.py
+++ b/portia/open_source_tools/crawl_tool.py
@@ -33,8 +33,7 @@ class CrawlToolSchema(BaseModel):
     max_depth: int = Field(
         default=DEFAULT_MAX_DEPTH,
         description=(
-            "Max depth of the crawl. Defines how far from the base URL "
-            "the crawler can explore"
+            "Max depth of the crawl. Defines how far from the base URL the crawler can explore"
         ),
         ge=1,
         le=5,

--- a/portia/open_source_tools/extract_tool.py
+++ b/portia/open_source_tools/extract_tool.py
@@ -28,11 +28,9 @@ class ExtractToolSchema(BaseModel):
             "including tables and embedded content, with higher success but may increase latency. "
             "Basic extraction costs 1 credit per 5 successful URL extractions, while advanced "
             "extraction costs 2 credits per 5 successful URL extractions."
-        )
+        ),
     )
-    format: str = Field(
-        default="markdown", description="Output format: 'markdown' or 'text'"
-    )
+    format: str = Field(default="markdown", description="Output format: 'markdown' or 'text'")
 
 
 class ExtractTool(Tool[str]):

--- a/portia/open_source_tools/map_tool.py
+++ b/portia/open_source_tools/map_tool.py
@@ -19,8 +19,7 @@ class MapToolSchema(BaseModel):
     max_depth: int = Field(
         default=1,
         description=(
-            "Max depth of the mapping. Defines how far from the base URL "
-            "the crawler can explore"
+            "Max depth of the mapping. Defines how far from the base URL the crawler can explore"
         ),
     )
     max_breadth: int = Field(
@@ -109,8 +108,15 @@ class MapTool(Tool[str]):
             **kwargs,
         )
 
-    def _execute_map_request(self, url: str, max_depth: int, max_breadth: int, limit: int,
-                           instructions: str | None, **kwargs: Any) -> str:
+    def _execute_map_request(
+        self,
+        url: str,
+        max_depth: int,
+        max_breadth: int,
+        limit: int,
+        instructions: str | None,
+        **kwargs: Any,
+    ) -> str:
         """Execute the map request with the given parameters."""
         api_key = os.getenv("TAVILY_API_KEY")
         if not api_key or api_key == "":
@@ -127,8 +133,15 @@ class MapTool(Tool[str]):
 
         return self._make_api_request(api_key, payload)
 
-    def _build_payload(self, url: str, max_depth: int, max_breadth: int, limit: int,
-                      instructions: str | None, **kwargs: Any) -> dict:
+    def _build_payload(
+        self,
+        url: str,
+        max_depth: int,
+        max_breadth: int,
+        limit: int,
+        instructions: str | None,
+        **kwargs: Any,
+    ) -> dict:
         """Build the API payload."""
         payload = {
             "url": url,
@@ -146,7 +159,7 @@ class MapTool(Tool[str]):
             "select_domains",
             "exclude_paths",
             "exclude_domains",
-            "categories"
+            "categories",
         ]
         for key in optional_keys:
             if key in kwargs and kwargs[key] is not None:

--- a/tests/unit/open_source_tools/test_crawl_tool.py
+++ b/tests/unit/open_source_tools/test_crawl_tool.py
@@ -415,11 +415,14 @@ def test_crawl_tool_http_status_error_with_json_response() -> None:
 
         with (
             patch("os.getenv", return_value=mock_api_key),
-            patch("httpx.post", side_effect=httpx.HTTPStatusError(
-                message="Unprocessable Entity",
-                request=Mock(),
-                response=mock_response,
-            )),
+            patch(
+                "httpx.post",
+                side_effect=httpx.HTTPStatusError(
+                    message="Unprocessable Entity",
+                    request=Mock(),
+                    response=mock_response,
+                ),
+            ),
         ):
             ctx = get_test_tool_context()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2135,7 +2135,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.4.11"
+version = "0.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Currently import of browser_tool module fails unless all google and ollama groups are installed, but this shouldnt be required

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
