### PR TITLE
Cleanup playwright processes when pausing browser tool execution

### DIFF
--- a/portia/open_source_tools/browser_tool.py
+++ b/portia/open_source_tools/browser_tool.py
@@ -545,6 +545,16 @@ class BrowserInfrastructureProviderLocal(BrowserInfrastructureProvider):
         """Called after the agent has been setup."""  # noqa: D401
         if browser.browser_pid:
             ctx.end_user.set_additional_data("browser_pid", str(browser.browser_pid))
+        if browser.playwright:
+            # We use the browseruse keep_alive=True option within a step so that we
+            # leave the browser open for user authentication. This option means the browser
+            # AND the playwright process are both left running. When we resume the step,
+            # we create a new BrowserSession object and pass the browser_pid, which reconnects
+            # us to the same browser process, but NOT the same playwright instance - a new
+            # instance is created.
+            # To avoid creating many playwright instances, we stop the playwright process
+            # NB this does not kill the browser process.
+            await browser.playwright.stop()
 
     async def construct_auth_clarification_url(
         self,

--- a/tests/unit/open_source_tools/test_browser_tool.py
+++ b/tests/unit/open_source_tools/test_browser_tool.py
@@ -885,12 +885,14 @@ async def test_browser_infra_local_post_agent_run(
 
     # Create mock browser with specified browser_pid
     mock_browser = MagicMock()
+    mock_browser.playwright = AsyncMock()
     mock_browser.browser_pid = browser_pid
 
     await local_browser_provider.post_agent_run(context, mock_browser)
 
     # Verify that browser_pid was set (or not set) as expected in additional_data
     assert context.end_user.get_additional_data("browser_pid") == expected_additional_data
+    assert mock_browser.playwright.stop.call_count == 1
 
 
 async def test_browser_infra_local_step_complete(


### PR DESCRIPTION
# Description


Prevents node spaffing logs on exit

See description in the diff for detailed explanation of why this is necessary

```
node:events:496
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:87:19)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}

Node.js v22.16.0
```




Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
