### PR TITLE
Fix logging exceptions within Stripe demo

### DIFF
--- a/portia/logger.py
+++ b/portia/logger.py
@@ -114,6 +114,7 @@ class Formatter:
         )
         if record.get("exception") and hasattr(record["exception"], "value"):
             formatted_stack_trace = "".join(traceback.format_exception(record["exception"].value))
+            formatted_stack_trace = self._sanitize_message_(formatted_stack_trace, truncate=False)
             result += f"\n{formatted_stack_trace}"
 
         # Add extra information if present
@@ -123,7 +124,7 @@ class Formatter:
         result += "\n"
         return result
 
-    def _sanitize_message_(self, msg: str) -> str:
+    def _sanitize_message_(self, msg: str, truncate: bool = True) -> str:
         """Sanitize a message to be used in a log record."""
         # doubles opening curly braces in a string { -> {{
         msg = re.sub(r"(?<!\{)\{(?!\{)", "{{", msg)
@@ -132,7 +133,7 @@ class Formatter:
         # escapes < and > in a string
         msg = msg.replace("<", r"\<").replace(">", r"\>")
 
-        return self._truncated_message_(msg)
+        return self._truncated_message_(msg) if truncate else msg
 
     def _get_function_color_(self, record: Any) -> str:  # noqa: ANN401
         """Get color based on function/module name. Default is white."""

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1779,13 +1779,13 @@ class Portia:
     def _handle_execution_error(
         self, plan_run: PlanRun, plan: Plan, index: int, step: Step, error: Exception
     ) -> PlanRun:
-        logger().exception(f"Error executing step {index}: {error}")
         error_output = LocalDataValue(value=str(error))
         self._set_step_output(error_output, plan_run, step)
         plan_run.outputs.final_output = error_output
         self._set_plan_run_state(plan_run, PlanRunState.FAILED)
         logger().error(
-            "error: {error}",
+            "Error executing step {index}: {error}",
+            index=index,
             error=error,
             plan=str(plan.id),
             plan_run=str(plan_run.id),

--- a/uv.lock
+++ b/uv.lock
@@ -1912,7 +1912,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Previously, the stack traces in the Stripe demo were causing an error for the logger because they had unescaped quotation marks. I've fixed that by sanitising the stack trace too. However, I also think the stack trace wasn't really needed for tool errors, so I've also combined it with the .error() message below.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
