### PR TITLE
Append plan run ID to trace metadata

### DIFF
--- a/portia/portia.py
+++ b/portia/portia.py
@@ -26,7 +26,7 @@ import time
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from langsmith import traceable
+from langsmith import traceable, update_current_run
 from pydantic import BaseModel
 
 from portia.builder.conditionals import ConditionalBlockClauseType, ConditionalStepResult
@@ -2666,9 +2666,11 @@ class Portia:
         plan_run = await self._aget_plan_run_from_plan(
             legacy_plan, end_user, plan_run_inputs, structured_output_schema
         )
-        return await self.resume_builder_plan(
+        plan_run = await self.resume_builder_plan(
             plan, plan_run, end_user=end_user, legacy_plan=legacy_plan
         )
+        update_current_run(metadata={"plan_run_id": str(plan_run.id)})
+        return plan_run
 
     async def resume_builder_plan(
         self,


### PR DESCRIPTION
## Summary
- ensure `run_builder_plan` updates LangSmith trace metadata with only the plan run ID
- cover trace metadata behavior with a unit test expecting the plan run ID

## Testing
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv)*
- `pytest tests/unit/test_portia_plan_v2.py::test_run_builder_plan_appends_plan_run_to_trace_metadata -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_b_68b6142e28788323b752ee75fe82aa19