### PR TITLE
Allow reference sub-path in an Input / Output

### DIFF
--- a/portia/builder/step_v2.py
+++ b/portia/builder/step_v2.py
@@ -175,9 +175,9 @@ class StepV2(BaseModel, ABC):
                 ref_obj = self._parse_reference_expression(ref_cls, paren_content)
                 resolved = self._resolve_references(ref_obj, run_data)
                 return str(resolved)
-            except (ValueError, AttributeError, KeyError):
+            except (ValueError, AttributeError, KeyError):  # pragma: no cover
                 # If parsing fails, return the original match
-                return full_match
+                return full_match  # pragma: no cover
 
         return re.sub(pattern, replace_reference, value)
 
@@ -214,7 +214,7 @@ class StepV2(BaseModel, ABC):
                 return StepOutput(name)
             return Input(name)
 
-        raise ValueError(f"Invalid reference format: {paren_content}")
+        raise ValueError(f"Invalid reference format: {paren_content}")  # pragma: no cover
 
     def _parse_reference_with_path(self, ref_cls: type[Reference], paren_content: str) -> Reference:
         """Parse reference expressions that include path parameters.
@@ -233,7 +233,9 @@ class StepV2(BaseModel, ABC):
         # Extract path parameter - should always be present since we detected a comma
         path_match = re.search(r"\bpath\s*=\s*['\"]([^'\"]*)['\"]", paren_content)
         if not path_match:
-            raise ValueError(f"Expected path parameter in reference expression: {paren_content}")
+            raise ValueError(  # pragma: no cover
+                f"Expected path parameter in reference expression: {paren_content}"
+            )
         path_param = path_match.group(1)
 
         # Extract the first parameter (step/input name)
@@ -247,7 +249,7 @@ class StepV2(BaseModel, ABC):
         ):
             step_param = first_param[1:-1]  # Remove quotes
         else:
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 f"Expected quoted string or number for step/input name, got: {first_param}"
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "instructor>=1.9.0 ; python_version >= '3.9' and python_version < '4.0'",
     "litellm>=1.74.9.post1",
     "openai<1.99",
+    "pydash>=8.0.0,<9",
 ]
 
 [project.optional-dependencies]
@@ -105,6 +106,10 @@ dev = [
     "pytest-xdist[psutil]>=3.6.1,<4",
     "pytest-asyncio>=1.1.0",
     "pytest-httpx>=0.35.0",
+    "pydash>=8.0.5",
+    "glom>=24.11.0",
+    "box>=0.1.5",
+    "nested-property>=1.0.2",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/tests/integration/test_plan_v2.py
+++ b/tests/integration/test_plan_v2.py
@@ -831,11 +831,9 @@ async def test_example_builder_plan_scenarios(
         execution_hooks=ExecutionHooks(clarification_handler=ExampleBuilderClarificationHandler()),
     )
 
-    def calculate_total_price(
-        price_with_currency: CommodityPriceWithCurrency, purchase_quantity: str | int
-    ) -> float:
+    def calculate_total_price(price: float, purchase_quantity: str | int) -> float:
         """Calculate total price with string to int conversion."""
-        return price_with_currency.price * int(purchase_quantity)
+        return price * int(purchase_quantity)
 
     plan = (
         PlanBuilderV2("Buy some gold")
@@ -865,7 +863,7 @@ async def test_example_builder_plan_scenarios(
             step_name="Calculate total price",
             function=calculate_total_price,
             args={
-                "price_with_currency": StepOutput("Search gold price"),
+                "price": StepOutput("Search gold price", path="price"),
                 "purchase_quantity": StepOutput("Purchase quantity"),
             },
         )

--- a/tests/unit/builder/test_step_v2.py
+++ b/tests/unit/builder/test_step_v2.py
@@ -227,6 +227,106 @@ def test_resolve_input_reference_with_regular_value() -> None:
     assert result == "regular_value"
 
 
+def test_string_templating_with_path_comprehensive() -> None:
+    """Test comprehensive string templating with path syntax for various scenarios."""
+    step = LLMStep(task="Test", step_name="test_step")
+
+    # Set up mock run data with complex nested structures
+    mock_run_data = Mock()
+    mock_run_data.plan = Mock()
+    mock_run_data.plan.plan_inputs = [
+        PlanInput(name="user_profile", description="User profile data"),
+        PlanInput(name="preferences", description="User preferences"),
+    ]
+    mock_run_data.plan_run = Mock()
+    mock_run_data.plan_run.plan_run_inputs = {
+        "user_profile": LocalDataValue(
+            value={
+                "profile": {"name": "Alice", "email": "alice@example.com"},
+                "settings": {"theme": "dark", "notifications": True},
+            }
+        ),
+        "preferences": LocalDataValue(
+            value=[{"category": "tech", "priority": 1}, {"category": "sports", "priority": 2}]
+        ),
+    }
+    mock_run_data.step_output_values = [
+        StepOutputValue(
+            step_num=0,
+            step_name="search",
+            value={"results": [{"title": "AI Research", "score": 0.95}]},
+            description="Search results",
+        ),
+        StepOutputValue(
+            step_num=1,
+            step_name="analysis",
+            value={"data": {"items": {"complex-key": {"value": "nested_data"}}}},
+            description="Analysis results",
+        ),
+    ]
+
+    # Test 1: StepOutput with simple path
+    result = step._template_references(
+        "Found: {{ StepOutput('search', path='results.0.title') }}", mock_run_data
+    )
+    assert result == "Found: AI Research"
+
+    # Test 2: StepOutput with complex path (special characters in key)
+    result = step._template_references(
+        "Data: {{ StepOutput('analysis', path='data.items.complex-key.value') }}", mock_run_data
+    )
+    assert result == "Data: nested_data"
+
+    # Test 3: Input with path accessing nested object
+    result = step._template_references(
+        "User: {{ Input('user_profile', path='profile.name') }}", mock_run_data
+    )
+    assert result == "User: Alice"
+
+    # Test 4: Input with path accessing array element
+    result = step._template_references(
+        "Top preference: {{ Input('preferences', path='0.category') }}", mock_run_data
+    )
+    assert result == "Top preference: tech"
+
+    # Test 5: Mixed StepOutput and Input references with paths
+    result = step._template_references(
+        "{{ Input('user_profile', path='profile.name') }} searched for "
+        "{{ StepOutput('search', path='results.0.title') }} with score "
+        "{{ StepOutput('search', path='results.0.score') }}",
+        mock_run_data,
+    )
+    assert result == "Alice searched for AI Research with score 0.95"
+
+    # Test 6: Mixed quote styles (single and double quotes)
+    result = step._template_references(
+        'Email: {{ Input("user_profile", path="profile.email") }}', mock_run_data
+    )
+    assert result == "Email: alice@example.com"
+
+    # Test 7: References without paths mixed with path references
+    mock_run_data.step_output_values.append(
+        StepOutputValue(
+            step_num=2,
+            step_name="simple",
+            value="simple_result",
+            description="Simple result",
+        )
+    )
+    result = step._template_references(
+        "Simple: {{ StepOutput('simple') }} vs Complex: "
+        "{{ StepOutput('analysis', path='data.items.complex-key.value') }}",
+        mock_run_data,
+    )
+    assert result == "Simple: simple_result vs Complex: nested_data"
+
+    # Test 8: Numeric step references with paths
+    result = step._template_references(
+        "Result from step 0: {{ StepOutput(0, path='results.0.title') }}", mock_run_data
+    )
+    assert result == "Result from step 0: AI Research"
+
+
 def test_resolve_input_names_for_printing_with_reference() -> None:
     """Test _resolve_input_names_for_printing with Reference."""
     step = ConcreteStepV2()

--- a/uv.lock
+++ b/uv.lock
@@ -181,6 +181,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boltons"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/54/71a94d8e02da9a865587fb3fff100cb0fc7aa9f4d5ed9ed3a591216ddcc7/boltons-25.0.0.tar.gz", hash = "sha256:e110fbdc30b7b9868cb604e3f71d4722dd8f4dcb4a5ddd06028ba8f1ab0b5ace", size = 246294, upload-time = "2025-02-03T05:57:59.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7f/0e961cf3908bc4c1c3e027de2794f867c6c89fb4916fc7dba295a0e80a2d/boltons-25.0.0-py3-none-any.whl", hash = "sha256:dc9fb38bf28985715497d1b54d00b62ea866eca3938938ea9043e254a3a6ca62", size = 194210, upload-time = "2025-02-03T05:57:56.705Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.40.11"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +215,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/b2/23e4dc97d941dad612959664029f2eb843fd65ce58cc7b3c02f996b6357c/botocore-1.40.11.tar.gz", hash = "sha256:95af22e1b2230bdd5faa9d1c87e8b147028b14b531770a1148bf495967ccba5e", size = 14339310, upload-time = "2025-08-15T19:25:54.286Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/f9/400e0da61cbbcea7868458f3a447d1191a62ae5e2852d2acdfd4d51b2843/botocore-1.40.11-py3-none-any.whl", hash = "sha256:4beca0c5f92201da1bf1bc0a55038538ad2defded32ab0638cb68f5631dcc665", size = 14005730, upload-time = "2025-08-15T19:25:49.793Z" },
+]
+
+[[package]]
+name = "box"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "columnar" },
+    { name = "executing" },
+    { name = "loguru" },
+    { name = "pysqlite3-binary", marker = "sys_platform == 'linux'" },
+    { name = "python-dateutil" },
+    { name = "timeago" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/38/9d6338243d4d5f297c3f55a3657fc69b3863d2b565137883dda765aa4099/box-0.1.5.tar.gz", hash = "sha256:3255adae67d2edd0ea864b97fa6cd6342d1a8403380b0024446f5dd647540396", size = 73803, upload-time = "2024-11-27T18:18:52.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/0f/ba3cdcfab92e02e27eb1834c40c7a9983b67709450fe1881ce1d1041e833/box-0.1.5-py3-none-any.whl", hash = "sha256:30f0af1cec0873a8185c63fb2ec27dfde1fd990aee29724e06cf5f328a3194ba", size = 162368, upload-time = "2024-11-27T18:18:50.652Z" },
 ]
 
 [[package]]
@@ -395,6 +422,19 @@ wheels = [
 ]
 
 [[package]]
+name = "columnar"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "toolz" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/d6/9652dc659e91efcc692e89077f04d41d21580fae6c2225227d4aa5f9af30/Columnar-1.3.1.tar.gz", hash = "sha256:3fda53a5c8858e5103a647bd23dc9ad11ed107888a409aeca1f3a89327abd0db", size = 10881, upload-time = "2019-11-13T21:26:03.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/39/65648b305cd3cd3c3551ddf5a2b5351d19372eda2d9a9e58c1db90f79297/Columnar-1.3.1-py3-none-any.whl", hash = "sha256:b7c3bf4d35e7b66db63077343bed15cbe5298f5215b3b3302543d9cf221440cc", size = 11657, upload-time = "2019-11-13T21:26:01.826Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -561,6 +601,27 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e4/efb182548f9931b36b76fd9ba2236bfc5e6d342c905beff92e868afb5b5c/executing-0.8.2.tar.gz", hash = "sha256:c23bf42e9a7b9b212f185b1b2c3c91feb895963378887bb10e64a2e612ec0023", size = 481669, upload-time = "2021-10-02T18:23:36.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/64/59e024b685666514cb20ffc2463a8b062df8e6c36efc5199cb422b728b78/executing-0.8.2-py2.py3-none-any.whl", hash = "sha256:32fc6077b103bd19e6494a72682d66d5763cf20a106d5aa7c5ccbea4e47b0df7", size = 16263, upload-time = "2021-10-02T18:23:31.297Z" },
+]
+
+[[package]]
+name = "face"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boltons" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/79/2484075a8549cd64beae697a8f664dee69a5ccf3a7439ee40c8f93c1978a/face-24.0.0.tar.gz", hash = "sha256:611e29a01ac5970f0077f9c577e746d48c082588b411b33a0dd55c4d872949f6", size = 62732, upload-time = "2024-11-02T05:24:26.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/47/21867c2e5fd006c8d36a560df9e32cb4f1f566b20c5dd41f5f8a2124f7de/face-24.0.0-py3-none-any.whl", hash = "sha256:0e2c17b426fa4639a4e77d1de9580f74a98f4869ba4c7c8c175b810611622cd3", size = 54742, upload-time = "2024-11-02T05:24:24.939Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -662,6 +723,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
+]
+
+[[package]]
+name = "glom"
+version = "24.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "boltons" },
+    { name = "face" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/89/b57cfbc448189426f2e01b244fbe9226b059ef5423a9d49c1d335a1f1026/glom-24.11.0.tar.gz", hash = "sha256:4325f96759a912044af7b6c6bd0dba44ad8c1eb6038aab057329661d2021bb27", size = 195120, upload-time = "2024-11-02T23:17:50.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/a2/75fd80784ec33da8d39cf885e8811a4fbc045a90db5e336b8e345e66dbb2/glom-24.11.0-py3-none-any.whl", hash = "sha256:991db7fcb4bfa9687010aa519b7b541bbe21111e70e58fdd2d7e34bbaa2c1fbd", size = 102690, upload-time = "2024-11-02T23:17:46.468Z" },
 ]
 
 [[package]]
@@ -1400,8 +1475,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '4.0' and sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "python_full_version < '4.0' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -1647,6 +1722,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
     { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
+]
+
+[[package]]
+name = "nested-property"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/31/12db32d69f7787aeb3eba23f11d7dd0ceab062f882ae28d3e717237a8a18/nested_property-1.0.2.tar.gz", hash = "sha256:8b297c3658d28c834af153912a78fef742208eba439df987a09e9c82f629c3c7", size = 5034, upload-time = "2025-08-07T08:13:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ac/c34c999a76eca606e0b02db625669d9d06a518ab5ab5d1dbfc00f2eff465/nested_property-1.0.2-py3-none-any.whl", hash = "sha256:2775b345ad3e93b2c7099ebb4c1decf189bfefeb93ff159ba8e0cdabafd48d23", size = 5253, upload-time = "2025-08-07T08:13:29.231Z" },
 ]
 
 [[package]]
@@ -2033,6 +2117,7 @@ dependencies = [
     { name = "pandas" },
     { name = "posthog" },
     { name = "pydantic" },
+    { name = "pydash" },
     { name = "pytest-mock" },
     { name = "python-dotenv" },
     { name = "testcontainers", extra = ["redis"], marker = "python_full_version < '4.0'" },
@@ -2095,7 +2180,11 @@ tools-pdf-reader = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "box" },
+    { name = "glom" },
+    { name = "nested-property" },
     { name = "pre-commit" },
+    { name = "pydash" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2157,6 +2246,7 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'tools-browser-local'", specifier = ">=1.49.0,<2" },
     { name = "posthog", specifier = "~=6.0" },
     { name = "pydantic", specifier = ">=2.11.5,<3" },
+    { name = "pydash", specifier = ">=8.0.0,<9" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "redis", marker = "extra == 'all'", specifier = ">=5.2.1,<6" },
@@ -2167,7 +2257,11 @@ provides-extras = ["mistral", "mistralai", "google", "amazon", "ollama", "groq",
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "box", specifier = ">=0.1.5" },
+    { name = "glom", specifier = ">=24.11.0" },
+    { name = "nested-property", specifier = ">=1.0.2" },
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
+    { name = "pydash", specifier = ">=8.0.5" },
     { name = "pyright", specifier = ">=1.1.382,<2" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
@@ -2450,6 +2544,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pydash"
+version = "8.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/24/91c037f47e434172c2112d65c00c84d475a6715425e3315ba2cbb7a87e66/pydash-8.0.5.tar.gz", hash = "sha256:7cc44ebfe5d362f4f5f06c74c8684143c5ac481376b059ff02570705523f9e2e", size = 164861, upload-time = "2025-01-17T16:08:50.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/86/e74c978800131c657fc5145f2c1c63e0cea01a49b6216f729cf77a2e1edf/pydash-8.0.5-py3-none-any.whl", hash = "sha256:b2625f8981862e19911daa07f80ed47b315ce20d9b5eb57aaf97aaf570c3892f", size = 102077, upload-time = "2025-01-17T16:08:47.91Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2490,6 +2596,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+]
+
+[[package]]
+name = "pysqlite3-binary"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c9/970017bfb83c3f374b3f85d85b2241954ca94a7cfe8d8709b0da5507a439/pysqlite3_binary-0.5.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf257ca54a0b94dce14324b29960fae5b1d57a669ce327b92fe245049abf2854", size = 5184545, upload-time = "2024-10-12T12:46:06.368Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6a/fd500f0ab7d722671c6ec93093e93b7448b416cee2f35fc6c40131ddfa87/pysqlite3_binary-0.5.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb551d736ac3a049b3a91332dbcb0df506eaed58add8a95acfd264dc45ce3fa8", size = 5195175, upload-time = "2024-10-12T12:46:13.976Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/f6638728ea46bf90f0fba63d7f53a57cbab1ba7d34a1eb86419ca582a797/pysqlite3_binary-0.5.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb3653a0eb0ef5db2d0ed49d43b11ab4be24fdf5b2e65a39650fc59348e30dc6", size = 5188499, upload-time = "2024-10-12T12:46:21.926Z" },
 ]
 
 [[package]]
@@ -2591,14 +2707,14 @@ psutil = [
 
 [[package]]
 name = "python-dateutil"
-version = "2.9.0.post0"
+version = "2.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86", size = 357324, upload-time = "2021-07-14T08:19:19.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9", size = 247702, upload-time = "2021-07-14T08:19:18.161Z" },
 ]
 
 [[package]]
@@ -3167,6 +3283,12 @@ wheels = [
 ]
 
 [[package]]
+name = "timeago"
+version = "1.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/71/4d579c1ffcffc736058fc174fd0e9ef0802a7207a0894dcb73f7684a0bc0/timeago-1.0.14.tar.gz", hash = "sha256:4308d0123a21c778e0ac66fb68e09c15ab6a006e152f8840902575b48aac373d", size = 24499, upload-time = "2020-04-18T19:17:35.014Z" }
+
+[[package]]
 name = "tokenizers"
 version = "0.21.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3228,6 +3350,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/0b/d80dfa675bf592f636d1ea0b835eab4ec8df6e9415d8cfd766df54456123/toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02", size = 66790, upload-time = "2024-10-04T16:17:04.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236", size = 56383, upload-time = "2024-10-04T16:17:01.533Z" },
 ]
 
 [[package]]
@@ -3321,6 +3452,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Allows specifying StepOutput("step_name", path="field_a.field_b") or similar for Input to access sub-paths of the output / input.

## Type of change

(select all that apply)

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
