### PR TITLE
Update pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 classifiers = ["Development Status :: 3 - Alpha"]
 dependencies = [
-    "pydantic>=2.10.3,<3",
+    "pydantic>=2.11.5,<3",
     "jinja2>=3.1.4,<4",
     "instructor>=1.9.0,<2 ; python_version >= '3.11' and python_version < '4.0'",
     "anthropic>=0.41.0,<=0.55.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1912,7 +1912,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'tools-browser-browserbase'", specifier = ">=1.49.0,<2" },
     { name = "playwright", marker = "extra == 'tools-browser-local'", specifier = ">=1.49.0,<2" },
     { name = "posthog", specifier = "~=6.0" },
-    { name = "pydantic", specifier = ">=2.10.3,<3" },
+    { name = "pydantic", specifier = ">=2.11.5,<3" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "redis", marker = "extra == 'all'", specifier = ">=5.2.1,<6" },


### PR DESCRIPTION
# Description

There was a pydantic fix that went into 2.11.5. Without that, https://github.com/portiaAI/portia-sdk-python/pull/633 causes an error when we loads tools from Portia.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
