### PR TITLE
Move run context

### DIFF
--- a/portia/builder/reference.py
+++ b/portia/builder/reference.py
@@ -12,7 +12,7 @@ from portia.logger import logger
 
 if TYPE_CHECKING:
     from portia.builder.plan_v2 import PlanV2
-    from portia.portia import RunContext
+    from portia.run_context import RunContext
 
 
 def default_step_name(step_index: int) -> str:

--- a/portia/execution_agents/execution_utils.py
+++ b/portia/execution_agents/execution_utils.py
@@ -128,8 +128,7 @@ def _template_inputs_into_arg_value(arg_value: str, step_inputs: list[StepInput]
     if len(untemplated_var_matches) > 0:
         extra_vars = ", ".join(list(untemplated_var_matches))
         raise ToolSoftError(
-            "Templated variables found in input that are not valid "
-            f"inputs for step: {extra_vars}"
+            f"Templated variables found in input that are not valid inputs for step: {extra_vars}"
         )
 
     return Template(arg_value).render(**template_args)

--- a/portia/run_context.py
+++ b/portia/run_context.py
@@ -1,0 +1,38 @@
+"""Context for a PlanV2 run."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from portia.builder.plan_v2 import PlanV2
+from portia.builder.reference import ReferenceValue
+from portia.config import Config
+from portia.end_user import EndUser
+from portia.execution_hooks import ExecutionHooks
+from portia.plan import Plan
+from portia.plan_run import PlanRun
+from portia.storage import Storage
+from portia.tool_registry import ToolRegistry
+
+
+class StepOutputValue(ReferenceValue):
+    """Value that can be referenced by name."""
+
+    step_name: str = Field(description="The name of the referenced value.")
+    step_num: int = Field(description="The step number of the referenced value.")
+
+
+class RunContext(BaseModel):
+    """Data that is returned from a step."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    plan: PlanV2 = Field(description="The Portia plan being executed.")
+    legacy_plan: Plan = Field(description="The legacy plan representation.")
+    plan_run: PlanRun = Field(description="The current plan run instance.")
+    end_user: EndUser = Field(description="The end user executing the plan.")
+    step_output_values: list[StepOutputValue] = Field(
+        default_factory=list, description="Outputs set by the step."
+    )
+    config: Config = Field(description="The Portia config.")
+    storage: Storage = Field(description="The Portia storage.")
+    tool_registry: ToolRegistry = Field(description="The Portia tool registry.")
+    execution_hooks: ExecutionHooks = Field(description="The Portia execution hooks.")

--- a/portia/storage.py
+++ b/portia/storage.py
@@ -402,10 +402,6 @@ class AdditionalStorage(ABC):
         return await asyncio.to_thread(self.get_end_user, external_id)
 
 
-class Storage(PlanStorage, RunStorage, AdditionalStorage):
-    """Combined base class for Plan Run + Additional storages."""
-
-
 class AgentMemory(ABC):
     """Abstract base class for storing items in agent memory."""
 
@@ -484,6 +480,10 @@ class AgentMemory(ABC):
         return await asyncio.to_thread(self.get_plan_run_output, output_name, plan_run_id)
 
 
+class Storage(PlanStorage, RunStorage, AdditionalStorage, AgentMemory):
+    """Combined base class for Plan Run + Additional storages."""
+
+
 MAX_STORAGE_OBJECT_BYTES = 32_000_000
 
 
@@ -524,7 +524,7 @@ def log_tool_call(tool_call: ToolCallRecord) -> None:
             logger().debug("Tool returned clarifications", output=output)
 
 
-class InMemoryStorage(PlanStorage, RunStorage, AdditionalStorage, AgentMemory):
+class InMemoryStorage(Storage):
     """Simple storage class that keeps plans + runs in memory.
 
     Tool Calls are logged via the LogAdditionalStorage.
@@ -726,7 +726,7 @@ class InMemoryStorage(PlanStorage, RunStorage, AdditionalStorage, AgentMemory):
         return None
 
 
-class DiskFileStorage(PlanStorage, RunStorage, AdditionalStorage, AgentMemory):
+class DiskFileStorage(Storage):
     """Disk-based implementation of the Storage interface.
 
     Stores serialized Plan and Run objects as JSON files on disk.
@@ -982,7 +982,7 @@ class DiskFileStorage(PlanStorage, RunStorage, AdditionalStorage, AgentMemory):
             return None
 
 
-class PortiaCloudStorage(Storage, AgentMemory):
+class PortiaCloudStorage(Storage):
     """Save plans, runs and tool calls to portia cloud."""
 
     DEFAULT_MAX_CACHE_SIZE = 20

--- a/tests/unit/builder/test_plan_builder_v2.py
+++ b/tests/unit/builder/test_plan_builder_v2.py
@@ -23,7 +23,7 @@ from portia.plan import PlanInput, Step
 from portia.tool import Tool
 
 if TYPE_CHECKING:
-    from portia.portia import RunContext
+    from portia.run_context import RunContext
 
 
 class OutputSchema(BaseModel):

--- a/tests/unit/builder/test_reference.py
+++ b/tests/unit/builder/test_reference.py
@@ -9,7 +9,7 @@ from portia.builder.reference import Input, ReferenceValue, StepOutput, default_
 from portia.builder.step_v2 import LLMStep, StepV2
 from portia.execution_agents.output import LocalDataValue
 from portia.plan import PlanInput
-from portia.portia import StepOutputValue
+from portia.run_context import StepOutputValue
 
 
 class TestDefaultStepName:

--- a/tests/unit/builder/test_step_v2.py
+++ b/tests/unit/builder/test_step_v2.py
@@ -10,9 +10,12 @@ import pytest
 from pydantic import BaseModel
 
 from portia.builder.reference import Input, ReferenceValue, StepOutput
+from portia.config import ExecutionAgentType
 from portia.errors import PlanRunExitError, ToolNotFoundError
-from portia.portia import StepOutputValue
+from portia.execution_agents.default_execution_agent import DefaultExecutionAgent
+from portia.execution_agents.one_shot_agent import OneShotAgent
 from portia.prefixed_uuid import PlanRunUUID
+from portia.run_context import StepOutputValue
 
 if TYPE_CHECKING:
     from portia.builder.plan_v2 import PlanV2
@@ -130,7 +133,7 @@ class TestStepV2Base:
         """Test _resolve_input_reference with string containing StepOutput template."""
         step = ConcreteStepV2()
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_run_data.step_output_values = [
             StepOutputValue(
                 value=LocalDataValue(value="step result"),
@@ -149,7 +152,7 @@ class TestStepV2Base:
         """Test _resolve_input_reference with string containing Input template."""
         step = ConcreteStepV2()
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_run_data.plan = Mock()
         mock_run_data.plan.plan_inputs = [PlanInput(name="username")]
         mock_run_data.plan_run = Mock()
@@ -165,7 +168,7 @@ class TestStepV2Base:
         """Test _get_value_for_input with ReferenceValue."""
         step = ConcreteStepV2()
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         reference_input = StepOutput(0)
 
@@ -345,7 +348,7 @@ class TestLLMStep:
         reference_input = StepOutput(0)
         step = LLMStep(task="Summarize result", step_name="summarize", inputs=[reference_input])
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         mock_data_value = LocalDataValue(value="Previous step result")
         mock_reference_value = ReferenceValue(value=mock_data_value, description="Step 0")
@@ -381,7 +384,7 @@ class TestLLMStep:
             inputs=["Context info", ref1, "Additional data", ref2],
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         mock_data_value1 = LocalDataValue(value="John")
         mock_ref1_value = ReferenceValue(value=mock_data_value1, description="User input")
@@ -633,7 +636,7 @@ class TestInvokeToolStep:
         mock_tool._arun = AsyncMock(return_value=mock_output)
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
             mock_get_tool.return_value = mock_tool
@@ -642,7 +645,12 @@ class TestInvokeToolStep:
             result = await step.run(run_data=mock_run_data)
 
             assert result == "tool result"
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once()
             call_args = mock_tool._arun.call_args
             assert call_args[1]["query"] == "search term"
@@ -669,8 +677,8 @@ class TestInvokeToolStep:
         )
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
-            patch.object(mock_run_data.portia.config, "get_default_model") as mock_get_model,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
+            patch.object(mock_run_data.config, "get_default_model") as mock_get_model,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
             mock_get_tool.return_value = mock_tool
@@ -681,7 +689,12 @@ class TestInvokeToolStep:
 
             assert isinstance(result, MockOutputSchema)
             assert result.result == "structured result"
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once()
             mock_model.aget_structured_response.assert_called_once()
 
@@ -706,8 +719,8 @@ class TestInvokeToolStep:
         )
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
-            patch.object(mock_run_data.portia.config, "get_default_model") as mock_get_model,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
+            patch.object(mock_run_data.config, "get_default_model") as mock_get_model,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
             mock_get_tool.return_value = mock_tool
@@ -718,7 +731,12 @@ class TestInvokeToolStep:
 
             assert isinstance(result, MockOutputSchema)
             assert result.result == "structured result"
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once()
             mock_model.aget_structured_response.assert_called_once()
 
@@ -730,7 +748,7 @@ class TestInvokeToolStep:
             tool="mock_tool", step_name="run_tool", args={"query": reference_input}
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_tool = Mock()
         mock_tool.structured_output_schema = None
         mock_output = Mock()
@@ -742,7 +760,7 @@ class TestInvokeToolStep:
         mock_reference_value = ReferenceValue(value=mock_data_value, description="Step 0")
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
             patch.object(reference_input, "get_value") as mock_get_value,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
@@ -753,7 +771,12 @@ class TestInvokeToolStep:
             result = await step.run(run_data=mock_run_data)
 
             assert result == "tool result with reference"
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once()
             call_args = mock_tool._arun.call_args
             assert call_args[1]["query"] == "previous step output"
@@ -774,7 +797,7 @@ class TestInvokeToolStep:
             },
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_tool = Mock()
         mock_tool.structured_output_schema = None
         mock_output = Mock()
@@ -788,7 +811,7 @@ class TestInvokeToolStep:
         mock_ref2_value = ReferenceValue(value=mock_data_value2, description="Step 1")
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
             patch.object(ref1, "get_value") as mock_get_value1,
             patch.object(ref2, "get_value") as mock_get_value2,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
@@ -801,7 +824,12 @@ class TestInvokeToolStep:
             result = await step.run(run_data=mock_run_data)
 
             assert result == "mixed inputs result"
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once()
             call_args = mock_tool._arun.call_args[1]
             assert call_args["context"] == "static context"
@@ -826,7 +854,7 @@ class TestInvokeToolStep:
         mock_tool._arun = AsyncMock(return_value=mock_output)
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
             mock_get_tool.return_value = mock_tool
@@ -837,7 +865,12 @@ class TestInvokeToolStep:
             assert isinstance(result, Clarification)
             assert result.user_guidance == "Need more information"
             assert result.plan_run_id == mock_run_data.plan_run.id
-            mock_get_tool.assert_called_once_with("mock_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "mock_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
             mock_tool._arun.assert_called_once_with(mock_ctx_class.return_value)
 
     @pytest.mark.asyncio
@@ -866,14 +899,19 @@ class TestInvokeToolStep:
         step = InvokeToolStep(tool="nonexistent_tool", step_name="run_tool", args={"query": "test"})
         mock_run_data = Mock()
 
-        with patch.object(mock_run_data.portia, "get_tool") as mock_get_tool:
+        with patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool:
             mock_get_tool.return_value = None  # Tool not found
 
             with pytest.raises(ToolNotFoundError) as exc_info:
                 await step.run(run_data=mock_run_data)
 
             assert "nonexistent_tool" in str(exc_info.value)
-            mock_get_tool.assert_called_once_with("nonexistent_tool", mock_run_data.plan_run)
+            mock_get_tool.assert_called_once_with(
+                "nonexistent_tool",
+                mock_run_data.tool_registry,
+                mock_run_data.storage,
+                mock_run_data.plan_run,
+            )
 
     @pytest.mark.asyncio
     async def test_invoke_tool_step_with_string_arg_templates(self) -> None:
@@ -884,7 +922,7 @@ class TestInvokeToolStep:
             args={"query": f"Search {StepOutput(0)} for {Input('username')}"},
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_run_data.step_output_values = [
             StepOutputValue(
                 value=LocalDataValue(value="result"),
@@ -905,7 +943,7 @@ class TestInvokeToolStep:
         mock_tool._arun = AsyncMock(return_value=mock_output)
 
         with (
-            patch.object(mock_run_data.portia, "get_tool") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
             patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
         ):
             mock_get_tool.return_value = mock_tool
@@ -1008,7 +1046,7 @@ class TestFunctionStep:
             function=example_function, step_name="calc", args={"x": 10, "y": reference_input}
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         mock_data_value = LocalDataValue(value="Previous step")
         mock_reference_value = ReferenceValue(value=mock_data_value, description="Step 0")
@@ -1061,7 +1099,7 @@ class TestFunctionStep:
             return_value=MockOutputSchema(result="converted output", count=1)
         )
 
-        with patch.object(mock_run_data.portia.config, "get_default_model") as mock_get_model:
+        with patch.object(mock_run_data.config, "get_default_model") as mock_get_model:
             mock_get_model.return_value = mock_model
 
             result = await step.run(run_data=mock_run_data)
@@ -1087,7 +1125,7 @@ class TestFunctionStep:
             args={"x": 5, "y": f"Value {StepOutput(0)} and {Input('username')}"},
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
         mock_run_data.step_output_values = [
             StepOutputValue(
                 value=LocalDataValue(value="result"),
@@ -1175,7 +1213,7 @@ class TestFunctionStep:
             args={"x": 10, "y": reference_input},
         )
         mock_run_data = Mock()
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         mock_data_value = LocalDataValue(value="Async Previous step")
         mock_reference_value = ReferenceValue(value=mock_data_value, description="Step 0")
@@ -1256,7 +1294,7 @@ class TestFunctionStep:
         mock_model.aget_structured_response = AsyncMock(
             return_value=MockOutputSchema(result="converted output", count=1)
         )
-        mock_run_data.portia.config.get_default_model.return_value = mock_model
+        mock_run_data.config.get_default_model.return_value = mock_model
 
         result = await step.run(run_data=mock_run_data)
 
@@ -1309,47 +1347,59 @@ class TestSingleToolAgent:
         assert str(step) == expected_str
 
     @pytest.mark.asyncio
-    async def test_single_tool_agent_run_with_mocked_agent(self) -> None:
-        """Test SingleToolAgent run with get_agent_for_step and agent mocked."""
-        step = SingleToolAgentStep(
-            tool="search_tool", task="Search for information", step_name="search"
-        )
+    @pytest.mark.parametrize(
+        ("execution_agent_type", "expected_one_shot"),
+        [
+            (ExecutionAgentType.ONE_SHOT, True),
+            (ExecutionAgentType.DEFAULT, False),
+        ],
+    )
+    async def test_single_tool_agent_step_with_execution_agent_types(
+        self, execution_agent_type: ExecutionAgentType, expected_one_shot: bool
+    ) -> None:
+        """Test SingleToolAgentStep uses correct execution agent type."""
+        step = SingleToolAgentStep(tool="mock_tool", task="test task", step_name="agent_step")
+
+        # Set up mock run_data with config
         mock_run_data = Mock()
+        mock_run_data.config.execution_agent_type = execution_agent_type
+        mock_run_data.tool_registry = Mock()
+        mock_run_data.storage = Mock()
+        mock_run_data.plan_run = Mock()
+        mock_run_data.legacy_plan = Mock()
+        mock_run_data.end_user = Mock()
+        mock_run_data.execution_hooks = Mock()
 
-        # Create mock agent and output object
-        mock_agent = Mock()
-        mock_output_obj = Mock()
-        mock_output_obj.get_value.return_value = "Agent execution result"
-        mock_agent.execute_async = AsyncMock(return_value=mock_output_obj)
+        mock_tool = Mock()
+        mock_output = Mock()
+        mock_output.get_value.return_value = "Agent execution result"
 
-        # Need to mock the plan for to_legacy_step conversion
-        mock_plan = Mock()
-        mock_plan.step_output_name.return_value = "$search_output"
-        mock_run_data.plan = mock_plan
-
-        with patch.object(mock_run_data.portia, "get_agent_for_step") as mock_get_agent:
-            mock_get_agent.return_value = mock_agent
+        with (
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
+            patch.object(
+                OneShotAgent, "execute_async", new_callable=AsyncMock, return_value=mock_output
+            ) as mock_oneshot_execute,
+            patch.object(
+                DefaultExecutionAgent,
+                "execute_async",
+                new_callable=AsyncMock,
+                return_value=mock_output,
+            ) as mock_default_execute,
+        ):
+            mock_get_tool.return_value = mock_tool
+            mock_ctx_class.return_value = Mock()
 
             result = await step.run(run_data=mock_run_data)
 
             assert result == "Agent execution result"
 
-            # Verify get_agent_for_step was called with correct arguments
-            mock_get_agent.assert_called_once()
-            call_args = mock_get_agent.call_args[0]
-            # First argument should be the legacy step
-            legacy_step = call_args[0]
-            assert legacy_step.task == "Search for information"
-            assert legacy_step.tool_id == "search_tool"
-            # Second and third arguments should be legacy plan and plan run
-            assert call_args[1] == mock_run_data.legacy_plan
-            assert call_args[2] == mock_run_data.plan_run
-
-            # Verify agent.execute_async was called
-            mock_agent.execute_async.assert_called_once()
-
-            # Verify output_obj.get_value was called
-            mock_output_obj.get_value.assert_called_once()
+            if expected_one_shot:
+                mock_oneshot_execute.assert_called_once()
+                mock_default_execute.assert_not_called()
+            else:
+                mock_default_execute.assert_called_once()
+                mock_oneshot_execute.assert_not_called()
 
     def test_single_tool_agent_to_legacy_step(self) -> None:
         """Test SingleToolAgent to_legacy_step method."""
@@ -1394,6 +1444,7 @@ class TestSingleToolAgent:
             inputs=[f"Context: {StepOutput(1)}", "Additional info", Input("category")],
         )
         mock_run_data = Mock()
+        mock_run_data.config.execution_agent_type = ExecutionAgentType.ONE_SHOT
         mock_run_data.plan = Mock()
         mock_run_data.plan.plan_inputs = [
             PlanInput(name="username"),
@@ -1405,39 +1456,50 @@ class TestSingleToolAgent:
             "category": LocalDataValue(value="Technology"),
         }
         mock_run_data.step_output_values = [
-            ReferenceValue(value=LocalDataValue(value="machine learning"), description="step0"),
-            ReferenceValue(value=LocalDataValue(value="AI research"), description="step1"),
+            StepOutputValue(
+                step_num=0,
+                step_name="step0",
+                value=LocalDataValue(value="machine learning"),
+                description="step0",
+            ),
+            StepOutputValue(
+                step_num=1,
+                step_name="step1",
+                value=LocalDataValue(value="AI research"),
+                description="step1",
+            ),
         ]
 
         # Create mock agent and output object
-        mock_agent = Mock()
         mock_output_obj = Mock()
         mock_output_obj.get_value.return_value = "Search completed successfully"
-        mock_agent.execute_async = AsyncMock(return_value=mock_output_obj)
+        mock_tool = Mock()
 
         # Mock the plan for to_legacy_step conversion
         mock_plan = Mock()
         mock_plan.step_output_name.return_value = "$templated_search_output"
         mock_run_data.plan = mock_plan
 
-        with patch.object(mock_run_data.portia, "get_agent_for_step") as mock_get_agent:
-            mock_get_agent.return_value = mock_agent
+        with (
+            patch("portia.builder.step_v2.ToolCallWrapper.from_tool_id") as mock_get_tool,
+            patch("portia.builder.step_v2.ToolRunContext") as mock_ctx_class,
+            patch.object(
+                OneShotAgent, "execute_async", new_callable=AsyncMock, return_value=mock_output_obj
+            ),
+        ):
+            mock_get_tool.return_value = mock_tool
+            mock_ctx_class.return_value = Mock()
 
             result = await step.run(mock_run_data)
 
             assert result == "Search completed successfully"
-
-            # Verify get_agent_for_step was called with correct arguments
-            mock_get_agent.assert_called_once()
-            call_args = mock_get_agent.call_args[0]
-            legacy_step = call_args[0]
 
             # The task should contain the original template string (not resolved yet)
             # Template resolution happens within the execution agent
             expected_task = (
                 f"Search for information about {StepOutput(0)} requested by {Input('username')}"
             )
-            assert legacy_step.task == expected_task
+            assert step.task == expected_task
 
 
 class TestUserVerifyStep:
@@ -1734,7 +1796,7 @@ class TestUserInputStep:
                 step_num=0,
             )
         ]
-        mock_run_data.portia.storage = Mock()
+        mock_run_data.storage = Mock()
 
         result = await step.run(mock_run_data)
 


### PR DESCRIPTION
# Description

This breaks the dependency between RunContext and Portia, so we can move RunContext into another file.

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
