### PR TITLE
timeout length upped

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   testing:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest-16core
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Description

Tests sometimes go above 15m and with async tests incomming, is timeing out the PR's

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
