### PR TITLE
[Issue#717] Fix LLMTool to expect dict as well

### DIFF
--- a/tests/unit/open_source_tools/test_llm_tool.py
+++ b/tests/unit/open_source_tools/test_llm_tool.py
@@ -145,6 +145,12 @@ def test_process_task_data_with_complex_objects() -> None:
     assert result == "TestObject\n{'nested': 'value'}"
 
 
+def test_process_task_data_with_dict() -> None:
+    """Test that process_task_data correctly handles dictionary input."""
+    result = LLMTool.process_task_data({"key": "value", "key2": "value2"})
+    assert result == "key: value\nkey2: value2"
+
+
 # Async tests for LLMTool.arun function
 @pytest.mark.asyncio
 async def test_llm_tool_async_plan_run(


### PR DESCRIPTION
# Description

Sometimes there is an issue where a model (e.g gemini-1.5) is generating a LLMTool call with Dict instead of str or list for `task_data`. So adding dict as another possible input for the LLMTool. This is causing pydantic validation error when executing the tool call. 

[Example trace](https://smith.langchain.com/public/5bbbf3c9-4296-49b8-9a19-859e6a930e36/r)

Ticket Link: https://github.com/portiaAI/portia-sdk-python/issues/717

## Type of change

(select all that apply)

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
