### PR TITLE
Add integration tests for ConditionalEvaluationAgent

### DIFF
--- a/portia/model.py
+++ b/portia/model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from abc import ABC, abstractmethod
@@ -762,9 +763,9 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
             api_key=api_key,
             **kwargs,
         )
-        kwargs_no_thinking = kwargs.copy()
+        kwargs_no_thinking = copy.deepcopy(kwargs)
         kwargs_no_thinking.get("model_kwargs", {}).pop("thinking", None)
-        # You cannot use structured output with thinking enabled, or you get an error saying 
+        # You cannot use structured output with thinking enabled, or you get an error saying
         # 'Thinking may not be enabled when tool_choice forces tool use'.
         # So we create a separate client for structured output.
         # NB Instructor can be used, because it doesn't use the tool_choice API.

--- a/portia/model.py
+++ b/portia/model.py
@@ -764,6 +764,11 @@ class AnthropicGenerativeModel(LangChainGenerativeModel):
         )
         kwargs_no_thinking = kwargs.copy()
         kwargs_no_thinking.get("model_kwargs", {}).pop("thinking", None)
+        # You cannot use structured output with thinking enabled, or you get an error saying 
+        # 'Thinking may not be enabled when tool_choice forces tool use'.
+        # So we create a separate client for structured output.
+        # NB Instructor can be used, because it doesn't use the tool_choice API.
+        # See https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use
         self._non_thinking_client = ChatAnthropic(
             model_name=model_name,
             timeout=timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ omit = [
     "portia/portia.py", # TODO: Remove this once testing has been added for new PlanV2
     "portia/builder/step_v2.py", # TODO: Remove this once testing has been added for string templating
     "portia/builder/plan_builder_v2.py", # TODO: Remove this once testing has been added for string templating
-    "portia/execution_agents/conditional_evaluation_agent.py", # TODO: Remove after tests added
 ]
 
 [tool.coverage.report]

--- a/tests/integration/test_conditional_evaluation_agent.py
+++ b/tests/integration/test_conditional_evaluation_agent.py
@@ -5,18 +5,16 @@ import pytest
 from portia import LLMProvider
 from portia.config import Config
 from portia.execution_agents.conditional_evaluation_agent import ConditionalEvaluationAgent
-from tests.integration.test_e2e import PROVIDER_MODELS
 
 
-@pytest.mark.parametrize(("llm_provider", "default_model_name"), PROVIDER_MODELS)
+@pytest.mark.parametrize(
+    "llm_provider", [LLMProvider.OPENAI, LLMProvider.ANTHROPIC, LLMProvider.GOOGLE]
+)
 @pytest.mark.asyncio
-async def test_conditional_evaluation_agent(
-    llm_provider: LLMProvider, default_model_name: str
-) -> None:
+async def test_conditional_evaluation_agent(llm_provider: LLMProvider) -> None:
     """The agent should correctly evaluate true and false statements."""
     config = Config.from_default(
         llm_provider=llm_provider,
-        default_model=default_model_name,
     )
     agent = ConditionalEvaluationAgent(config)
 
@@ -27,15 +25,14 @@ async def test_conditional_evaluation_agent(
     assert false_result is False
 
 
-@pytest.mark.parametrize(("llm_provider", "default_model_name"), PROVIDER_MODELS)
+@pytest.mark.parametrize(
+    "llm_provider", [LLMProvider.OPENAI, LLMProvider.ANTHROPIC, LLMProvider.GOOGLE]
+)
 @pytest.mark.asyncio
-async def test_conditional_evaluation_agent_with_arguments(
-    llm_provider: LLMProvider, default_model_name: str
-) -> None:
+async def test_conditional_evaluation_agent_with_arguments(llm_provider: LLMProvider) -> None:
     """The agent should correctly evaluate statements using passed arguments."""
     config = Config.from_default(
         llm_provider=llm_provider,
-        default_model=default_model_name,
     )
     agent = ConditionalEvaluationAgent(config)
 

--- a/tests/integration/test_conditional_evaluation_agent.py
+++ b/tests/integration/test_conditional_evaluation_agent.py
@@ -1,0 +1,52 @@
+"""Integration tests for the ConditionalEvaluationAgent."""
+
+import pytest
+
+from portia import LLMProvider
+from portia.config import Config
+from portia.execution_agents.conditional_evaluation_agent import ConditionalEvaluationAgent
+from tests.integration.test_e2e import PROVIDER_MODELS
+
+
+@pytest.mark.parametrize(("llm_provider", "default_model_name"), PROVIDER_MODELS)
+@pytest.mark.asyncio
+async def test_conditional_evaluation_agent(
+    llm_provider: LLMProvider, default_model_name: str
+) -> None:
+    """The agent should correctly evaluate true and false statements."""
+    config = Config.from_default(
+        llm_provider=llm_provider,
+        default_model=default_model_name,
+    )
+    agent = ConditionalEvaluationAgent(config)
+
+    true_result = await agent.execute("2 + 2 == 4", {})
+    false_result = await agent.execute("2 + 2 == 5", {})
+
+    assert true_result is True
+    assert false_result is False
+
+
+@pytest.mark.parametrize(("llm_provider", "default_model_name"), PROVIDER_MODELS)
+@pytest.mark.asyncio
+async def test_conditional_evaluation_agent_with_arguments(
+    llm_provider: LLMProvider, default_model_name: str
+) -> None:
+    """The agent should correctly evaluate statements using passed arguments."""
+    config = Config.from_default(
+        llm_provider=llm_provider,
+        default_model=default_model_name,
+    )
+    agent = ConditionalEvaluationAgent(config)
+
+    true_result = await agent.execute(
+        "x + y == z",
+        {"x": 2, "y": 2, "z": 4},
+    )
+    false_result = await agent.execute(
+        "x + y == z",
+        {"x": 2, "y": 2, "z": 5},
+    )
+
+    assert true_result is True
+    assert false_result is False


### PR DESCRIPTION
## Summary
- extend ConditionalEvaluationAgent integration coverage with argument-based evaluation

## Testing
- `pre-commit run --files tests/integration/test_conditional_evaluation_agent.py` *(fails: command not found)*
- `pytest tests/integration/test_conditional_evaluation_agent.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68a6d2284acc8329b775d07c517b1bbf