### PR TITLE
[POR-1651] Fix various issues with soft error handling

### DIFF
--- a/portia/execution_agents/base_execution_agent.py
+++ b/portia/execution_agents/base_execution_agent.py
@@ -12,7 +12,12 @@ from langchain_core.messages import ToolMessage
 from langgraph.graph import END, MessagesState
 
 from portia.execution_agents.context import StepInput, build_context
-from portia.execution_agents.execution_utils import MAX_RETRIES, AgentNode, is_clarification
+from portia.execution_agents.execution_utils import (
+    MAX_RETRIES,
+    AgentNode,
+    is_clarification,
+    is_soft_tool_error,
+)
 from portia.execution_agents.output import LocalDataValue
 from portia.logger import logger
 from portia.plan import Plan, ReadOnlyStep, Step
@@ -144,9 +149,9 @@ class BaseExecutionAgent:
         """
         messages = state["messages"]
         last_message = messages[-1]
-        errors = [msg for msg in messages if "ToolSoftError" in msg.content]
+        errors = [msg for msg in messages if is_soft_tool_error(msg)]
 
-        if "ToolSoftError" in last_message.content and len(errors) < MAX_RETRIES:
+        if is_soft_tool_error(last_message) and len(errors) < MAX_RETRIES:
             return AgentNode.TOOL_AGENT
 
         for message in messages:

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -24,6 +24,7 @@ from portia.execution_agents.clarification_tool import ClarificationTool
 from portia.execution_agents.context import StepInput  # noqa: TC001
 from portia.execution_agents.execution_utils import (
     AgentNode,
+    is_soft_tool_error,
     process_output,
     template_in_required_inputs,
     tool_call_or_end,
@@ -169,7 +170,7 @@ class OneShotToolCallingModel:
 
         model = self.model.to_langchain().bind_tools(self.tools)
         messages = state["messages"]
-        past_errors = [str(msg) for msg in messages if "ToolSoftError" in msg.content]
+        past_errors = [str(msg) for msg in messages if is_soft_tool_error(msg)]
         clarification_tool = ClarificationTool(step=self.agent.plan_run.current_step_index)
         formatted_messages = self.arg_parser_prompt.format_messages(
             context=self.agent.get_system_context(self.tool_context, state["step_inputs"]),

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -498,11 +498,9 @@ class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
         output_value = output.get_value()
 
         # Handle Tool Errors
-        if isinstance(output_value, str):
-            if "ToolSoftError" in output_value:
-                raise ToolSoftError(output_value)
-            if "ToolHardError" in output_value:
-                raise ToolHardError(output_value)
+        if "soft_error" in response:
+            raise ToolSoftError(str(output_value))
+
         # Handle Clarifications
         if isinstance(output_value, list) and output_value and "category" in output_value[0]:
             clarification = output_value[0]

--- a/tests/unit/execution_agents/test_base_execution_agent.py
+++ b/tests/unit/execution_agents/test_base_execution_agent.py
@@ -109,6 +109,7 @@ def test_next_state_after_tool_call_no_error() -> None:
             content="Success message",
             tool_call_id="123",
             name="test_tool",
+            status="success",
         ),
     ]
     state: MessagesState = {"messages": messages}  # type: ignore  # noqa: PGH003
@@ -139,6 +140,7 @@ def test_next_state_after_tool_call_with_summarize() -> None:
             content="Success message",
             tool_call_id="123",
             name="test_tool",
+            status="success",
         ),
     ]
     state: MessagesState = {"messages": messages}  # type: ignore  # noqa: PGH003
@@ -171,6 +173,7 @@ def test_next_state_after_tool_call_with_large_output() -> None:
             content="Test" * 1000,
             tool_call_id="123",
             name="test_tool",
+            status="success",
         ),
     ]
     state: MessagesState = {"messages": messages}  # type: ignore  # noqa: PGH003
@@ -199,6 +202,7 @@ def test_next_state_after_tool_call_with_error_retry() -> None:
                 content=f"ToolSoftError: Error {j}",
                 tool_call_id=str(j),
                 name="test_tool",
+                status="error",
             )
             for j in range(1, i + 1)
         ]
@@ -238,6 +242,7 @@ def test_next_state_after_tool_call_with_clarification_artifact() -> None:
             tool_call_id="123",
             name="test_tool",
             artifact=clarification,
+            status="success",
         ),
     ]
     state: MessagesState = {"messages": messages}  # type: ignore  # noqa: PGH003
@@ -285,6 +290,7 @@ def test_next_state_after_tool_call_with_list_of_clarifications() -> None:
             tool_call_id="123",
             name="test_tool",
             artifact=clarifications,
+            status="success",
         ),
     ]
     state: MessagesState = {"messages": messages}  # type: ignore  # noqa: PGH003

--- a/tests/unit/execution_agents/test_execution_utils.py
+++ b/tests/unit/execution_agents/test_execution_utils.py
@@ -63,8 +63,18 @@ def test_process_output_with_tool_errors() -> None:
     """Test process_output with tool errors."""
     tool = AdditionTool()
 
-    soft_error = ToolMessage(content="Error: ToolSoftError(test)", tool_call_id="1", name="test")
-    hard_error = ToolMessage(content="Error: ToolHardError(test)", tool_call_id="1", name="test")
+    soft_error = ToolMessage(
+        content="Error: ToolSoftError(test)",
+        tool_call_id="1",
+        name="test",
+        status="error",
+    )
+    hard_error = ToolMessage(
+        content="Error: ToolHardError(test)",
+        tool_call_id="1",
+        name="test",
+        status="error",
+    )
 
     with pytest.raises(ToolRetryError):
         process_output([soft_error], tool)

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -250,7 +250,7 @@ def test_remote_tool_soft_error(httpx_mock: HTTPXMock) -> None:
     endpoint = "https://api.fake-portia.test"
     httpx_mock.add_response(
         url=f"{endpoint}/api/v0/tools/test/run/",
-        json={"output": {"value": "ToolSoftError: An error occurred."}},
+        json={"output": {"value": "ToolSoftError: An error occurred."}, "soft_error": True},
     )
 
     tool = PortiaRemoteTool(
@@ -312,44 +312,6 @@ def test_remote_tool_bad_response(httpx_mock: HTTPXMock) -> None:
         },
     }
 
-    assert (
-        httpx_mock.get_request(
-            method="POST",
-            url=f"{endpoint}/api/v0/tools/test/run/",
-            match_json=content,
-        )
-        is not None
-    )
-
-
-def test_remote_tool_hard_error(httpx_mock: HTTPXMock) -> None:
-    """Test remote hard errors come back to hard errors."""
-    endpoint = "https://api.fake-portia.test"
-    httpx_mock.add_response(
-        url=f"{endpoint}/api/v0/tools/test/run/",
-        json={"output": {"value": "ToolHardError: An error occurred."}},
-    )
-
-    tool = PortiaRemoteTool(
-        id="test",
-        name="test",
-        description="",
-        output_schema=("", ""),
-        client=httpx.Client(base_url=endpoint),
-    )
-
-    ctx = get_test_tool_context()
-    with pytest.raises(ToolHardError):
-        tool.run(ctx)
-
-    content = {
-        "arguments": {},
-        "execution_context": {
-            "end_user_id": ctx.end_user.external_id,
-            "plan_run_id": str(ctx.plan_run.id),
-            "additional_data": ctx.end_user.additional_data,
-        },
-    }
     assert (
         httpx_mock.get_request(
             method="POST",


### PR DESCRIPTION
# Description

Ensure that if linear returns a result containing ToolSoftError, that it will not interpret this as an actual error.

Closes: POR-1571

Ticket Link: N/A 

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [X] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
