### PR TITLE
Fix large outputs from invoke_tool_step being used in final_output 

### DIFF
--- a/example_builder.py
+++ b/example_builder.py
@@ -43,7 +43,7 @@ plan = (
         ),
         args={
             "price_with_currency": StepOutput("Search gold price"),
-            "purchase_quantity": 100,
+            "purchase_quantity": Input("purchase_quantity"),
         },
     )
     .if_(

--- a/example_builder.py
+++ b/example_builder.py
@@ -3,10 +3,8 @@
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-from portia.builder.plan_builder_v2 import PlanBuilderV2
-from portia.builder.reference import Input, StepOutput
+from portia import Input, PlanBuilderV2, Portia, StepOutput
 from portia.cli import CLIExecutionHooks
-from portia.portia import Portia
 
 load_dotenv()
 
@@ -45,7 +43,7 @@ plan = (
         ),
         args={
             "price_with_currency": StepOutput("Search gold price"),
-            "purchase_quantity": Input("purchase_quantity"),
+            "purchase_quantity": 100,
         },
     )
     .if_(

--- a/portia/builder/step_v2.py
+++ b/portia/builder/step_v2.py
@@ -301,9 +301,10 @@ class InvokeToolStep(StepV2):
         if isinstance(output_value, Clarification) and output_value.plan_run_id is None:
             output_value.plan_run_id = run_data.plan_run.id
 
+        output_schema = self.output_schema or tool.structured_output_schema
         if (
-            self.output_schema
-            and not isinstance(output_value, self.output_schema)
+            output_schema
+            and not isinstance(output_value, output_schema)
             and not isinstance(output_value, Clarification)
         ):
             model = run_data.portia.config.get_default_model()
@@ -314,7 +315,7 @@ class InvokeToolStep(StepV2):
                         content=f"Convert this output to the desired schema: {output}",
                     )
                 ],
-                self.output_schema,
+                output_schema,
             )
         return output_value
 

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -2387,7 +2387,7 @@ class Portia:
 
         """
         final_output = LocalDataValue(
-            value=step_output.get_value(),
+            value=step_output.full_value(self.storage),
             summary=None,
         )
         if skip_summarization:

--- a/uv.lock
+++ b/uv.lock
@@ -1994,7 +1994,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description

Fix two issues:
* Use structured output from the tool in invoke_tool_step (if it is specified)
* Always give out the full value for final_output (i.e. don't give a summary if it is in agent memory)

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
