### PR TITLE
Improve handling of plan inputs without description

### DIFF
--- a/portia/templates/default_planning_agent.xml.jinja
+++ b/portia/templates/default_planning_agent.xml.jinja
@@ -71,7 +71,7 @@ Use the following information to construct a plan in response to the following u
 {% endif %}{% if plan_inputs %}
 <PlanInputs>{% for input in plan_inputs %}
     <PlanInput name="{{input.name}}">
-        {{input.description}}
+        {% if input.description %}<PlanInput.Description>{{ input.description }}</PlanInput.Description>{% endif %}
     </PlanInput>{% endfor %}
 </PlanInputs>
 {% endif %}


### PR DESCRIPTION
# Description

Context: https://discord.com/channels/1331293596665512067/1408030210707820564/1408071539349393488

@nuj846k was trying to use plan inputs without descriptions, but it wasn't working well for them. This was because the planner saw `None` being printed under the PlanInput in the XML and interpreted that as a value being missing, rather than a description missing.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
