### PR TITLE
Move api_key to authorization header for search tool

### DIFF
--- a/portia/open_source_tools/search_tool.py
+++ b/portia/open_source_tools/search_tool.py
@@ -51,9 +51,8 @@ class SearchTool(Tool[str]):
         payload = {
             "query": search_query,
             "include_answer": True,
-            "api_key": api_key,
         }
-        headers = {"Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
 
         response = httpx.post(url, headers=headers, json=payload)
         response.raise_for_status()


### PR DESCRIPTION
# Description

https://docs.tavily.com/documentation/api-reference/endpoint/search#authorization-authorization
Tavily's search API used to send the api key in the request payload but according to api docs it expects in the header.

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update