### PR TITLE
Add llm tool default back

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -45,6 +45,7 @@ from portia.errors import (
     PlanError,
     PlanNotFoundError,
     SkipExecutionError,
+    ToolNotFoundError,
 )
 from portia.execution_agents.base_execution_agent import BaseExecutionAgent
 from portia.execution_agents.default_execution_agent import DefaultExecutionAgent
@@ -2126,11 +2127,14 @@ class Portia:
     def _get_tool_for_step(self, step: Step, plan_run: PlanRun) -> Tool | None:
         if not step.tool_id:
             return None
-        if step.tool_id == LLMTool.LLM_TOOL_ID:
-            # Special case LLMTool so it doesn't need to be in all tool registries
-            child_tool = LLMTool()
-        else:
+        try:
             child_tool = self.tool_registry.get_tool(step.tool_id)
+        except ToolNotFoundError:
+            # Special case LLMTool so it doesn't need to be in all tool registries
+            if step.tool_id == LLMTool.LLM_TOOL_ID:
+                child_tool = LLMTool()
+            else:
+                raise
         return ToolCallWrapper(
             child_tool=child_tool,
             storage=self.storage,

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -2126,7 +2126,11 @@ class Portia:
     def _get_tool_for_step(self, step: Step, plan_run: PlanRun) -> Tool | None:
         if not step.tool_id:
             return None
-        child_tool = self.tool_registry.get_tool(step.tool_id)
+        if step.tool_id == LLMTool.LLM_TOOL_ID:
+            # Special case LLMTool so it doesn't need to be in all tool registries
+            child_tool = LLMTool()
+        else:
+            child_tool = self.tool_registry.get_tool(step.tool_id)
         return ToolCallWrapper(
             child_tool=child_tool,
             storage=self.storage,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,6 @@ import pytest
 
 from portia.config import FEATURE_FLAG_AGENT_MEMORY_ENABLED, GenerativeModelsConfig
 from portia.model import GenerativeModel
-from portia.open_source_tools.llm_tool import LLMTool
 from portia.portia import Portia
 from portia.telemetry.telemetry_service import BaseProductTelemetry
 from portia.tool_registry import ToolRegistry
@@ -42,7 +41,7 @@ def portia(planning_model: MagicMock, default_model: MagicMock, telemetry: Magic
             default_model=default_model,
         ),
     )
-    tool_registry = ToolRegistry([AdditionTool(), ClarificationTool(), LLMTool()])
+    tool_registry = ToolRegistry([AdditionTool(), ClarificationTool()])
     return Portia(config=config, tools=tool_registry, telemetry=telemetry)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1912,7 +1912,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

This adds the LLM tool default back (see slack for details) but tries to fetch it from the registry first. This is needed in order to make the tool stubbing work within steel thread.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
