### PR TITLE
Browseruse fixes for local infra option

### DIFF
--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -513,7 +513,11 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
                 "BrowserTool is using a local browser instance and does not support "
                 "end users and so will be ignored.",
             )
-        browser_pid_str = ctx.end_user.get_additional_data("browser_pid")
+        browser_pid_str = (
+            ctx.end_user.get_additional_data("browser_pid")
+            if str(ctx.end_user.get_additional_data("browser_pid")).isdigit()
+            else None
+        )
         return Browser(
             browser_pid=int(browser_pid_str) if browser_pid_str else None,
             browser_profile=BrowserConfig(

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -595,6 +595,8 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
     async def step_complete(self, ctx: ToolRunContext) -> None:
         """Call when the step is complete to e.g release the session."""
         browser = self._get_browser(ctx)
+        if browser.playwright:
+            await browser.playwright.stop()
         await browser.kill()
         ctx.end_user.remove_additional_data("browser_pid")
 

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -488,6 +488,7 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
         """Initialize the BrowserInfrastructureProviderLocal."""
         self.chrome_path = chrome_path or self.get_chrome_instance_path()
         self.extra_chromium_args = extra_chromium_args or self.get_extra_chromium_args()
+        self._browser_pid: int | None = None
 
     def setup_browser(self, ctx: ToolRunContext) -> Browser:
         """Get a Browser instance.
@@ -507,14 +508,16 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
                 "BrowserTool is using a local browser instance and does not support "
                 "end users and so will be ignored.",
             )
-        return Browser(
+        browser = Browser(
+            browser_pid=self._browser_pid,
             browser_profile=BrowserConfig(
                 executable_path=self.chrome_path,
                 args=self.extra_chromium_args or [],
                 keep_alive=True,
-                storage_state=f".browser_storage_{ctx.plan_run.id}.json",
             ),
         )
+        self._browser_pid = browser.browser_pid
+        return browser
 
     def construct_auth_clarification_url(
         self,

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -367,7 +367,7 @@ class BrowserTool(Tool[str | BaseModel]):
 
             task_result = await run_agent_task(task_to_complete, output_model)
             if task_result.human_login_required:  # type: ignore reportCallIssue
-                return handle_login_requirement(task_result)  # type: ignore reportCallIssue
+                return await ghandle_login_requirement(task_result)  # type: ignore reportCallIssue
 
             await self.infrastructure_provider.step_complete(ctx)
             return task_result.task_output  # type: ignore reportCallIssue

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -367,7 +367,7 @@ class BrowserTool(Tool[str | BaseModel]):
 
             task_result = await run_agent_task(task_to_complete, output_model)
             if task_result.human_login_required:  # type: ignore reportCallIssue
-                return await ghandle_login_requirement(task_result)  # type: ignore reportCallIssue
+                return await handle_login_requirement(task_result)  # type: ignore reportCallIssue
 
             await self.infrastructure_provider.step_complete(ctx)
             return task_result.task_output  # type: ignore reportCallIssue

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -488,7 +488,6 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
         """Initialize the BrowserInfrastructureProviderLocal."""
         self.chrome_path = chrome_path or self.get_chrome_instance_path()
         self.extra_chromium_args = extra_chromium_args or self.get_extra_chromium_args()
-        self._browser_pid: int | None = None
 
     def setup_browser(self, ctx: ToolRunContext) -> Browser:
         """Get a Browser instance.
@@ -508,15 +507,16 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
                 "BrowserTool is using a local browser instance and does not support "
                 "end users and so will be ignored.",
             )
+        browser_pid_str = ctx.end_user.get_additional_data("browser_pid")
         browser = Browser(
-            browser_pid=self._browser_pid,
+            browser_pid=int(browser_pid_str) if browser_pid_str else None,
             browser_profile=BrowserConfig(
                 executable_path=self.chrome_path,
                 args=self.extra_chromium_args or [],
                 keep_alive=True,
             ),
         )
-        self._browser_pid = browser.browser_pid
+        ctx.end_user.set_additional_data("browser_pid", str(browser.browser_pid))
         return browser
 
     def construct_auth_clarification_url(

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -25,6 +25,7 @@ from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+import psutil
 from browser_use import Agent, Browser, BrowserConfig, Controller
 from browser_use.llm import (
     BaseChatModel,
@@ -317,7 +318,7 @@ class BrowserTool(Tool[str | BaseModel]):
         llm = convert_model_to_browser_use_model(model)
 
         async def run_browser_tasks() -> str | BaseModel | ActionClarification:
-            def handle_login_requirement(
+            async def handle_login_requirement(
                 result: BrowserTaskOutput,
             ) -> ActionClarification:
                 """Handle cases where login is required with an ActionClarification."""
@@ -327,7 +328,7 @@ class BrowserTool(Tool[str | BaseModel]):
                     )
                 return ActionClarification(
                     user_guidance=result.user_login_guidance,
-                    action_url=self.infrastructure_provider.construct_auth_clarification_url(
+                    action_url=await self.infrastructure_provider.construct_auth_clarification_url(
                         ctx,
                         result.login_url,
                     ),
@@ -343,7 +344,7 @@ class BrowserTool(Tool[str | BaseModel]):
                 task_description: str,
                 output_model: type[BaseModel],
             ) -> BaseModel:
-                browser = self.infrastructure_provider.setup_browser(ctx)
+                browser = await self.infrastructure_provider.setup_browser(ctx)
                 agent = Agent(
                     task=task_description,
                     llm=llm,
@@ -351,7 +352,7 @@ class BrowserTool(Tool[str | BaseModel]):
                     controller=Controller(output_model=output_model),
                 )
                 result = await agent.run()
-                self.infrastructure_provider.post_agent_run(ctx, browser)
+                await self.infrastructure_provider.post_agent_run(ctx, browser)
                 return output_model.model_validate(json.loads(result.final_result()))  # type: ignore reportCallIssue
 
             # Main task
@@ -368,7 +369,7 @@ class BrowserTool(Tool[str | BaseModel]):
             if task_result.human_login_required:  # type: ignore reportCallIssue
                 return handle_login_requirement(task_result)  # type: ignore reportCallIssue
 
-            self.infrastructure_provider.step_complete(ctx)
+            await self.infrastructure_provider.step_complete(ctx)
             return task_result.task_output  # type: ignore reportCallIssue
 
         try:
@@ -464,22 +465,24 @@ class BrowserInfrastructureProvider(ABC):
     """Abstract base class for browser infrastructure providers."""
 
     @abstractmethod
-    def setup_browser(self, ctx: ToolRunContext) -> Browser:
+    async def setup_browser(self, ctx: ToolRunContext) -> Browser:
         """Get a Browser instance.
 
         This is called at the start of every step using this tool.
         """
 
-    def post_agent_run(self, ctx: ToolRunContext, browser: Browser) -> None:  # noqa: ARG002
+    async def post_agent_run(self, ctx: ToolRunContext, browser: Browser) -> None:  # noqa: ARG002
         """Called after the agent has been setup."""  # noqa: D401
         return
 
     @abstractmethod
-    def construct_auth_clarification_url(self, ctx: ToolRunContext, sign_in_url: str) -> HttpUrl:
+    async def construct_auth_clarification_url(
+        self, ctx: ToolRunContext, sign_in_url: str
+    ) -> HttpUrl:
         """Construct the URL for the auth clarification."""
 
     @abstractmethod
-    def step_complete(self, ctx: ToolRunContext) -> None:
+    async def step_complete(self, ctx: ToolRunContext) -> None:
         """Call when the step is complete to e.g. release the session if needed."""
 
 
@@ -495,7 +498,7 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
         self.chrome_path = chrome_path or self.get_chrome_instance_path()
         self.extra_chromium_args = extra_chromium_args or self.get_extra_chromium_args()
 
-    def setup_browser(self, ctx: ToolRunContext) -> Browser:
+    async def setup_browser(self, ctx: ToolRunContext) -> Browser:
         """Get a Browser instance.
 
         Note: This provider does not support end_user_id.
@@ -513,13 +516,12 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
                 "BrowserTool is using a local browser instance and does not support "
                 "end users and so will be ignored.",
             )
-        browser_pid_str = (
-            ctx.end_user.get_additional_data("browser_pid")
-            if str(ctx.end_user.get_additional_data("browser_pid")).isdigit()
-            else None
-        )
+        return self._get_browser(ctx)
+
+    def _get_browser(self, ctx: ToolRunContext) -> Browser:
+        """Get a Browser instance."""
         return Browser(
-            browser_pid=int(browser_pid_str) if browser_pid_str else None,
+            browser_pid=self._get_or_reset_browser_pid(ctx),
             browser_profile=BrowserConfig(
                 executable_path=self.chrome_path,
                 args=self.extra_chromium_args or [],
@@ -527,12 +529,24 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
             ),
         )
 
-    def post_agent_run(self, ctx: ToolRunContext, browser: Browser) -> None:
+    def _get_or_reset_browser_pid(self, ctx: ToolRunContext) -> int | None:
+        """Get the browser pid from the context or reset it."""
+        browser_pid_str = ctx.end_user.get_additional_data("browser_pid")
+        if (
+            browser_pid_str is not None
+            and browser_pid_str.isdigit()
+            and psutil.pid_exists(int(browser_pid_str))
+        ):
+            return int(browser_pid_str)
+        ctx.end_user.remove_additional_data("browser_pid")
+        return None
+
+    async def post_agent_run(self, ctx: ToolRunContext, browser: Browser) -> None:
         """Called after the agent has been setup."""  # noqa: D401
         if browser.browser_pid:
             ctx.end_user.set_additional_data("browser_pid", str(browser.browser_pid))
 
-    def construct_auth_clarification_url(
+    async def construct_auth_clarification_url(
         self,
         ctx: ToolRunContext,  # noqa: ARG002
         sign_in_url: str,
@@ -578,8 +592,11 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
             case _:
                 raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
-    def step_complete(self, ctx: ToolRunContext) -> None:
+    async def step_complete(self, ctx: ToolRunContext) -> None:
         """Call when the step is complete to e.g release the session."""
+        browser = self._get_browser(ctx)
+        await browser.kill()
+        ctx.end_user.remove_additional_data("browser_pid")
 
     def get_extra_chromium_args(self) -> list[str] | None:
         """Get the extra Chromium arguments.
@@ -645,7 +662,7 @@ if BROWSERBASE_AVAILABLE:
 
             self.bb = Browserbase(api_key=api_key)
 
-        def step_complete(self, ctx: ToolRunContext) -> None:
+        async def step_complete(self, ctx: ToolRunContext) -> None:
             """Call when the step is complete closes the session to persist context."""
             # Only clean up the session on the final browser tool call
             if any(
@@ -764,7 +781,7 @@ if BROWSERBASE_AVAILABLE:
 
             return session_connect_url
 
-        def construct_auth_clarification_url(
+        async def construct_auth_clarification_url(
             self,
             ctx: ToolRunContext,
             sign_in_url: str,  # noqa: ARG002
@@ -791,7 +808,7 @@ if BROWSERBASE_AVAILABLE:
             live_view_link = self.bb.sessions.debug(session_id)
             return HttpUrl(live_view_link.pages[-1].debugger_fullscreen_url)
 
-        def setup_browser(self, ctx: ToolRunContext) -> Browser:
+        async def setup_browser(self, ctx: ToolRunContext) -> Browser:
             """Set up a Browser instance connected to BrowserBase.
 
             Creates or retrieves a BrowserBase session and configures a Browser instance

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -512,6 +512,7 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
                 executable_path=self.chrome_path,
                 args=self.extra_chromium_args or [],
                 keep_alive=True,
+                storage_state=f".browser_storage_{ctx.plan_run.id}.json",
             ),
         )
 

--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -511,6 +511,7 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
             browser_profile=BrowserConfig(
                 executable_path=self.chrome_path,
                 args=self.extra_chromium_args or [],
+                keep_alive=True,
             ),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,11 @@ google = [
 ollama = ["langchain-ollama>=0.2.2,<0.3 ; python_version >= '3.11' and python_version < '4.0'"]
 tools-browser-local = [
     "playwright>=1.49.0,<2",
-    "browser-use>=0.4.2 ; python_version >= '3.11' and python_version < '4.0'",
+    "browser-use>=0.5.5 ; python_version >= '3.11' and python_version < '4.0'",
 ]
 tools-browser-browserbase = [
     "playwright>=1.49.0,<2",
-    "browser-use>=0.4.2 ; python_version >= '3.11' and python_version < '4.0'",
+    "browser-use>=0.5.5 ; python_version >= '3.11' and python_version < '4.0'",
     "browserbase>=1.2.0,<2",
 ]
 tools-pdf-reader = ["mistralai>=1.2.5,<2"]
@@ -68,7 +68,7 @@ all = [
     "google-genai>=1.18.0",
     "langchain-ollama>=0.2.2,<0.3 ; python_version >= '3.11' and python_version < '4.0'",
     "playwright>=1.49.0,<2",
-    "browser-use>=0.4.2 ; python_version >= '3.11' and python_version < '4.0'",
+    "browser-use>=0.5.5 ; python_version >= '3.11' and python_version < '4.0'",
     "browserbase>=1.2.0,<2",
     "redis>=5.2.1,<6",
     "langchain-redis>=0.1.2 ; python_version >= '3.11' and python_version < '3.14'"

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "browser-use"
-version = "0.5.3"
+version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "python_full_version < '4'" },
@@ -241,6 +241,7 @@ dependencies = [
     { name = "google-genai", marker = "python_full_version < '4'" },
     { name = "groq", marker = "python_full_version < '4'" },
     { name = "httpx", marker = "python_full_version < '4'" },
+    { name = "markdown-pdf", marker = "python_full_version < '4'" },
     { name = "markdownify", marker = "python_full_version < '4'" },
     { name = "mcp", marker = "python_full_version < '4'" },
     { name = "ollama", marker = "python_full_version < '4'" },
@@ -260,9 +261,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '4'" },
     { name = "uuid7", marker = "python_full_version < '4'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/a7/8a790fa803c48763f770184187614af4099236d943454a3329b089a3f395/browser_use-0.5.3.tar.gz", hash = "sha256:9c4ffbfd91a9df41091f70635f499d0061569000695a773107b589d20fa588c2", size = 233391, upload-time = "2025-07-09T05:36:20.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/ff/88113c9fcf722cc140578b56d790d64cee56c0e248d175c4c5fb610fce6c/browser_use-0.5.5.tar.gz", hash = "sha256:cecca95576623a269ab0880fe295c7db98787fbcd33c8a6d3cd7a277d0e3ec5f", size = 240819, upload-time = "2025-07-16T17:37:39.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/95459e7d93561914a5f048a8812aaf899f3838f3237186d45f10dfd2a371/browser_use-0.5.3-py3-none-any.whl", hash = "sha256:379592173946f8dcafef138417108f45e36d67f51917af0cc154abbad3d05500", size = 284041, upload-time = "2025-07-09T05:36:19.111Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b0/ab4a0b76935257bd07af98b6b073ec1610ce843402b9e08ef5d8625f4337/browser_use-0.5.5-py3-none-any.whl", hash = "sha256:ad65b0c8e67e14537bb898745deea674e11fcb662433f072febf81d77587b29c", size = 297158, upload-time = "2025-07-16T17:37:38.693Z" },
 ]
 
 [[package]]
@@ -1492,6 +1493,19 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-pdf"
+version = "1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", marker = "python_full_version < '4'" },
+    { name = "pymupdf", marker = "python_full_version < '4'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/79/0d03f40cf12170b098a30d64ba1a86ae7b5087d6a98d215c399c5ea48bc0/markdown_pdf-1.7.tar.gz", hash = "sha256:92258102198b5b94c82b837a51f0b4b8f102e2b3bfcd5ab99761ea544fdc2a6a", size = 17110, upload-time = "2025-04-17T16:19:04.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/e9/c21ceb65683375d0b329e29de8acc51d12598ded720642df23251bc6a3fb/markdown_pdf-1.7-py3-none-any.whl", hash = "sha256:8022945f3e05f4ba4bf80c5d51c71bccf12d153ffdbe96ef4b49c01d6aabec72", size = 17254, upload-time = "2025-04-17T16:19:02.785Z" },
+]
+
+[[package]]
 name = "markdownify"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2594,6 +2608,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/0a/c06b542ac108bfc73200677309cd9188a3a01b127a63f20cadc18d873d88/pymdown_extensions-10.16.tar.gz", hash = "sha256:71dac4fca63fabeffd3eb9038b756161a33ec6e8d230853d3cecf562155ab3de", size = 853197, upload-time = "2025-06-21T17:56:36.974Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/d4/10bb14004d3c792811e05e21b5e5dcae805aacb739bd12a0540967b99592/pymdown_extensions-10.16-py3-none-any.whl", hash = "sha256:f5dd064a4db588cb2d95229fc4ee63a1b16cc8b4d0e6145c0899ed8723da1df2", size = 266143, upload-time = "2025-06-21T17:56:35.356Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/47/b61c1c44b87cbdaeecdec3f43ce524ed6b3c72172bc6184eb82c94fbc43d/pymupdf-1.25.3.tar.gz", hash = "sha256:b640187c64c5ac5d97505a92e836da299da79c2f689f3f94a67a37a493492193", size = 67259841, upload-time = "2025-02-06T13:06:03.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/9b/98ef4b98309e9db3baa9fe572f0e61b6130bb9852d13189970f35b703499/pymupdf-1.25.3-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:96878e1b748f9c2011aecb2028c5f96b5a347a9a91169130ad0133053d97915e", size = 19343576, upload-time = "2025-02-06T13:03:51.663Z" },
+    { url = "https://files.pythonhosted.org/packages/14/62/4e12126db174c8cfbf692281cda971cc4046c5f5226032c2cfaa6f83e08d/pymupdf-1.25.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6ef753005b72ebfd23470f72f7e30f61e21b0b5e748045ec5b8f89e6e3068d62", size = 18580114, upload-time = "2025-02-06T13:03:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c5/cf7ecf005e4f8ba3664d6aaa0613adeba4c2ab524832c452c69857e7184f/pymupdf-1.25.3-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cbff443d899f37b17f1e67563cc03673d50b4bf33ccc237e73d34f18f3a07ccf", size = 19442580, upload-time = "2025-03-12T11:47:22.196Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/bd1418e31f73d37b8381cd5deacfd681e6be702b8890e123e83724569ee1/pymupdf-1.25.3-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46d90c4f9e62d1856e8db4b9f04a202ff4a7f086a816af73abdc86adb7f5e25a", size = 19999825, upload-time = "2025-02-06T13:04:39.487Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/3c449b0de061440ba1ac984aa845315e9e2dca0ff2003c5adfc6febff203/pymupdf-1.25.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5de51efdbe4d486b6c1111c84e8a231cbfb426f3d6ff31ab530ad70e6f39756", size = 21123157, upload-time = "2025-02-06T13:03:06.966Z" },
+    { url = "https://files.pythonhosted.org/packages/83/53/71faaaf91c56f2883b13f3dd849bf2697f012eb35eb7b952d62734cff41f/pymupdf-1.25.3-cp39-abi3-win32.whl", hash = "sha256:bca72e6089f985d800596e22973f79cc08af6cbff1d93e5bda9248326a03857c", size = 15094211, upload-time = "2025-02-06T13:04:52.08Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e0/d72e88a1d5e23aa381fd463057dc3d0fb29090e1e7308a870c334716579c/pymupdf-1.25.3-cp39-abi3-win_amd64.whl", hash = "sha256:4fb357438c9129fbf939b5af85323434df64e36759c399c376b62ad6da95498c", size = 16542949, upload-time = "2025-02-06T13:04:22.444Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2235,9 +2235,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.41.0,<=0.55.0" },
-    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'all'", specifier = ">=0.4.2" },
-    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'tools-browser-browserbase'", specifier = ">=0.4.2" },
-    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'tools-browser-local'", specifier = ">=0.4.2" },
+    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'all'", specifier = ">=0.5.5" },
+    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'tools-browser-browserbase'", specifier = ">=0.5.5" },
+    { name = "browser-use", marker = "python_full_version >= '3.11' and python_full_version < '4' and extra == 'tools-browser-local'", specifier = ">=0.5.5" },
     { name = "browserbase", marker = "extra == 'all'", specifier = ">=1.2.0,<2" },
     { name = "browserbase", marker = "extra == 'tools-browser-browserbase'", specifier = ">=1.2.0,<2" },
     { name = "click", specifier = ">=8.1.7,<9" },


### PR DESCRIPTION
# Description

Browseruse now uses Playwright + Chromium in "local mode" by default. This is actually kind of nice and isolated, but it does have some issues:
* The browser closes at the end of the agent run, by default. This means clarifications for auth can't be completed because there is nowhere to enter the info
* To solve the above, you can add "keep-alive", but to ensure playwright connects to the same browser process on resume, you have to track the browser PID, and you have to implement killing the Chromium instance after completion.
* Browseruse appears to not clean up the playwright process correctly when closing the browser.

It seems like there is a bug that means playwright + Chromium is the only option that works at the moment, i.e. you can't connect to Chrome - at least I'm getting the same issue described here: https://github.com/browser-use/browser-use/issues/2360

Made the browser-infra class interface async because most of the browseruse and playwright stuff is async anyway, and to use it behind a sync interface is messy (threads and event loop shenanigans).

I've tested that this works on our getting started browser example.

Alternative fixes to this PR:
* Rollback browseruse version
* Wait for browseruse to merge a fix that allows Chrome usage and remain with that approach

If we take the option in this PR, we need to update our docs

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
