### PR TITLE
feat(trace-logging): add TRACE level and LLM call traces (#607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Head over to <a href="https://app.portialabs.ai" target="_blank">**app.portialab
 The example below introduces **some** of the config options available with Portia AI (check out our <a href="https://docs.portialabs.ai/manage-config" target="_blank">**docs (↗)**</a> for more):
 - The `storage_class` is set using the `StorageClass.CLOUD` ENUM. So long as your `PORTIA_API_KEY` is set, runs and tool calls will be logged and appear automatically in your Portia dashboard at <a href="https://app.portialabs.ai" target="_blank">**app.portialabs.ai (↗)**</a>.
 - The `default_log_level` is set using the `LogLevel.DEBUG` ENUM to `DEBUG` so you can get some insight into the sausage factory in your terminal, including plan generation, run states, tool calls and outputs at every step 😅
+  - To enable ultra-verbose tracing of LLM calls across agents and tools, set `default_log_level=LogLevel.TRACE` (or the string "TRACE"). TRACE includes all DEBUG logs plus additional "LLM call" entries showing the model and high-level purpose (planning, introspection, summarization, parsing/verification, tool-calling).
 - The `llm_provider` and `xxx_api_key` (varies depending on model provider chosen) are used to choose the specific LLM provider. In the example below we're using GPT 4o, but you can use Anthropic, Gemini and others!
 
 Finally we also introduce the concept of a `tool_registry`, which is a flexible grouping of tools.

--- a/portia/config.py
+++ b/portia/config.py
@@ -242,6 +242,7 @@ class LogLevel(Enum):
     """Enum for available log levels.
 
     Attributes:
+        TRACE: Trace log level (very verbose; below DEBUG).
         DEBUG: Debug log level.
         INFO: Info log level.
         WARNING: Warning log level.
@@ -250,6 +251,7 @@ class LogLevel(Enum):
 
     """
 
+    TRACE = "TRACE"
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARNING = "WARNING"

--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -276,6 +276,7 @@ class ParserModel:
         errors = []
         tool_inputs: ToolInputs | None = None
         try:
+            logger().trace(f"LLM call: argument parsing model={self.model!s}")
             response = self.model.get_structured_response(
                 messages=[Message.from_langchain(m) for m in formatted_messages],
                 schema=ToolInputs,
@@ -416,6 +417,7 @@ class VerifierModel:
             tool_args=self.agent.tool.args_json_schema(),
             tool_description=self.agent.tool.description,
         )
+        logger().trace(f"LLM call: argument verification model={self.model!s}")
         response = self.model.get_structured_response(
             messages=[Message.from_langchain(m) for m in formatted_messages],
             schema=VerifiedToolInputs,
@@ -555,6 +557,7 @@ class ToolCallingModel:
         self.agent.telemetry.capture(
             ToolCallTelemetryEvent(tool_id=self.agent.tool.id if self.agent.tool else None)
         )
+        logger().trace(f"LLM call: tool calling model={self.model!s}")
         response = model.invoke(
             self.tool_calling_prompt.format_messages(
                 verified_args=verified_args.model_dump_json(indent=2),

--- a/portia/execution_agents/default_execution_agent.py
+++ b/portia/execution_agents/default_execution_agent.py
@@ -276,7 +276,7 @@ class ParserModel:
         errors = []
         tool_inputs: ToolInputs | None = None
         try:
-            logger().trace(f"LLM call: argument parsing model={self.model!s}")
+            logger().trace("LLM call: argument parsing")
             response = self.model.get_structured_response(
                 messages=[Message.from_langchain(m) for m in formatted_messages],
                 schema=ToolInputs,
@@ -417,7 +417,7 @@ class VerifierModel:
             tool_args=self.agent.tool.args_json_schema(),
             tool_description=self.agent.tool.description,
         )
-        logger().trace(f"LLM call: argument verification model={self.model!s}")
+        logger().trace("LLM call: argument verification")
         response = self.model.get_structured_response(
             messages=[Message.from_langchain(m) for m in formatted_messages],
             schema=VerifiedToolInputs,
@@ -557,7 +557,7 @@ class ToolCallingModel:
         self.agent.telemetry.capture(
             ToolCallTelemetryEvent(tool_id=self.agent.tool.id if self.agent.tool else None)
         )
-        logger().trace(f"LLM call: tool calling model={self.model!s}")
+        logger().trace("LLM call: tool calling")
         response = model.invoke(
             self.tool_calling_prompt.format_messages(
                 verified_args=verified_args.model_dump_json(indent=2),

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -170,7 +170,7 @@ class OneShotToolCallingModel:
 
         """
         model, formatted_messages = self._setup_model(state)
-        logger().trace(f"LLM call: tool calling (one-shot) model={self.model!s}")
+        logger().trace("LLM call: tool calling (one-shot)")
         response = model.invoke(formatted_messages)
         result = template_in_required_inputs(response, state["step_inputs"])
         return self._handle_execution_hooks(response) or {"messages": [result]}
@@ -242,7 +242,7 @@ class OneShotToolCallingModel:
 
         """
         model, formatted_messages = self._setup_model(state)
-        logger().trace(f"LLM call: tool calling (one-shot) model={self.model!s}")
+        logger().trace("LLM call: tool calling (one-shot)")
         response = await model.ainvoke(formatted_messages)
         result = template_in_required_inputs(response, state["step_inputs"])
         return self._handle_execution_hooks(response) or {"messages": [result]}

--- a/portia/execution_agents/one_shot_agent.py
+++ b/portia/execution_agents/one_shot_agent.py
@@ -170,6 +170,7 @@ class OneShotToolCallingModel:
 
         """
         model, formatted_messages = self._setup_model(state)
+        logger().trace(f"LLM call: tool calling (one-shot) model={self.model!s}")
         response = model.invoke(formatted_messages)
         result = template_in_required_inputs(response, state["step_inputs"])
         return self._handle_execution_hooks(response) or {"messages": [result]}
@@ -241,6 +242,7 @@ class OneShotToolCallingModel:
 
         """
         model, formatted_messages = self._setup_model(state)
+        logger().trace(f"LLM call: tool calling (one-shot) model={self.model!s}")
         response = await model.ainvoke(formatted_messages)
         result = template_in_required_inputs(response, state["step_inputs"])
         return self._handle_execution_hooks(response) or {"messages": [result]}

--- a/portia/execution_agents/utils/final_output_summarizer.py
+++ b/portia/execution_agents/utils/final_output_summarizer.py
@@ -116,16 +116,12 @@ class FinalOutputSummarizer:
                 fo_summary: str = Field(description="The summary of the plan output")
 
             msg = self.summarizer_and_structured_output_prompt + context
-            preview = msg.replace("\n", " ")[:120]
-            logger().trace(
-                f"LLM call: summarization (final output) model={model!s} msg={preview!r}"
-            )
+            logger().trace("LLM call: summarization (final output)")
             return model.get_structured_response(
                 [Message(content=msg, role="user")],
                 SchemaWithSummary,
             )
         msg = self.summarizer_only_prompt + context
-        preview = msg.replace("\n", " ")[:120]
-        logger().trace(f"LLM call: summarization (final output) model={model!s} msg={preview!r}")
+        logger().trace("LLM call: summarization (final output)")
         response = model.get_response([Message(content=msg, role="user")])
         return str(response.content) if response.content else None

--- a/portia/execution_agents/utils/final_output_summarizer.py
+++ b/portia/execution_agents/utils/final_output_summarizer.py
@@ -10,6 +10,7 @@ from portia.introspection_agents.introspection_agent import (
     COMPLETED_OUTPUT,
     SKIPPED_OUTPUT,
 )
+from portia.logger import logger
 from portia.model import Message
 from portia.token_check import exceeds_context_threshold
 
@@ -114,6 +115,7 @@ class FinalOutputSummarizer:
                 # summary = Field(description="The summary of the weather in london") # noqa: ERA001
                 fo_summary: str = Field(description="The summary of the plan output")
 
+            logger().trace(f"LLM call: summarization (final output) model={model!s}")
             return model.get_structured_response(
                 [
                     Message(
@@ -122,6 +124,7 @@ class FinalOutputSummarizer:
                 ],
                 SchemaWithSummary,
             )
+        logger().trace(f"LLM call: summarization (final output) model={model!s}")
         response = model.get_response(
             [Message(content=self.summarizer_only_prompt + context, role="user")],
         )

--- a/portia/execution_agents/utils/final_output_summarizer.py
+++ b/portia/execution_agents/utils/final_output_summarizer.py
@@ -121,15 +121,11 @@ class FinalOutputSummarizer:
                 f"LLM call: summarization (final output) model={model!s} msg={preview!r}"
             )
             return model.get_structured_response(
-                [
-                    Message(content=msg, role="user")
-                ],
+                [Message(content=msg, role="user")],
                 SchemaWithSummary,
             )
         msg = self.summarizer_only_prompt + context
         preview = msg.replace("\n", " ")[:120]
-        logger().trace(
-            f"LLM call: summarization (final output) model={model!s} msg={preview!r}"
-        )
+        logger().trace(f"LLM call: summarization (final output) model={model!s} msg={preview!r}")
         response = model.get_response([Message(content=msg, role="user")])
         return str(response.content) if response.content else None

--- a/portia/execution_agents/utils/final_output_summarizer.py
+++ b/portia/execution_agents/utils/final_output_summarizer.py
@@ -115,17 +115,21 @@ class FinalOutputSummarizer:
                 # summary = Field(description="The summary of the weather in london") # noqa: ERA001
                 fo_summary: str = Field(description="The summary of the plan output")
 
-            logger().trace(f"LLM call: summarization (final output) model={model!s}")
+            msg = self.summarizer_and_structured_output_prompt + context
+            preview = msg.replace("\n", " ")[:120]
+            logger().trace(
+                f"LLM call: summarization (final output) model={model!s} msg={preview!r}"
+            )
             return model.get_structured_response(
                 [
-                    Message(
-                        content=self.summarizer_and_structured_output_prompt + context, role="user"
-                    )
+                    Message(content=msg, role="user")
                 ],
                 SchemaWithSummary,
             )
-        logger().trace(f"LLM call: summarization (final output) model={model!s}")
-        response = model.get_response(
-            [Message(content=self.summarizer_only_prompt + context, role="user")],
+        msg = self.summarizer_only_prompt + context
+        preview = msg.replace("\n", " ")[:120]
+        logger().trace(
+            f"LLM call: summarization (final output) model={model!s} msg={preview!r}"
         )
+        response = model.get_response([Message(content=msg, role="user")])
         return str(response.content) if response.content else None

--- a/portia/execution_agents/utils/step_summarizer.py
+++ b/portia/execution_agents/utils/step_summarizer.py
@@ -139,6 +139,7 @@ Here is original task:
             and isinstance(last_message.artifact, LocalDataValue)
         ):
             try:
+                logger().trace(f"LLM call: summarization (step) model={self.model!s}")
                 result = self.model.get_structured_response(
                     parsed_messages, summarizer_output_model
                 )
@@ -150,6 +151,7 @@ Here is original task:
             return {"messages": [last_message]}
 
         try:
+            logger().trace(f"LLM call: summarization (step) model={self.model!s}")
             response: Message = self.model.get_response(
                 messages=parsed_messages,
             )
@@ -274,6 +276,7 @@ Here is original task:
             and isinstance(last_message.artifact, LocalDataValue)
         ):
             try:
+                logger().trace(f"LLM call: summarization (step) model={self.model!s}")
                 result = await self.model.aget_structured_response(
                     parsed_messages, summarizer_output_model
                 )
@@ -285,6 +288,7 @@ Here is original task:
             return {"messages": [last_message]}
 
         try:
+            logger().trace(f"LLM call: summarization (step) model={self.model!s}")
             response: Message = await self.model.aget_response(
                 messages=parsed_messages,
             )

--- a/portia/execution_agents/utils/step_summarizer.py
+++ b/portia/execution_agents/utils/step_summarizer.py
@@ -139,7 +139,7 @@ Here is original task:
             and isinstance(last_message.artifact, LocalDataValue)
         ):
             try:
-                logger().trace(f"LLM call: summarization (step) model={self.model!s}")
+                logger().trace("LLM call: summarization (step)")
                 result = self.model.get_structured_response(
                     parsed_messages, summarizer_output_model
                 )
@@ -151,7 +151,7 @@ Here is original task:
             return {"messages": [last_message]}
 
         try:
-            logger().trace(f"LLM call: summarization (step) model={self.model!s}")
+            logger().trace("LLM call: summarization (step)")
             response: Message = self.model.get_response(
                 messages=parsed_messages,
             )
@@ -276,7 +276,7 @@ Here is original task:
             and isinstance(last_message.artifact, LocalDataValue)
         ):
             try:
-                logger().trace(f"LLM call: summarization (step) model={self.model!s}")
+                logger().trace("LLM call: summarization (step)")
                 result = await self.model.aget_structured_response(
                     parsed_messages, summarizer_output_model
                 )
@@ -288,7 +288,7 @@ Here is original task:
             return {"messages": [last_message]}
 
         try:
-            logger().trace(f"LLM call: summarization (step) model={self.model!s}")
+            logger().trace("LLM call: summarization (step)")
             response: Message = await self.model.aget_response(
                 messages=parsed_messages,
             )

--- a/portia/introspection_agents/default_introspection_agent.py
+++ b/portia/introspection_agents/default_introspection_agent.py
@@ -14,6 +14,7 @@ from portia.introspection_agents.introspection_agent import (
     BaseIntrospectionAgent,
     PreStepIntrospection,
 )
+from portia.logger import logger
 from portia.model import Message
 from portia.plan import Plan
 from portia.plan_run import PlanRun
@@ -113,7 +114,9 @@ Return the outcome and reason in the given format.
             and output.output_name in introspection_condition
         ]
 
-        return self.config.get_introspection_model().get_structured_response(
+        model = self.config.get_introspection_model()
+        logger().trace(f"LLM call: introspection model={model!s}")
+        return model.get_structured_response(
             schema=PreStepIntrospection,
             messages=[
                 Message.from_langchain(m)
@@ -154,7 +157,9 @@ Return the outcome and reason in the given format.
             and output.output_name in introspection_condition
         ]
 
-        return await self.config.get_introspection_model().aget_structured_response(
+        model = self.config.get_introspection_model()
+        logger().trace(f"LLM call: introspection model={model!s}")
+        return await model.aget_structured_response(
             schema=PreStepIntrospection,
             messages=[
                 Message.from_langchain(m)

--- a/portia/introspection_agents/default_introspection_agent.py
+++ b/portia/introspection_agents/default_introspection_agent.py
@@ -115,7 +115,7 @@ Return the outcome and reason in the given format.
         ]
 
         model = self.config.get_introspection_model()
-        logger().trace(f"LLM call: introspection model={model!s}")
+        logger().trace("LLM call: introspection")
         return model.get_structured_response(
             schema=PreStepIntrospection,
             messages=[
@@ -158,7 +158,7 @@ Return the outcome and reason in the given format.
         ]
 
         model = self.config.get_introspection_model()
-        logger().trace(f"LLM call: introspection model={model!s}")
+        logger().trace("LLM call: introspection")
         return await model.aget_structured_response(
             schema=PreStepIntrospection,
             messages=[

--- a/portia/logger.py
+++ b/portia/logger.py
@@ -54,6 +54,7 @@ class LoggerInterface(Protocol):
 
     """
 
+    def trace(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
     def debug(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
     def info(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
     def warning(self, msg: str, *args, **kwargs) -> None: ...  # noqa: ANN002, ANN003, D102
@@ -172,6 +173,13 @@ class SafeLogger(LoggerInterface):
             if isinstance(child_logger, type(default_logger))
             else child_logger
         )
+
+    def trace(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        """Wrap the child logger's trace method to catch exceptions."""
+        try:
+            self.child_logger.trace(msg, *args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            self.child_logger.error(f"Failed to log: {e}")  # noqa: G004, TRY400
 
     def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Wrap the child logger's debug method to catch exceptions."""

--- a/portia/model.py
+++ b/portia/model.py
@@ -130,8 +130,8 @@ class GenerativeModel(ABC):
                 content_preview = " ".join(msg.content.replace("\n", " ") for msg in messages)
                 preview = content_preview[:120]
                 logger().trace(f"LLM call: model={self!s} msg={preview!r}")
-        except Exception:
-            pass
+        except Exception:  # noqa: BLE001, S110
+            pass  # pragma: no cover
 
     @abstractmethod
     def get_response(self, messages: list[Message]) -> Message:

--- a/portia/model.py
+++ b/portia/model.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import json
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from contextvars import ContextVar
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
@@ -125,13 +126,11 @@ class GenerativeModel(ABC):
 
     def _log_llm_call(self, messages: list[Message]) -> None:
         """Log TRACE level information about the LLM call."""
-        try:
+        with suppress(Exception):
             if messages:
                 content_preview = " ".join(msg.content.replace("\n", " ") for msg in messages)
                 preview = content_preview[:120]
                 logger().trace(f"LLM call: model={self!s} msg={preview!r}")
-        except Exception:  # noqa: BLE001, S110
-            pass  # pragma: no cover
 
     @abstractmethod
     def get_response(self, messages: list[Message]) -> Message:

--- a/portia/model.py
+++ b/portia/model.py
@@ -143,7 +143,6 @@ class GenerativeModel(ABC):
             Message: The response from the model.
 
         """
-        self._log_llm_call(messages)
 
     @abstractmethod
     def get_structured_response(
@@ -161,7 +160,6 @@ class GenerativeModel(ABC):
             BaseModelT: The structured response from the model.
 
         """
-        self._log_llm_call(messages)
 
     @abstractmethod
     async def aget_response(self, messages: list[Message]) -> Message:
@@ -171,7 +169,6 @@ class GenerativeModel(ABC):
             messages (list[Message]): The list of messages to send to the model.
 
         """
-        self._log_llm_call(messages)
         raise NotImplementedError("async is not implemented")  # pragma: no cover
 
     @abstractmethod
@@ -187,7 +184,6 @@ class GenerativeModel(ABC):
             schema (type[BaseModelT]): The Pydantic model to use for the response.
 
         """
-        self._log_llm_call(messages)
         raise NotImplementedError("async is not implemented")  # pragma: no cover
 
     def get_context_window_size(self) -> int:

--- a/portia/model.py
+++ b/portia/model.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, SecretStr, ValidationError
 from redis import RedisError
 
 from portia.common import validate_extras_dependencies
+from portia.logger import logger
 from portia.token_check import estimate_tokens
 
 if TYPE_CHECKING:
@@ -122,6 +123,16 @@ class GenerativeModel(ABC):
         """
         self.model_name = model_name
 
+    def _log_llm_call(self, messages: list[Message]) -> None:
+        """Log TRACE level information about the LLM call."""
+        try:
+            if messages:
+                content_preview = " ".join(msg.content.replace("\n", " ") for msg in messages)
+                preview = content_preview[:120]
+                logger().trace(f"LLM call: model={self!s} msg={preview!r}")
+        except Exception:
+            pass
+
     @abstractmethod
     def get_response(self, messages: list[Message]) -> Message:
         """Given a list of messages, call the model and return its response as a new message.
@@ -133,6 +144,7 @@ class GenerativeModel(ABC):
             Message: The response from the model.
 
         """
+        self._log_llm_call(messages)
 
     @abstractmethod
     def get_structured_response(
@@ -150,6 +162,7 @@ class GenerativeModel(ABC):
             BaseModelT: The structured response from the model.
 
         """
+        self._log_llm_call(messages)
 
     @abstractmethod
     async def aget_response(self, messages: list[Message]) -> Message:
@@ -159,6 +172,7 @@ class GenerativeModel(ABC):
             messages (list[Message]): The list of messages to send to the model.
 
         """
+        self._log_llm_call(messages)
         raise NotImplementedError("async is not implemented")  # pragma: no cover
 
     @abstractmethod
@@ -174,6 +188,7 @@ class GenerativeModel(ABC):
             schema (type[BaseModelT]): The Pydantic model to use for the response.
 
         """
+        self._log_llm_call(messages)
         raise NotImplementedError("async is not implemented")  # pragma: no cover
 
     def get_context_window_size(self) -> int:
@@ -225,6 +240,7 @@ class LangChainGenerativeModel(GenerativeModel):
 
     def get_response(self, messages: list[Message]) -> Message:
         """Get response using LangChain model."""
+        super()._log_llm_call(messages)
         langchain_messages = [msg.to_langchain() for msg in messages]
         response = self._client.invoke(langchain_messages)
         return Message.from_langchain(response)
@@ -246,6 +262,7 @@ class LangChainGenerativeModel(GenerativeModel):
             BaseModelT: The structured response from the model.
 
         """
+        super()._log_llm_call(messages)
         langchain_messages = [msg.to_langchain() for msg in messages]
         structured_client = self._client.with_structured_output(schema, **kwargs)
         response = structured_client.invoke(langchain_messages)
@@ -260,6 +277,7 @@ class LangChainGenerativeModel(GenerativeModel):
             messages (list[Message]): The list of messages to send to the model.
 
         """
+        super()._log_llm_call(messages)
         langchain_messages = [msg.to_langchain() for msg in messages]
         response = await self._client.ainvoke(langchain_messages)
         return Message.from_langchain(response)
@@ -278,6 +296,7 @@ class LangChainGenerativeModel(GenerativeModel):
             **kwargs: Additional keyword arguments to pass to the with_structured_output method.
 
         """
+        super()._log_llm_call(messages)
         langchain_messages = [msg.to_langchain() for msg in messages]
         structured_client = self._client.with_structured_output(schema, **kwargs)
         response = await structured_client.ainvoke(langchain_messages)
@@ -464,6 +483,7 @@ class OpenAIGenerativeModel(LangChainGenerativeModel):
         schema: type[BaseModelT],
     ) -> BaseModelT:
         """Get structured response using instructor."""
+        super()._log_llm_call(messages)
         instructor_messages = [map_message_to_instructor(msg) for msg in messages]
         return self._cached_instructor_call(
             client=self._instructor_client,
@@ -508,6 +528,7 @@ class OpenAIGenerativeModel(LangChainGenerativeModel):
         schema: type[BaseModelT],
     ) -> BaseModelT:
         """Get structured response using instructor asynchronously."""
+        super()._log_llm_call(messages)
         instructor_messages = [map_message_to_instructor(msg) for msg in messages]
         return await self._acached_instructor_call(
             client=self._instructor_client_async,
@@ -688,6 +709,7 @@ class AzureOpenAIGenerativeModel(LangChainGenerativeModel):
         schema: type[BaseModelT],
     ) -> BaseModelT:
         """Get structured response using instructor."""
+        super()._log_llm_call(messages)
         instructor_messages = [map_message_to_instructor(msg) for msg in messages]
         return self._cached_instructor_call(
             client=self._instructor_client,
@@ -860,6 +882,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         schema: type[BaseModelT],
     ) -> BaseModelT:
         """Get structured response using instructor."""
+        super()._log_llm_call(messages)
         instructor_messages = [map_message_to_instructor(msg) for msg in messages]
         return self._cached_instructor_call(
             client=self._instructor_client,
@@ -937,6 +960,7 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         schema: type[BaseModelT],
     ) -> BaseModelT:
         """Get structured response using instructor asynchronously."""
+        super()._log_llm_call(messages)
         instructor_messages = [map_message_to_instructor(msg) for msg in messages]
         return await self._acached_instructor_call(
             client=self._instructor_client_async,
@@ -1023,6 +1047,7 @@ if validate_extras_dependencies("mistralai", raise_error=False):
             schema: type[BaseModelT],
         ) -> BaseModelT:
             """Get structured response using instructor."""
+            super()._log_llm_call(messages)
             instructor_messages = [map_message_to_instructor(msg) for msg in messages]
             return self._cached_instructor_call(
                 client=self._instructor_client,
@@ -1075,6 +1100,7 @@ if validate_extras_dependencies("mistralai", raise_error=False):
             schema: type[BaseModelT],
         ) -> BaseModelT:
             """Get structured response using instructor asynchronously."""
+            super()._log_llm_call(messages)
             instructor_messages = [map_message_to_instructor(msg) for msg in messages]
             return await self._acached_instructor_call(
                 client=self._instructor_client_async,

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -101,7 +101,7 @@ class LLMTool(Tool[str | BaseModel]):
         """Run the LLMTool."""
         model = ctx.config.get_generative_model(self.model) or ctx.config.get_default_model()
         messages = self._get_messages(task, task_data)
-        logger().trace(f"LLM call: llm-tool model={model!s}")
+        logger().trace("LLM call: llm-tool")
         if self.structured_output_schema:
             return model.get_structured_response(messages, self.structured_output_schema)
 
@@ -114,7 +114,7 @@ class LLMTool(Tool[str | BaseModel]):
         """Run the LLMTool asynchronously."""
         model = ctx.config.get_generative_model(self.model) or ctx.config.get_default_model()
         messages = self._get_messages(task, task_data)
-        logger().trace(f"LLM call: llm-tool model={model!s}")
+        logger().trace("LLM call: llm-tool")
         if self.structured_output_schema:
             return await model.aget_structured_response(messages, self.structured_output_schema)
         response = await model.aget_response(messages)

--- a/portia/open_source_tools/llm_tool.py
+++ b/portia/open_source_tools/llm_tool.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field
 
+from portia.logger import logger
 from portia.model import GenerativeModel, Message
 from portia.tool import Tool, ToolRunContext
 
@@ -100,6 +101,7 @@ class LLMTool(Tool[str | BaseModel]):
         """Run the LLMTool."""
         model = ctx.config.get_generative_model(self.model) or ctx.config.get_default_model()
         messages = self._get_messages(task, task_data)
+        logger().trace(f"LLM call: llm-tool model={model!s}")
         if self.structured_output_schema:
             return model.get_structured_response(messages, self.structured_output_schema)
 
@@ -112,6 +114,7 @@ class LLMTool(Tool[str | BaseModel]):
         """Run the LLMTool asynchronously."""
         model = ctx.config.get_generative_model(self.model) or ctx.config.get_default_model()
         messages = self._get_messages(task, task_data)
+        logger().trace(f"LLM call: llm-tool model={model!s}")
         if self.structured_output_schema:
             return await model.aget_structured_response(messages, self.structured_output_schema)
         response = await model.aget_response(messages)

--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
+from portia.logger import logger
 from portia.model import Message
 from portia.open_source_tools.llm_tool import LLMTool
 from portia.planning_agents.base_planning_agent import BasePlanningAgent, StepsOrError
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from portia.plan import Plan, PlanInput, Step
     from portia.tool import Tool
 
-logger = logging.getLogger(__name__)
 
 DEFAULT_PLANNING_PROMPT = """
 You are an outstanding task planner. Your job is to provide a detailed plan of action in the form
@@ -92,6 +91,7 @@ class DefaultPlanningAgent(BasePlanningAgent):
                 plan_inputs,
                 previous_errors,
             )
+            logger().trace(f"LLM call: planning model={self.model!s}")
             response = self.model.get_structured_response(
                 schema=StepsOrError,
                 messages=[
@@ -173,6 +173,7 @@ class DefaultPlanningAgent(BasePlanningAgent):
                 plan_inputs,
                 previous_errors,
             )
+            logger().trace(f"LLM call: planning model={self.model!s}")
             response = await self.model.aget_structured_response(
                 schema=StepsOrError,
                 messages=[

--- a/portia/planning_agents/default_planning_agent.py
+++ b/portia/planning_agents/default_planning_agent.py
@@ -91,7 +91,7 @@ class DefaultPlanningAgent(BasePlanningAgent):
                 plan_inputs,
                 previous_errors,
             )
-            logger().trace(f"LLM call: planning model={self.model!s}")
+            logger().trace("LLM call: planning")
             response = self.model.get_structured_response(
                 schema=StepsOrError,
                 messages=[
@@ -173,7 +173,7 @@ class DefaultPlanningAgent(BasePlanningAgent):
                 plan_inputs,
                 previous_errors,
             )
-            logger().trace(f"LLM call: planning model={self.model!s}")
+            logger().trace("LLM call: planning")
             response = await self.model.aget_structured_response(
                 schema=StepsOrError,
                 messages=[

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -181,6 +181,7 @@ def test_safe_logger_error_handling() -> None:
     safe_logger = SafeLogger(mock_logger)
 
     # Make each method raise an exception
+    mock_logger.trace.side_effect = Exception("trace error")
     mock_logger.debug.side_effect = Exception("debug error")
     mock_logger.info.side_effect = Exception("info error")
     mock_logger.warning.side_effect = Exception("warning error")
@@ -189,6 +190,7 @@ def test_safe_logger_error_handling() -> None:
     # Test error log separately as all the other methods call the error log on exception
     mock_logger.error.side_effect = None
 
+    safe_logger.trace("trace message")
     safe_logger.debug("debug message")
     safe_logger.info("info message")
     safe_logger.warning("warning message")
@@ -203,8 +205,9 @@ def test_safe_logger_error_handling() -> None:
     assert mock_logger.warning.call_count == 1
     assert mock_logger.critical.call_count == 1
     assert mock_logger.exception.call_count == 1
-    assert mock_logger.error.call_count == 7
+    assert mock_logger.error.call_count == 8
 
+    mock_logger.error.assert_any_call("Failed to log: trace error")
     mock_logger.error.assert_any_call("Failed to log: debug error")
     mock_logger.error.assert_any_call("Failed to log: info error")
     mock_logger.error.assert_any_call("Failed to log: warning error")

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -157,6 +157,7 @@ def test_safe_logger_successful_logs() -> None:
     safe_logger = SafeLogger(mock_logger)
 
     # Test each log level
+    safe_logger.trace("trace message", "arg1", kwarg1="value1")
     safe_logger.debug("debug message", "arg1", kwarg1="value1")  # noqa: PLE1205
     safe_logger.info("info message", "arg1", kwarg1="value1")  # noqa: PLE1205
     safe_logger.warning("warning message", "arg1", kwarg1="value1")  # noqa: PLE1205
@@ -165,6 +166,7 @@ def test_safe_logger_successful_logs() -> None:
     safe_logger.exception("exception message", "arg1", kwarg1="value1")  # noqa: PLE1205
 
     # Verify each method was called with correct arguments
+    mock_logger.trace.assert_called_once_with("trace message", "arg1", kwarg1="value1")
     mock_logger.debug.assert_called_once_with("debug message", "arg1", kwarg1="value1")
     mock_logger.info.assert_called_once_with("info message", "arg1", kwarg1="value1")
     mock_logger.warning.assert_called_once_with("warning message", "arg1", kwarg1="value1")


### PR DESCRIPTION
# Description

Introduce a new TRACE logging level and emit trace logs for every LLM call across the SDK. TRACE includes all DEBUG logs plus a one-line “LLM call” entry showing the model and the high-level purpose (planning, introspection, summarization, argument parsing/verification, tool-calling). Updated README to document how to enable TRACE.

Ticket Link: https://github.com/portiaAI/portia-sdk-python/issues/607

## Type of change

(select all that apply)

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [x] Documentation update

## Changelog

Added TRACE logging level and per-LLM-call trace lines across agents and LLMTool; documented usage in README.
