### PR TITLE
String interpolation + specified inputs

### DIFF
--- a/portia/builder/plan_builder.py
+++ b/portia/builder/plan_builder.py
@@ -24,15 +24,16 @@ class PlanBuilder:
         """Initialize the builder."""
         self.plan = PortiaPlan(steps=[], task=task)
 
-    def input(self, name: str, description: str | None = None) -> PlanBuilder:
+    def input(self, name: str, description: str | None = None, value: Any | None = None) -> PlanBuilder:
         """Add an input to the plan.
 
         Args:
             name: The name of the input.
             description: The description of the input.
+            value: The value of the input.
 
         """
-        self.plan.plan_inputs.append(PlanInput(name=name, description=description))
+        self.plan.plan_inputs.append(PlanInput(name=name, description=description, value=value))
         return self
 
     def llm_step(

--- a/portia/builder/reference.py
+++ b/portia/builder/reference.py
@@ -52,6 +52,10 @@ class StepOutput(Reference):
         """Get the name of the reference to use with legacy Portia plans."""
         return plan.step_output_name(self.step)
 
+    def __str__(self) -> str:
+        """Get the string representation of the step output."""
+        return f"{{{{ StepOutput({self.step}) }}}}"
+
     @override
     def get_value(self, run_data: RunContext) -> ReferenceValue | None:
         """Get the value of the step output."""
@@ -98,6 +102,10 @@ class Input(Reference):
             value=value,
             description=plan_input.description or "Input to plan",
         )
+
+    def __str__(self) -> str:
+        """Get the string representation of the input."""
+        return f"{{{{ Input({self.name}) }}}}"
 
 
 class ReferenceValue(BaseModel):

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -1263,7 +1263,23 @@ class Portia:
 
         """
         if plan.plan_inputs and not plan_run_inputs:
-            raise ValueError("Inputs are required for this plan but have not been specified")
+            # Check if all required inputs have default values
+            missing_inputs = [
+                input_obj.name
+                for input_obj in plan.plan_inputs
+                if input_obj.value is None
+            ]
+            if missing_inputs:
+                raise ValueError(f"Missing required plan input values: {', '.join(missing_inputs)}")
+            
+            # Use default values from plan inputs
+            for plan_input in plan.plan_inputs:
+                if plan_input.value is not None:
+                    plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
+                        value=plan_input.value
+                    )
+            return
+
         if plan_run_inputs and not plan.plan_inputs:
             logger().warning(
                 "Inputs are not required for this plan but plan inputs were provided",
@@ -1272,19 +1288,25 @@ class Portia:
         if plan_run_inputs and plan.plan_inputs:
             input_values_by_name = {input_obj.name: input_obj for input_obj in plan_run_inputs}
 
-            # Validate all required inputs are provided
+            # Validate all required inputs are provided or have default values
             missing_inputs = [
                 input_obj.name
                 for input_obj in plan.plan_inputs
-                if input_obj.name not in input_values_by_name
+                if input_obj.name not in input_values_by_name and input_obj.value is None
             ]
             if missing_inputs:
                 raise ValueError(f"Missing required plan input values: {', '.join(missing_inputs)}")
 
             for plan_input in plan.plan_inputs:
                 if plan_input.name in input_values_by_name:
+                    # Use provided value
                     plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
                         value=input_values_by_name[plan_input.name].value
+                    )
+                elif plan_input.value is not None:
+                    # Use default value
+                    plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
+                        value=plan_input.value
                     )
 
             # Check for unknown inputs
@@ -1312,7 +1334,23 @@ class Portia:
 
         """
         if plan.plan_inputs and not plan_run_inputs:
-            raise ValueError("Inputs are required for this plan but have not been specified")
+            # Check if all required inputs have default values
+            missing_inputs = [
+                input_obj.name
+                for input_obj in plan.plan_inputs
+                if input_obj.value is None
+            ]
+            if missing_inputs:
+                raise ValueError(f"Missing required plan input values: {', '.join(missing_inputs)}")
+            
+            # Use default values from plan inputs
+            for plan_input in plan.plan_inputs:
+                if plan_input.value is not None:
+                    plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
+                        value=plan_input.value
+                    )
+            return
+
         if plan_run_inputs and not plan.plan_inputs:
             logger().warning(
                 "Inputs are not required for this plan but plan inputs were provided",
@@ -1321,19 +1359,25 @@ class Portia:
         if plan_run_inputs and plan.plan_inputs:
             input_values_by_name = {input_obj.name: input_obj for input_obj in plan_run_inputs}
 
-            # Validate all required inputs are provided
+            # Validate all required inputs are provided or have default values
             missing_inputs = [
                 input_obj.name
                 for input_obj in plan.plan_inputs
-                if input_obj.name not in input_values_by_name
+                if input_obj.name not in input_values_by_name and input_obj.value is None
             ]
             if missing_inputs:
                 raise ValueError(f"Missing required plan input values: {', '.join(missing_inputs)}")
 
             for plan_input in plan.plan_inputs:
                 if plan_input.name in input_values_by_name:
+                    # Use provided value
                     plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
                         value=input_values_by_name[plan_input.name].value
+                    )
+                elif plan_input.value is not None:
+                    # Use default value
+                    plan_run.plan_run_inputs[plan_input.name] = LocalDataValue(
+                        value=plan_input.value
                     )
 
             # Check for unknown inputs


### PR DESCRIPTION
# Description

This is my test query:

```
plan = PlanBuilder(
    task="Research information about Paris including its capital status, population, and mayor"
).input(
    name="country_name",
    description="The name of the country to research"
).llm_step(
    task="Find the capital of the country provided",
    inputs=[Input("country_name")],
    name="capital_name"
).tool_call(
    tool="portia:tavily::search",
    args={"search_query": f"population of {StepOutput('capital_name')}"},
    name="find_population"
).input(
    name="email_address",
    description="The email address to send the search result to",
    value="emma@portialabs.ai"
).single_tool_agent(
    tool="portia:google:gmail:send_email",
    task="Send me an email summarizing the search result",
    inputs=[StepOutput("find_population"), StepOutput("capital_name"), Input("email_address")],
    name="send_email"
).final_output(
    output_schema=None,
    summarize=True
).build()
```

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
