### PR TITLE
Update documentation + allow references in user_input options

### DIFF
--- a/example_builder.py
+++ b/example_builder.py
@@ -1,4 +1,8 @@
-"""A simple example of using the PlanBuilderV2."""
+"""A simple example of using the PlanBuilderV2.
+
+This example demonstrates how to build and execute a multi-step agentic workflow
+that combines tool calling, user interactions, conditional logic, and LLM tasks.
+"""
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
@@ -9,6 +13,7 @@ from portia.cli import CLIExecutionHooks
 load_dotenv()
 
 
+# Define output schemas using Pydantic - these structure the data returned by steps
 class CommodityPriceWithCurrency(BaseModel):
     """Price of a commodity."""
 
@@ -23,39 +28,48 @@ class FinalOutput(BaseModel):
     email_address: str
 
 
+# Initialize Portia with CLI hooks for interactive prompts and progress display
 portia = Portia(execution_hooks=CLIExecutionHooks())
 
+# Build a multi-step plan using our plan builder
 plan = (
-    PlanBuilderV2("Buy some gold")
+    PlanBuilderV2("Buy some gold")  # Plan description
+    # Define plan inputs - Input() references these throughout the plan
     .input(name="currency", description="The currency to purchase the gold in", default_value="GBP")
+    # Call a search tool to get current gold price
     .invoke_tool_step(
         step_name="Search gold price",
         tool="search_tool",
         args={
             "search_query": f"What is the price of gold per ounce in {Input('currency')}?",
         },
-        output_schema=CommodityPriceWithCurrency,
+        output_schema=CommodityPriceWithCurrency,  # Structure the tool's output
     )
+    # Interactive user input with predefined options to get the purchase quantity
     .user_input(
         message="How many ounces of gold do you want to purchase?",
         options=[50, 100, 200],
     )
+    # Pure function step for calculation of the total price
     .function_step(
         step_name="Calculate total price",
         function=lambda price_with_currency, purchase_quantity: (
             price_with_currency.price * purchase_quantity
         ),
         args={
+            # StepOutput() references previous step results - can use either step name or number
             "price_with_currency": StepOutput("Search gold price"),
             "purchase_quantity": StepOutput(1),
         },
     )
+    # User verification with dynamic message - this will exit the plan if the user rejects
     .user_verify(
         message=(
             f"Do you want to proceed with the purchase? Price is "
             f"{StepOutput('Calculate total price')}"
         )
     )
+    # Conditional logic based on calculated price
     .if_(
         condition=lambda total_price: total_price > 100,  # noqa: PLR2004
         args={"total_price": StepOutput("Calculate total price")},
@@ -64,21 +78,25 @@ plan = (
     .else_()
     .function_step(function=lambda: print("We need more gold!"))  # noqa: T201
     .endif()
+    # LLM step for generating a receipt using natural language instructions
     .llm_step(
         task="Create a fake receipt for the purchase of gold.",
         inputs=[StepOutput("Calculate total price"), Input("currency")],
     )
+    # Single tool agent step - LLM uses a specific tool to complete a task
     .single_tool_agent_step(
         task="Send the receipt to Robbie in an email at not_an_email@portialabs.ai",
         tool="portia:google:gmail:send_email",
-        inputs=[StepOutput(9)],
+        inputs=[StepOutput(9)],  # Reference the receipt from previous step
     )
+    # Define the final output structure
     .final_output(
         output_schema=FinalOutput,
     )
-    .build()
+    .build()  # Build the plan object
 )
 
+# Execute the plan with runtime inputs (overrides default currency)
 plan_run = portia.run_plan(
     plan,
     plan_run_inputs={"currency": "USD"},

--- a/portia/builder/reference.py
+++ b/portia/builder/reference.py
@@ -1,4 +1,30 @@
-"""References to values in a plan."""
+"""References to values in a plan.
+
+This module provides reference classes that allow you to reference variables in your plan whose
+values are not known when the plan is built, such as outputs from previous steps or user-provided
+inputs. When the plan is run, these references are then resolved to their actual values.
+
+The Reference class provides an interface for all reference types. It then has the following
+implementations:
+    StepOutput: References the output value from a previous step.
+    Input: References a user-provided input value.
+
+Example:
+    ```python
+    from portia.builder import PlanBuilderV2
+    from portia.builder.reference import StepOutput, Input
+
+    builder = PlanBuilderV2()
+    builder.input("user_query", description="The user's search query")
+
+    # Step 1: Search for information
+    builder.step("search", tools=[search_tool], inputs={"query": Input("user_query")})
+
+    # Step 2: Process the search results
+    builder.step("process", tools=[llm_tool], inputs={"data": StepOutput("search")})
+    ```
+
+"""
 
 from __future__ import annotations
 
@@ -15,12 +41,29 @@ if TYPE_CHECKING:
 
 
 def default_step_name(step_index: int) -> str:
-    """Return the default name for the step."""
+    """Generate a default name for a step based on its index.
+
+    Args:
+        step_index: The zero-based index of the step in the plan.
+
+    Returns:
+        A string in the format "step_{index}" (e.g., "step_0", "step_1").
+
+    """
     return f"step_{step_index}"
 
 
 class Reference(BaseModel, ABC):
-    """A reference to a value."""
+    """Abstract base class for all reference types in Portia plans.
+
+    References allow you to dynamically reference values that will be resolved at runtime,
+    such as outputs from previous steps or user-provided inputs. This enables building
+    flexible workflows where later steps can depend on the results of earlier operations.
+
+    This is an abstract base class that defines the interface all reference types must
+    implement. Concrete implementations include StepOutput and Input.
+
+    """
 
     # Allow setting temporary/mock attributes in tests (e.g. patch.object(..., "get_value"))
     # Without this, Pydantic v2 prevents setting non-field attributes on instances.
@@ -28,37 +71,74 @@ class Reference(BaseModel, ABC):
 
     @abstractmethod
     def get_legacy_name(self, plan: PlanV2) -> str:
-        """Get the name of the reference to use with legacy Portia plans."""
+        """Get the reference name for compatibility with legacy Portia plans.
+
+        Args:
+            plan: The PlanV2 instance containing the reference.
+
+        """
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
     def get_value(self, run_data: RunContext) -> Any | None:  # noqa: ANN401
-        """Get the value of the reference."""
+        """Resolve and return the value this reference points to.
+
+        Args:
+            run_data: The runtime context containing step outputs, inputs, and other
+                execution data needed to resolve the reference.
+
+        Returns:
+            The resolved value, or None if the reference cannot be resolved.
+
+        Raises:
+            NotImplementedError: This method must be implemented by subclasses.
+
+        """
         raise NotImplementedError  # pragma: no cover
 
 
 class StepOutput(Reference):
-    """A reference to the output of a previous step.
+    """A reference to the output of a previous step in the plan.
 
-    When building your plan, you can use this class to reference the output of a previous step.
-    The output from the specified step will then be substituted in when the plan is run.
+    StepOutput allows you to reference the output value produced by an earlier step,
+    enabling you to create workflows where later steps depend on the results of
+    previous operations. The reference is resolved at runtime during plan execution.
 
-    See the example usage in example_builder.py for more details.
+    You can reference a step either by its name (string) or by its position (integer index).
+    Step indices are zero-based, so the first step is index 0.
+
+    Example:
+        ```python
+        from portia.builder import PlanBuilderV2
+        from portia.builder.reference import StepOutput
+
+        builder = PlanBuilderV2()
+
+        # Create a step that produces some output
+        builder.step("search", tools=[search_tool], inputs={"query": "Python tutorials"})
+
+        # Reference the output by name
+        builder.step("analyze", tools=[llm_tool], inputs={"data": StepOutput("search")})
+
+        # Reference the output by index (0 = first step)
+        builder.step("summarize", tools=[llm_tool], inputs={"data": StepOutput(0)})
+        ```
+
     """
 
     step: str | int = Field(
-        description="The step to reference the output of. If a string is provided, this will be"
-        "used to find the step by name. If an integer is provided, this will be used to find the"
+        description="The step to reference the output of. If a string is provided, this will be "
+        "used to find the step by name. If an integer is provided, this will be used to find the "
         "step by index (steps are 0-indexed)."
     )
 
     def __init__(self, step: str | int) -> None:
-        """Initialize the step output."""
+        """Initialize a reference to a step's output."""
         super().__init__(step=step)  # type: ignore[call-arg]
 
     @override
     def get_legacy_name(self, plan: PlanV2) -> str:
-        """Get the name of the reference to use with legacy Portia plans."""
+        """Get the reference name for compatibility with legacy Portia plans."""
         return plan.step_output_name(self.step)
 
     def __str__(self) -> str:
@@ -71,7 +151,13 @@ class StepOutput(Reference):
 
     @override
     def get_value(self, run_data: RunContext) -> Any | None:
-        """Get the value of the step output."""
+        """Resolve and return the output value from the referenced step.
+
+        Note:
+            If the step cannot be found, a warning is logged and None is returned.
+            The step is matched by either name (string) or index (integer).
+
+        """
         for step_output in run_data.step_output_values:
             if isinstance(self.step, int) and step_output.step_num == self.step:
                 return step_output.value
@@ -91,30 +177,65 @@ class StepOutput(Reference):
 
 
 class Input(Reference):
-    """A reference to a plan input.
+    """A reference to a user-provided plan input.
 
-    When building your plan, you can specify plan inputs using the PlanBuilder.input() method. These
-    are inputs whose values you provide when running the plan, rather than when building the plan.
-    You can then use this to reference those inputs later in your plan. When you do this, the values
-    will be substituted in when the plan is run.
+    Input allows you to reference values that are provided at runtime when the plan
+    is executed, rather than when the plan is built. This enables creating reusable
+    plans that can work with different input values each time they run.
 
-    See the example usage in example_builder.py for more details.
+    Plan inputs are defined using the PlanBuilder.input() method when building your
+    plan, and their values are provided when calling portia.run() or portia.arun().
+    The Input reference is then resolved to the actual value during execution.
+
+    Example:
+        ```python
+        from portia.builder import PlanBuilderV2
+        from portia.builder.reference import Input
+
+        builder = PlanBuilderV2()
+
+        # Define an input that will be provided at runtime
+        builder.input("user_query", description="The user's search query")
+        builder.input("max_results", description="Maximum number of results")
+
+        # Use the inputs in steps
+        builder.step("search",
+                    tools=[search_tool],
+                    inputs={
+                        "query": Input("user_query"),
+                        "limit": Input("max_results")
+                    })
+
+        # When running the plan, provide the input values:
+        # portia.run(plan, inputs={"user_query": "Python tutorials", "max_results": 10})
+        ```
+
     """
 
-    name: str = Field(description="The name of the input.")
+    name: str = Field(description="The name of the input as defined in the plan.")
 
     def __init__(self, name: str) -> None:
-        """Initialize the input."""
+        """Initialize a reference to a plan input."""
+        # We have this __init__ method so users can create an Input reference without having to
+        # specify name= in the constructor.
         super().__init__(name=name)  # type: ignore[call-arg]
 
     @override
     def get_legacy_name(self, plan: PlanV2) -> str:
-        """Get the name of the reference to use with legacy Portia plans."""
+        """Get the reference name for compatibility with legacy Portia plans."""
         return self.name
 
     @override
     def get_value(self, run_data: RunContext) -> Any | None:
-        """Get the value of the input."""
+        """Resolve and return the user-provided input value.
+
+        Returns:
+            The user-provided value for this input, or None if not found.
+
+        Note:
+            If the input value is itself a Reference, it will be recursively resolved.
+
+        """
         plan_input = next(
             (_input for _input in run_data.plan.plan_inputs if _input.name == self.name), None
         )

--- a/portia/plan.py
+++ b/portia/plan.py
@@ -23,11 +23,13 @@ from __future__ import annotations
 from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from typing_extensions import deprecated
 
 from portia.common import Serializable
 from portia.prefixed_uuid import PlanUUID
 
 
+@deprecated("Use PlanBuilderV2 instead")
 class PlanBuilder:
     """A builder for creating plans.
 
@@ -40,6 +42,8 @@ class PlanBuilder:
                 .step("Step 2", "tool_id_2", "output_2") \
                 .input("input_1", "value_1") \
                 .build()
+
+    This class is now deprecated. Use PlanBuilderV2 instead.
 
     """
 


### PR DESCRIPTION
## Summary
* Update PlanBuilderV2 documentation - both to make it easier for human users + coding agents using our library
* I also snuck in a feature (because I realised in writing the documentation that we were missing it) to allow using reference variables in the options of the user_input step. Happy to break this out into a separate PR if that's easier.

------
https://chatgpt.com/codex/tasks/task_b_68b747b68b1c8323a513727ce9f6eb39