### PR TITLE
Add UserVerifyStep and builder support

### DIFF
--- a/portia/builder/plan_builder_v2.py
+++ b/portia/builder/plan_builder_v2.py
@@ -13,6 +13,7 @@ from portia.builder.step_v2 import (
     InvokeToolStep,
     LLMStep,
     SingleToolAgentStep,
+     UserVerifyStep,
     StepV2,
 )
 from portia.plan import PlanInput
@@ -271,6 +272,25 @@ class PlanBuilderV2:
                 task=task,
                 inputs=inputs or [],
                 output_schema=output_schema,
+                step_name=step_name or default_step_name(len(self.plan.steps)),
+                conditional_block=self._current_conditional_block,
+            )
+        )
+        return self
+
+    def user_verify_step(
+        self, *, message: str, step_name: str | None = None
+    ) -> PlanBuilderV2:
+        """Add a step that requires user verification before continuing.
+
+        Args:
+            message: The message the user needs to verify.
+            step_name: Optional name for the step. If not provided, will be auto-generated.
+
+        """
+        self.plan.steps.append(
+            UserVerifyStep(
+                message=message,
                 step_name=step_name or default_step_name(len(self.plan.steps)),
                 conditional_block=self._current_conditional_block,
             )

--- a/tests/unit/builder/test_plan_builder_v2.py
+++ b/tests/unit/builder/test_plan_builder_v2.py
@@ -15,6 +15,7 @@ from portia.builder.step_v2 import (
     InvokeToolStep,
     LLMStep,
     SingleToolAgentStep,
+    UserVerifyStep,
     StepV2,
 )
 from portia.plan import PlanInput, Step
@@ -337,6 +338,18 @@ class TestPlanBuilderV2:
         assert step.inputs == inputs
         assert step.output_schema == OutputSchema
         assert step.step_name == "agent_step"
+
+    def test_user_verify_step_method(self) -> None:
+        """Test the user_verify_step() method."""
+        builder = PlanBuilderV2()
+
+        result = builder.user_verify_step(message="Check this")
+
+        assert result is builder
+        assert len(builder.plan.steps) == 1
+        assert isinstance(builder.plan.steps[0], UserVerifyStep)
+        assert builder.plan.steps[0].message == "Check this"
+        assert builder.plan.steps[0].step_name == "step_0"
 
     def test_final_output_method_basic(self) -> None:
         """Test the final_output() method with basic parameters."""


### PR DESCRIPTION
## Summary
- add `UserVerifyStep` that prompts for user verification and raises a clarification
- allow PlanBuilderV2 to create user verification steps
- test user verification step behaviour and PlanBuilder integration

## Testing
- `pytest tests/unit/builder/test_step_v2.py::TestUserVerifyStep -q` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_68aad760ab0883238500109744ac44b7