### PR TITLE
Add an optional timeout for tool calls

### DIFF
--- a/portia/mcp_session.py
+++ b/portia/mcp_session.py
@@ -38,6 +38,7 @@ class SseMcpClientConfig(BaseModel):
     headers: dict[str, Any] | None = None
     timeout: float = 5
     sse_read_timeout: float = 60 * 5
+    tool_call_timeout_seconds: float | None = None
 
 
 class StdioMcpClientConfig(BaseModel):
@@ -49,6 +50,7 @@ class StdioMcpClientConfig(BaseModel):
     env: dict[str, str] | None = None
     encoding: str = "utf-8"
     encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    tool_call_timeout_seconds: float | None = None
 
     @classmethod
     def from_raw(cls, config: str | dict[str, Any]) -> StdioMcpClientConfig:
@@ -108,6 +110,7 @@ class StreamableHttpMcpClientConfig(BaseModel):
     sse_read_timeout: float = 60 * 5
     terminate_on_close: bool = True
     auth: httpx.Auth | None = None
+    tool_call_timeout_seconds: float | None = None
 
 
 McpClientConfig = SseMcpClientConfig | StdioMcpClientConfig | StreamableHttpMcpClientConfig

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -847,4 +847,4 @@ class PortiaMcpTool(Tool[str]):
                     f"{self.mcp_client_config.tool_call_timeout_seconds}s"
                 ) from None
             # Non-timeout MCP errors: surface as a soft error for callers
-            raise ToolSoftError(f"MCP tool {name} error: {eg}") from None
+            raise ToolHardError(f"MCP tool {name} error: {eg}") from None

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -841,7 +841,6 @@ class PortiaMcpTool(Tool[str]):
                     and inner.error.code == httpx.codes.REQUEST_TIMEOUT
                 ):
                     is_timeout = True
-                    break
             if is_timeout:
                 raise ToolSoftError(
                     f"MCP tool {name} timed out after "

--- a/portia/tool_registry.py
+++ b/portia/tool_registry.py
@@ -418,6 +418,7 @@ class McpToolRegistry(ToolRegistry):
         timeout: float = 5,
         sse_read_timeout: float = 60 * 5,
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using an SSE connection (Sync version)."""
         config = SseMcpClientConfig(
@@ -426,6 +427,7 @@ class McpToolRegistry(ToolRegistry):
             headers=headers,
             timeout=timeout,
             sse_read_timeout=sse_read_timeout,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = cls._load_tools(config, read_timeout=tool_list_read_timeout)
         return cls(tools)
@@ -439,6 +441,7 @@ class McpToolRegistry(ToolRegistry):
         timeout: float = 5,  # noqa: ASYNC109
         sse_read_timeout: float = 60 * 5,
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using an SSE connection (Async version)."""
         config = SseMcpClientConfig(
@@ -447,6 +450,7 @@ class McpToolRegistry(ToolRegistry):
             headers=headers,
             timeout=timeout,
             sse_read_timeout=sse_read_timeout,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = await cls._load_tools_async(config, read_timeout=tool_list_read_timeout)
         return cls(tools)
@@ -461,6 +465,7 @@ class McpToolRegistry(ToolRegistry):
         encoding: str = "utf-8",
         encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict",
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using a stdio connection (Sync version)."""
         config = StdioMcpClientConfig(
@@ -470,6 +475,7 @@ class McpToolRegistry(ToolRegistry):
             env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = cls._load_tools(config, read_timeout=tool_list_read_timeout)
         return cls(tools)
@@ -479,6 +485,7 @@ class McpToolRegistry(ToolRegistry):
         cls,
         config: str | dict[str, Any],
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using a stdio connection from a string.
 
@@ -487,12 +494,14 @@ class McpToolRegistry(ToolRegistry):
         Args:
             config: The string or dict to parse.
             tool_list_read_timeout: The timeout for the request.
+            tool_call_timeout_seconds: The timeout for the tool call.
 
         Returns:
             A McpToolRegistry.
 
         """
         parsed_config = StdioMcpClientConfig.from_raw(config)
+        parsed_config.tool_call_timeout_seconds = tool_call_timeout_seconds
         tools = cls._load_tools(parsed_config, read_timeout=tool_list_read_timeout)
         return cls(tools)
 
@@ -506,6 +515,7 @@ class McpToolRegistry(ToolRegistry):
         encoding: str = "utf-8",
         encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict",
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using a stdio connection (Async version)."""
         config = StdioMcpClientConfig(
@@ -515,6 +525,7 @@ class McpToolRegistry(ToolRegistry):
             env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = await cls._load_tools_async(config, read_timeout=tool_list_read_timeout)
         return cls(tools)
@@ -531,6 +542,7 @@ class McpToolRegistry(ToolRegistry):
         terminate_on_close: bool = True,
         auth: httpx.Auth | None = None,
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using a StreamableHTTP connection (Sync version)."""
         config = StreamableHttpMcpClientConfig(
@@ -541,6 +553,7 @@ class McpToolRegistry(ToolRegistry):
             sse_read_timeout=sse_read_timeout,
             terminate_on_close=terminate_on_close,
             auth=auth,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = cls._load_tools(config, read_timeout=tool_list_read_timeout)
         return cls(tools)
@@ -557,6 +570,7 @@ class McpToolRegistry(ToolRegistry):
         terminate_on_close: bool = True,
         auth: httpx.Auth | None = None,
         tool_list_read_timeout: float | None = None,
+        tool_call_timeout_seconds: float | None = None,
     ) -> McpToolRegistry:
         """Create a new MCPToolRegistry using a StreamableHTTP connection (Async version)."""
         config = StreamableHttpMcpClientConfig(
@@ -567,6 +581,7 @@ class McpToolRegistry(ToolRegistry):
             sse_read_timeout=sse_read_timeout,
             terminate_on_close=terminate_on_close,
             auth=auth,
+            tool_call_timeout_seconds=tool_call_timeout_seconds,
         )
         tools = await cls._load_tools_async(config, read_timeout=tool_list_read_timeout)
         return cls(tools)

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -780,6 +780,40 @@ async def test_portia_mcp_tool_call_with_timeout() -> None:
         await tool.arun(get_test_tool_context(), a=1, b=2)
 
 
+@pytest.mark.asyncio
+async def test_portia_mcp_tool_call_with_other_mcp_error() -> None:
+    """Test that other MCP errors are raised as hard errors."""
+    mock_mcp_session = MockMcpSessionWrapper(MagicMock(spec=ClientSession))
+    mock_mcp_session.session.call_tool.side_effect = mcp.McpError(
+        mcp.types.ErrorData(
+            code=httpx.codes.INTERNAL_SERVER_ERROR,
+            message="Internal server error",
+        ),
+    )
+
+    tool = PortiaMcpTool(
+        id="mcp:mock_mcp:test_tool",
+        name="test_tool",
+        description="I am a tool",
+        output_schema=("str", "Tool output formatted as a JSON string"),
+        mcp_client_config=StdioMcpClientConfig(
+            server_name="mock_mcp",
+            command="test",
+            args=["test"],
+            tool_call_timeout_seconds=1,
+        ),
+    )
+
+    with (
+        patch(
+            "portia.tool.get_mcp_session",
+            new=mock_mcp_session.mock_mcp_session,
+        ),
+        pytest.raises(ToolHardError),
+    ):
+        await tool.arun(get_test_tool_context(), a=1, b=2)
+
+
 # Async tests for PortiaMcpTool
 @pytest.mark.asyncio
 async def test_portia_mcp_tool_async_call() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '4'",
@@ -1912,7 +1912,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Tested this many times locally - it stops the tool call without hanging, which was an issue with only using the sse_read_timeout setting

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
