### PR TITLE
Ensure step outputs can be referenced correctly

### DIFF
--- a/portia/builder/reference.py
+++ b/portia/builder/reference.py
@@ -73,15 +73,13 @@ class StepOutput(Reference):
     @override
     def get_value(self, run_data: RunContext) -> ReferenceValue | None:
         """Get the value of the step output."""
-        try:
-            if isinstance(self.step, int):
-                return run_data.step_output_values[self.step]
-            step_index = run_data.plan.idx_by_name(self.step)
-            val = run_data.step_output_values[step_index]
-        except (ValueError, IndexError):
-            logger().warning(f"Output value for step {self.step} not found")
-            return None
-        return val
+        for step_output in run_data.step_output_values:
+            if isinstance(self.step, int) and step_output.step_num == self.step:
+                return step_output
+            if isinstance(self.step, str) and step_output.step_name == self.step:
+                return step_output
+        logger().warning(f"Output value for step {self.step} not found")
+        return None
 
 
 class Input(Reference):

--- a/portia/portia.py
+++ b/portia/portia.py
@@ -104,6 +104,13 @@ if TYPE_CHECKING:
     from portia.planning_agents.base_planning_agent import BasePlanningAgent
 
 
+class StepOutputValue(ReferenceValue):
+    """Value that can be referenced by name."""
+
+    step_name: str = Field(description="The name of the referenced value.")
+    step_num: int = Field(description="The step number of the referenced value.")
+
+
 class RunContext(BaseModel):
     """Data that is returned from a step."""
 
@@ -113,7 +120,7 @@ class RunContext(BaseModel):
     legacy_plan: Plan = Field(description="The legacy plan representation.")
     plan_run: PlanRun = Field(description="The current plan run instance.")
     end_user: EndUser = Field(description="The end user executing the plan.")
-    step_output_values: list[ReferenceValue] = Field(
+    step_output_values: list[StepOutputValue] = Field(
         default_factory=list, description="Outputs set by the step."
     )
     portia: Portia = Field(description="The Portia client instance.")
@@ -2460,8 +2467,8 @@ class Portia:
         for clarification in clarifications:
             clarification.step = plan_run.current_step_index
             logger().info(
-                f"Clarification requested - category: {clarification.category}, "
-                f"user_guidance: {clarification.user_guidance}.",
+                f"Clarification requested - category: {clarification.category}, ",
+                user_guidance=clarification.user_guidance,
                 plan=str(plan_run.plan_id),
                 plan_run=str(plan_run.id),
             )
@@ -2816,12 +2823,15 @@ class Portia:
             output_value = LocalDataValue(value=result)
             # This may persist the output to memory - store the memory value if it does
             output_value = self._set_step_output(output_value, run_data.plan_run, legacy_step)
-            output = ReferenceValue(
-                value=output_value,
-                description=(f"Output from step '{step.step_name}' (Description: {step})"),
-            )
             if not isinstance(result, Clarification):
-                run_data.step_output_values.append(output)
+                run_data.step_output_values.append(
+                    StepOutputValue(
+                        step_name=step.step_name,
+                        step_num=i,
+                        value=output_value,
+                        description=(f"Output from step '{step.step_name}' (Description: {step})"),
+                    )
+                )
 
             try:
                 if clarified_plan_run := self._handle_post_step_execution(
@@ -2843,11 +2853,14 @@ class Portia:
                 )
                 error_value = LocalDataValue(value=str(e))
                 self._set_step_output(error_value, run_data.plan_run, step.to_legacy_step(plan))
-                error_output = ReferenceValue(
-                    value=error_value,
-                    description=(f"Error from step '{step.step_name}' (Description: {step})"),
+                run_data.step_output_values.append(
+                    StepOutputValue(
+                        step_name=step.step_name,
+                        step_num=i,
+                        value=error_value,
+                        description=f"Error from step '{step.step_name}' (Description: {step})",
+                    )
                 )
-                run_data.step_output_values.append(error_output)
                 # Skip the after_step_execution hook as we have already run it
                 return self._handle_plan_run_execution_error(
                     run_data.plan_run, run_data.legacy_plan, error_value

--- a/tests/unit/builder/test_step_v2.py
+++ b/tests/unit/builder/test_step_v2.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from portia.builder.reference import Input, ReferenceValue, StepOutput
 from portia.errors import PlanRunExitError, ToolNotFoundError
+from portia.portia import StepOutputValue
 from portia.prefixed_uuid import PlanRunUUID
 
 if TYPE_CHECKING:
@@ -1294,7 +1295,9 @@ class TestUserVerifyStep:
         mock_run_data.plan.plan_inputs = [PlanInput(name="username")]
         mock_run_data.plan_run.plan_run_inputs = {"username": LocalDataValue(value="Alice")}
         mock_run_data.step_output_values = [
-            ReferenceValue(value=LocalDataValue(value="result"), description="step0")
+            StepOutputValue(
+                step_num=0, step_name="step_0", value=LocalDataValue(value="result"), description=""
+            )
         ]
 
         result = await step.run(run_data=mock_run_data)


### PR DESCRIPTION
# Description

Previously, if steps were skipped due to an if statement, they wouldn't give out outputs and so this meant that we didn't pick the correct step output value. This PR fixes it by tracking name + step index with the output and using that when we do the lookup.

## Type of change

(select all that apply)

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
