### PR TITLE
Fix logging issue

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1242,9 +1242,11 @@ class Portia:
                     return plan_run
 
                 logger().info(
-                    f"Executing step {index}: {step.task}",
-                    plan=str(plan.id),
-                    plan_run=str(plan_run.id),
+                    f"Executing step {index}: {step.task.replace('{', '{{').replace('}', '}}')}",
+                    extra={
+                        "plan_id": str(plan.id),
+                        "plan_run_id": str(plan_run.id),
+                    },
                 )
 
                 if (

--- a/uv.lock
+++ b/uv.lock
@@ -1878,7 +1878,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

This was causing an error to be printed to the logs when the task contains a variable with {} in it.

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
