### PR TITLE
Adjust planning prompt

### DIFF
--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -57,7 +57,8 @@ IMPORTANT GUIDELINES:
   2. Condition field: Write the condition in concise natural language.
 - Do not use the condition field for non-conditional steps.
 - If plan inputs are provided, make sure you specify them as inputs to the appropriate steps.
-- Only use plan inputs if they are provided - DO NOT make any up
+- Only use plan inputs if they are provided - DO NOT make any up. Use the error field if you do not
+have the correct plan inputs to generate a plan.
 """
 
 


### PR DESCRIPTION
# Description

There have been a number of recent eval drops on anthropic particularly for is_plan_generated. Full analysis is [here](https://docs.google.com/document/d/13hT0M4ta-Q3JoMmYNIlmsxa-xqvi3B270b_sbcw0Z0w/edit?tab=t.0). But to summarise, this is mostly one eval that is failing because it _wants_ an error to be produced but instead the planner is hallucinating a second plan input that doesn't exist.

Over 200 runs on that particular eval, the is_plan_generated metric increased from 0.4 to 0.8 and running across the complete eval set showed no drop on other metrics so I think worth getting this in.

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
