### PR TITLE
Update linting github actions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
-          args: check
+          version: "0.8.6"
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check --diff
           version: "0.8.6"

--- a/portia/open_source_tools/sql_tool.py
+++ b/portia/open_source_tools/sql_tool.py
@@ -52,25 +52,25 @@ def _sqlite_authorizer(
     """
     # Allow read operations
     if action in (
-        sqlite3.SQLITE_READ,      # Reading data from tables
-        sqlite3.SQLITE_SELECT,    # SELECT statements
-    sqlite3.SQLITE_FUNCTION,  # Using functions in queries
-):
+        sqlite3.SQLITE_READ,  # Reading data from tables
+        sqlite3.SQLITE_SELECT,  # SELECT statements
+        sqlite3.SQLITE_FUNCTION,  # Using functions in queries
+    ):
         return sqlite3.SQLITE_OK
     # Allow only specific safe, read-only PRAGMA statements
     if action == sqlite3.SQLITE_PRAGMA:
         pragma_name = arg1.lower() if arg1 else ""
         # Only allow read-only PRAGMA operations
         safe_pragmas = {
-            "table_info",        # Get table schema information
-            "table_list",        # List tables
-            "database_list",     # List databases
+            "table_info",  # Get table schema information
+            "table_list",  # List tables
+            "database_list",  # List databases
             "foreign_key_list",  # List foreign keys
-            "index_list",        # List indexes
-            "index_info",        # Get index information
-            "schema_version",    # Get schema version
-            "user_version",      # Get user version (read-only)
-            "compile_options",   # Get compile options
+            "index_list",  # List indexes
+            "index_info",  # Get index information
+            "schema_version",  # Get schema version
+            "user_version",  # Get user version (read-only)
+            "compile_options",  # Get compile options
         }
         if pragma_name in safe_pragmas:
             return sqlite3.SQLITE_OK
@@ -91,9 +91,7 @@ class SQLAdapter:
         """List available table names."""
         raise NotImplementedError
 
-    def get_table_schemas(
-        self, tables: list[str]
-    ) -> dict[str, list[dict[str, Any]]]:
+    def get_table_schemas(self, tables: list[str]) -> dict[str, list[dict[str, Any]]]:
         """Return column schemas for the given tables."""
         raise NotImplementedError
 
@@ -243,17 +241,13 @@ class BaseSQLTool(Tool[Any]):
             raise ToolSoftError(f"Invalid config_json: {e}") from e
         db_path = cfg.get("db_path")
         if not isinstance(db_path, str) or not db_path:
-            raise ToolSoftError(
-                "config_json must include a non-empty 'db_path' for SQLite"
-            )
+            raise ToolSoftError("config_json must include a non-empty 'db_path' for SQLite")
         return SQLiteAdapter(SQLiteConfig(db_path=db_path))
 
     def _get_adapter(self, config_json: str | None = None) -> SQLAdapter:
         """Get the appropriate adapter based on config."""
         return (
-            self._adapter_from_config_json(config_json)
-            or self._adapter
-            or self._adapter_from_env()
+            self._adapter_from_config_json(config_json) or self._adapter or self._adapter_from_env()
         )
 
 
@@ -366,5 +360,3 @@ class CheckSQLTool(BaseSQLTool):
         args = CheckSQLArgs.model_validate(kwargs)
         adapter = self._get_adapter(args.config_json)
         return adapter.check_sql(args.query)
-
-

--- a/tests/unit/open_source_tools/test_sql_tool.py
+++ b/tests/unit/open_source_tools/test_sql_tool.py
@@ -62,9 +62,8 @@ def temp_sqlite_db() -> Generator[Path, None, None]:
     tmp_path.unlink(missing_ok=True)
 
 
-
-
 # Tests for the new specific tools
+
 
 def test_run_sql_tool(temp_sqlite_db: Path, test_context: ToolRunContext) -> None:
     """RunSQLTool executes SELECT queries and returns results."""
@@ -160,15 +159,9 @@ def test_check_sql_tool_valid_and_invalid(
 def test_sqlite_authorizer() -> None:
     """Test the SQLite authorizer function covers all branches."""
     # Test allowed operations
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_READ, None, None, None, None) == sqlite3.SQLITE_OK
-    )
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_SELECT, None, None, None, None) == sqlite3.SQLITE_OK
-    )
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_FUNCTION, None, None, None, None) == sqlite3.SQLITE_OK
-    )
+    assert _sqlite_authorizer(sqlite3.SQLITE_READ, None, None, None, None) == sqlite3.SQLITE_OK
+    assert _sqlite_authorizer(sqlite3.SQLITE_SELECT, None, None, None, None) == sqlite3.SQLITE_OK
+    assert _sqlite_authorizer(sqlite3.SQLITE_FUNCTION, None, None, None, None) == sqlite3.SQLITE_OK
 
     # Test allowed PRAGMA operations
     assert (
@@ -195,15 +188,9 @@ def test_sqlite_authorizer() -> None:
     )
 
     # Test denied operations
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_INSERT, None, None, None, None) == sqlite3.SQLITE_DENY
-    )
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_UPDATE, None, None, None, None) == sqlite3.SQLITE_DENY
-    )
-    assert (
-        _sqlite_authorizer(sqlite3.SQLITE_DELETE, None, None, None, None) == sqlite3.SQLITE_DENY
-    )
+    assert _sqlite_authorizer(sqlite3.SQLITE_INSERT, None, None, None, None) == sqlite3.SQLITE_DENY
+    assert _sqlite_authorizer(sqlite3.SQLITE_UPDATE, None, None, None, None) == sqlite3.SQLITE_DENY
+    assert _sqlite_authorizer(sqlite3.SQLITE_DELETE, None, None, None, None) == sqlite3.SQLITE_DENY
 
 
 def test_sql_adapter_abstract_methods() -> None:
@@ -278,7 +265,6 @@ def test_sqlite_adapter_memory_db() -> None:
     finally:
         # Cleanup
         tmp_path.unlink(missing_ok=True)
-
 
 
 def test_sqlite_adapter_error_handling() -> None:
@@ -373,10 +359,7 @@ def test_tools_with_env_config(test_context: ToolRunContext, temp_sqlite_db: Pat
         tool = RunSQLTool()
 
         # Now test the tool with existing data
-        result = tool._run(
-            test_context,
-            query="SELECT * FROM users LIMIT 1"
-        )
+        result = tool._run(test_context, query="SELECT * FROM users LIMIT 1")
         rows = result.get_value()
         assert rows is not None
         assert len(rows) == 1


### PR DESCRIPTION
# Description

Currently, we run `ruff format --check` with pre-commit but not in github actions. This allows code to get in that then doesn't pass the linter in pre-commit. Adding this to GH actions should mean that all code that gets into main passes pre-commit.

Note: We should run pre-commit as part of the Github actions rather than these, so we do the linting in GH the same way that we do linting locally, but for now this should be fine.


## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [X] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
