### PR TITLE
Support additionalProperties and improve serialisation of pydantic objects

### DIFF
--- a/portia/tool.py
+++ b/portia/tool.py
@@ -711,6 +711,14 @@ class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
 
         """
         try:
+            # Default function for JSON serialization of Pydantic models
+            def default_serializer(
+                obj: Any,  # noqa: ANN401
+            ) -> dict[str, Any] | list[Any] | str | int | float | bool | None:
+                if isinstance(obj, BaseModel):
+                    return json.loads(obj.model_dump_json())
+                raise TypeError(f"Object of type {type(obj)} is not JSON serializable")  # noqa: TRY301
+
             # Send to Cloud
             response = self.client.post(
                 url=f"/api/v0/tools/{self.id}/run/",
@@ -723,6 +731,7 @@ class PortiaRemoteTool(Tool, Generic[SERIALIZABLE_TYPE_VAR]):
                             "additional_data": ctx.end_user.additional_data,
                         },
                     },
+                    default=default_serializer,
                 ),
             )
             response.raise_for_status()

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -769,7 +769,7 @@ def _additional_properties_validator(
 ) -> BaseModelT:
     """Validate that extra properties against a schema."""
     if self.model_extra is None:
-        return self
+        return self  # pragma: no cover
     for key, value in self.model_extra.items():  # all unknowns live here
         try:
             extras_schema.model_validate({field_name: value})

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -282,6 +282,30 @@ def test_remote_tool_hard_error_from_server(httpx_mock: HTTPXMock) -> None:
     )
 
 
+def test_remote_tool_run_with_unserializable_object() -> None:
+    """Test remote tool run with unserializable object."""
+    endpoint = "https://api.fake-portia.test"
+
+    class UnserializableObject:
+        pass
+
+    tool = PortiaRemoteTool(
+        id="test",
+        name="test",
+        description="",
+        output_schema=("", ""),
+        client=httpx.Client(base_url=endpoint),
+    )
+    ctx = get_test_tool_context()
+    with pytest.raises(
+        ToolHardError,
+        match="Object of type <class 'tests.unit.test_tool."
+        "test_remote_tool_run_with_unserializable_object"
+        ".<locals>.UnserializableObject'> is not JSON serializable",
+    ):
+        tool.run(ctx, some_object=UnserializableObject())
+
+
 def test_remote_tool_soft_error(httpx_mock: HTTPXMock) -> None:
     """Test remote soft errors come back to soft errors."""
     endpoint = "https://api.fake-portia.test"


### PR DESCRIPTION
# Description

- Fixed serialisation of pydantic objects to JSON when they found nested within Python objects (e.g. list of pydantic objects)
- Support JSON schema `additionalProperties` on objects by allowing extra fields on the pydantic object, and validating the types if provided. 

Ticket Link: [POR-1767](https://linear.app/portialabs/issue/POR-1767/fix-notion-create-pages-tool-schema-is-incompatible-with-sdk)

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
