### PR TITLE
 Provide example plans by ID

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -359,7 +359,7 @@ class Portia:
 
         return resolved_plans
 
-    def _resolve_single_example_plan(self, example_plan: Plan | PlanUUID | UUID | str) -> Plan:
+    def _resolve_single_example_plan(self, example_plan: Plan | PlanUUID | str) -> Plan:
         """Resolve a single example plan from various input types."""
         if isinstance(example_plan, Plan):
             return example_plan
@@ -369,7 +369,7 @@ class Portia:
             return self._resolve_string_example_plan(example_plan)
         raise TypeError(
             f"Invalid example plan type: {type(example_plan)}. "
-            "Expected Plan, PlanUUID, UUID, or str."
+            "Expected Plan, PlanUUID, or str."
         )
 
     def _load_plan_by_uuid(self, plan_uuid: PlanUUID) -> Plan:

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -64,10 +64,9 @@ from portia.introspection_agents.introspection_agent import (
 )
 from portia.logger import logger, logger_manager
 from portia.open_source_tools.llm_tool import LLMTool
-from portia.plan import Plan, PlanContext, PlanInput, ReadOnlyPlan, ReadOnlyStep, Step
+from portia.plan import Plan, PlanContext, PlanInput, PlanUUID, ReadOnlyPlan, ReadOnlyStep, Step
 from portia.plan_run import PlanRun, PlanRunState, PlanRunUUID, ReadOnlyPlanRun
 from portia.planning_agents.default_planning_agent import DefaultPlanningAgent
-from portia.prefixed_uuid import PlanUUID
 from portia.storage import (
     DiskFileStorage,
     InMemoryStorage,
@@ -168,7 +167,7 @@ class Portia:
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan] | None = None,
+        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_run_inputs: list[PlanInput] | list[dict[str, str]] | dict[str, str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -182,8 +181,11 @@ class Portia:
             query (str): The query to be executed.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan] | None): Optional list of example plans. If not
-            provide a default set of example plans will be used.
+            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
+            plans or plan IDs. This can include Plan objects, PlanUUID objects, raw UUID
+            objects,
+            or plan ID strings (starting with "plan-"). Plan IDs and UUIDs will be loaded from
+            storage. If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The end user for this plan run.
             plan_run_inputs (list[PlanInput] | list[dict[str, str]] | dict[str, str] | None):
                 Provides input values for the run. This can be a list of PlanInput objects, a list
@@ -265,7 +267,7 @@ class Portia:
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan] | None = None,
+        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -277,8 +279,11 @@ class Portia:
             query (str): The query to generate the plan for.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan] | None): Optional list of example plans. If not
-            provide a default set of example plans will be used.
+            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
+            plans or plan IDs.
+            This can include Plan objects, PlanUUID objects, raw UUID objects, or plan ID strings
+            (starting with "plan-"). Plan IDs and UUIDs will be loaded from storage.
+            If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
             plan_inputs (list[PlanInput] | list[dict[str, str]] | list[str] | None): Optional list
                 of inputs required for the plan.
@@ -324,11 +329,81 @@ class Portia:
             use_cached_plan,
         )
 
+    def _resolve_example_plans(
+        self, example_plans: list[Plan | PlanUUID | UUID | str] | None
+    ) -> list[Plan] | None:
+        """Resolve example plans from Plan objects, PlanUUIDs, UUID strings, and planID strings.
+
+        Args:
+            example_plans (list[Plan | PlanUUID | UUID | str] | None): List of example plans or
+            plan IDs.
+                - Plan objects are used directly
+                - PlanUUID objects are loaded from storage
+                - UUID objects are converted to PlanUUID and loaded from storage
+                - String objects must be plan ID strings (starting with "plan-")
+
+        Returns:
+            list[Plan] | None: List of resolved Plan objects, or None if input was None.
+
+        Raises:
+            PlanNotFoundError: If a plan ID cannot be found in storage.
+            ValueError: If a string is not a plan ID string.
+            TypeError: If an invalid type is provided.
+
+        """
+        if example_plans is None:
+            return None
+
+        resolved_plans = []
+        for example_plan in example_plans:
+            resolved_plan = self._resolve_single_example_plan(example_plan)
+            resolved_plans.append(resolved_plan)
+
+        return resolved_plans
+
+    def _resolve_single_example_plan(self, example_plan: Plan | PlanUUID | UUID | str) -> Plan:
+        """Resolve a single example plan from various input types."""
+        if isinstance(example_plan, Plan):
+            return example_plan
+        if isinstance(example_plan, PlanUUID):
+            return self._load_plan_by_uuid(example_plan)
+        if isinstance(example_plan, UUID):
+            plan_uuid = PlanUUID(uuid=example_plan)
+            return self._load_plan_by_uuid(plan_uuid)
+        if isinstance(example_plan, str):
+            return self._resolve_string_example_plan(example_plan)
+        raise TypeError(
+            f"Invalid example plan type: {type(example_plan)}. "
+            "Expected Plan, PlanUUID, UUID, or str."
+        )
+
+    def _load_plan_by_uuid(self, plan_uuid: PlanUUID) -> Plan:
+        """Load a plan from storage by UUID."""
+        try:
+            return self.storage.get_plan(plan_uuid)
+        except Exception as e:
+            raise PlanNotFoundError(plan_uuid) from e
+
+    def _resolve_string_example_plan(self, example_plan: str) -> Plan:
+        """Resolve a string example plan - must be a plan ID string."""
+        # Only support plan ID strings, not query strings
+        if not example_plan.startswith("plan-"):
+            raise ValueError(
+                f"String '{example_plan}' must be a plan ID (starting with 'plan-'). "
+                "Query strings are not supported."
+            )
+
+        plan_uuid = PlanUUID.from_string(example_plan)
+        try:
+            return self._load_plan_by_uuid(plan_uuid)
+        except Exception as e:
+            raise PlanNotFoundError(plan_uuid) from e
+
     def _plan(
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan] | None = None,
+        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -340,8 +415,11 @@ class Portia:
             query (str): The query to generate the plan for.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan] | None): Optional list of example plans. If not
-            provide a default set of example plans will be used.
+            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
+            plans or plan IDs.
+            This can include Plan objects, PlanUUID objects, raw UUID objects, or plan ID strings
+            (starting with "plan-"). Plan IDs and UUIDs will be loaded from storage.
+            If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
             plan_inputs (list[PlanInput] | list[dict[str, str]] | list[str] | None): Optional list
                 of inputs required for the plan.
@@ -376,6 +454,9 @@ class Portia:
         if not tools:
             tools = self.tool_registry.match_tools(query)
 
+        # Resolve example plans from PlanUUIDs to Plan objects
+        resolved_example_plans = self._resolve_example_plans(example_plans)
+
         end_user = self.initialize_end_user(end_user)
         logger().info(f"Running planning_agent for query - {query}")
         planning_agent = self._get_planning_agent()
@@ -384,7 +465,7 @@ class Portia:
             query=query,
             tool_list=tools,
             end_user=end_user,
-            examples=example_plans,
+            examples=resolved_example_plans,
             plan_inputs=coerced_plan_inputs,
         )
         if outcome.error:
@@ -396,7 +477,7 @@ class Portia:
                     outcome.error,
                     query,
                     end_user,
-                    example_plans,
+                    resolved_example_plans,
                 )
             logger().error(f"Error in planning - {outcome.error}")
             raise PlanError(outcome.error)

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -167,7 +167,7 @@ class Portia:
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
+        example_plans: list[Plan | PlanUUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_run_inputs: list[PlanInput] | list[dict[str, str]] | dict[str, str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -181,10 +181,9 @@ class Portia:
             query (str): The query to be executed.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
-            plans or plan IDs. This can include Plan objects, PlanUUID objects, raw UUID
-            objects,
-            or plan ID strings (starting with "plan-"). Plan IDs and UUIDs will be loaded from
+            example_plans (list[Plan | PlanUUID | str] | None): Optional list of example
+            plans or plan IDs. This can include Plan objects, PlanUUID objects,
+            or plan ID strings (starting with "plan-"). Plan IDs will be loaded from
             storage. If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The end user for this plan run.
             plan_run_inputs (list[PlanInput] | list[dict[str, str]] | dict[str, str] | None):
@@ -267,7 +266,7 @@ class Portia:
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
+        example_plans: list[Plan | PlanUUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -279,10 +278,10 @@ class Portia:
             query (str): The query to generate the plan for.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
+            example_plans (list[Plan | PlanUUID | str] | None): Optional list of example
             plans or plan IDs.
-            This can include Plan objects, PlanUUID objects, raw UUID objects, or plan ID strings
-            (starting with "plan-"). Plan IDs and UUIDs will be loaded from storage.
+            This can include Plan objects, PlanUUID objects, or plan ID strings
+            (starting with "plan-"). Plan IDs will be loaded from storage.
             If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
             plan_inputs (list[PlanInput] | list[dict[str, str]] | list[str] | None): Optional list
@@ -330,16 +329,15 @@ class Portia:
         )
 
     def _resolve_example_plans(
-        self, example_plans: list[Plan | PlanUUID | UUID | str] | None
+        self, example_plans: list[Plan | PlanUUID | str] | None
     ) -> list[Plan] | None:
-        """Resolve example plans from Plan objects, PlanUUIDs, UUID strings, and planID strings.
+        """Resolve example plans from Plan objects, PlanUUIDs and planID strings.
 
         Args:
-            example_plans (list[Plan | PlanUUID | UUID | str] | None): List of example plans or
+            example_plans (list[Plan | PlanUUID | str] | None): List of example plans or
             plan IDs.
                 - Plan objects are used directly
                 - PlanUUID objects are loaded from storage
-                - UUID objects are converted to PlanUUID and loaded from storage
                 - String objects must be plan ID strings (starting with "plan-")
 
         Returns:
@@ -367,9 +365,6 @@ class Portia:
             return example_plan
         if isinstance(example_plan, PlanUUID):
             return self._load_plan_by_uuid(example_plan)
-        if isinstance(example_plan, UUID):
-            plan_uuid = PlanUUID(uuid=example_plan)
-            return self._load_plan_by_uuid(plan_uuid)
         if isinstance(example_plan, str):
             return self._resolve_string_example_plan(example_plan)
         raise TypeError(
@@ -403,7 +398,7 @@ class Portia:
         self,
         query: str,
         tools: list[Tool] | list[str] | None = None,
-        example_plans: list[Plan | PlanUUID | UUID | str] | None = None,
+        example_plans: list[Plan | PlanUUID | str] | None = None,
         end_user: str | EndUser | None = None,
         plan_inputs: list[PlanInput] | list[dict[str, str]] | list[str] | None = None,
         structured_output_schema: type[BaseModel] | None = None,
@@ -415,10 +410,10 @@ class Portia:
             query (str): The query to generate the plan for.
             tools (list[Tool] | list[str] | None): List of tools to use for the query.
             If not provided all tools in the registry will be used.
-            example_plans (list[Plan | PlanUUID | UUID | str] | None): Optional list of example
+            example_plans (list[Plan | PlanUUID | str] | None): Optional list of example
             plans or plan IDs.
-            This can include Plan objects, PlanUUID objects, raw UUID objects, or plan ID strings
-            (starting with "plan-"). Plan IDs and UUIDs will be loaded from storage.
+            This can include Plan objects, PlanUUID objects or plan ID strings
+            (starting with "plan-"). Plan IDs will be loaded from storage.
             If not provided, a default set of example plans will be used.
             end_user (str | EndUser | None = None): The optional end user for this plan.
             plan_inputs (list[PlanInput] | list[dict[str, str]] | list[str] | None): Optional list
@@ -454,7 +449,6 @@ class Portia:
         if not tools:
             tools = self.tool_registry.match_tools(query)
 
-        # Resolve example plans from PlanUUIDs to Plan objects
         resolved_example_plans = self._resolve_example_plans(example_plans)
 
         end_user = self.initialize_end_user(end_user)

--- a/tests/unit/test_portia.py
+++ b/tests/unit/test_portia.py
@@ -2835,7 +2835,7 @@ def test_portia_tool_readiness_rechecked_after_raised_clarification(
 
 
 def test_portia_run_plan_with_all_plan_types(portia: Portia, telemetry: MagicMock) -> None:
-    """Test that run_plan works with Plan, PlanUUID, and raw UUID types."""
+    """Test that run_plan works with Plan and PlanUUID types."""
     # Create a test plan
     plan = Plan(
         plan_context=PlanContext(query="test all plan types", tool_ids=["add_tool"]),
@@ -2864,7 +2864,7 @@ def test_portia_run_plan_with_all_plan_types(portia: Portia, telemetry: MagicMoc
         plan_run_2 = portia.run_plan(plan.id)
         assert plan_run_2.plan_id == plan.id
 
-        # Verify resume was called 3 times
+        # Verify resume was called 2 times
         assert mock_resume.call_count == 2
 
         # Verify all plan runs have the same plan_id
@@ -2901,7 +2901,7 @@ def test_portia_run_plan_with_all_plan_types_error_handling(portia: Portia) -> N
 
 
 def test_portia_example_plans_with_all_types(portia: Portia, planning_model: MagicMock) -> None:
-    """Test that example_plans parameter works with Plan, PlanUUID, UUID, and string types."""
+    """Test that example_plans parameter works with Plan, PlanUUID, and string types."""
     # Create example plans
     example_plan_1 = Plan(
         plan_context=PlanContext(query="example query 1", tool_ids=["add_tool"]),
@@ -2919,7 +2919,7 @@ def test_portia_example_plans_with_all_types(portia: Portia, planning_model: Mag
     # Mock planning model
     planning_model.get_structured_response.return_value = StepsOrError(steps=[], error=None)
 
-    # Test with mixed example_plans types: Plan, PlanUUID, UUID, string
+    # Test with mixed example_plans types: Plan, PlanUUID, string
     example_plans = [
         example_plan_1,  # Plan object
         example_plan_2.id,  # PlanUUID
@@ -2959,7 +2959,7 @@ def test_portia_resolve_example_plans_error_handling(portia: Portia) -> None:
 
     # Test with raw UUID, should raise TypeError
     with pytest.raises(TypeError, match="Invalid example plan type"):
-        portia._resolve_example_plans([UUID("99fc470b-4cbd-489b-b251-7076bf7e8f05")])
+        portia._resolve_example_plans([UUID("99fc470b-4cbd-489b-b251-7076bf7e8f05")])  # type: ignore[arg-type]
 
 
 
@@ -2982,8 +2982,7 @@ def test_portia_run_with_example_plans_all_types(portia: Portia, planning_model:
     # Mock planning model
     planning_model.get_structured_response.return_value = StepsOrError(steps=[], error=None)
 
-    # Test with mixed example_plans types: Plan, PlanUUID, UUID
-    # We'll test string queries separately since they need special handling
+    # Test with mixed example_plans types: Plan, PlanUUID
     example_plans = [
         example_plan_1,  # Plan object
         example_plan_2.id,  # PlanUUID
@@ -3013,7 +3012,7 @@ def test_portia_resolve_example_plans_with_all_types(portia: Portia) -> None:
     portia.storage.save_plan(example_plan_1)
     portia.storage.save_plan(example_plan_2)
 
-    # Test with all supported types: Plan, PlanUUID, UUID, plan ID string
+    # Test with all supported types: Plan, PlanUUID, plan ID string
     example_plans = [
         example_plan_1,  # Plan object
         example_plan_2.id,  # PlanUUID
@@ -3084,7 +3083,7 @@ def test_portia_resolve_example_plans_with_plan_id_strings(portia: Portia) -> No
     plan_id_string_1 = str(example_plan_1.id)  # "plan-uuid"
     plan_id_string_2 = str(example_plan_2.id)  # "plan-uuid"
 
-    example_plans: list[Plan | PlanUUID | UUID | str] = [plan_id_string_1, plan_id_string_2]
+    example_plans: list[Plan | PlanUUID | str] = [plan_id_string_1, plan_id_string_2]
 
     resolved_plans = portia._resolve_example_plans(example_plans)
 


### PR DESCRIPTION
# Description

Allows multiple input types for plan identification. Users can now use Plan objects, PlanUUID objects, raw UUID objects, and plan ID strings interchangeably.

```
# Before: Only worked with Plan objects
portia.run_plan(plan)

# After
portia.run_plan(plan)                    # Plan object
portia.run_plan(plan.id)                 # PlanUUID
portia.run_plan(plan.id.uuid)            # Raw UUID

# Example plans also support mixed types
plan_id_1 = PlanUUID.from_string("plan-f66b141b-5603-4bd9-b827-0c7a41bf5d5c")
plan_id_2 = "plan-f66b141b-5603-4bd9-b827-0c7a41bf5d5c"
portia.plan(
    query="Get the weather in Paris",
    example_plans=[plan_id_1, plan_id_2]  # Mixed types supported
)
```
Ticket Link: https://github.com/portiaAI/portia-sdk-python/issues/574

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Testing

- Unit Tests
- Tested by trying portia plan in example.py - Run this https://pastebin.com/7fEN38j9