### PR TITLE
feat: support step-level error handling in PlanBuilderV2

### DIFF
--- a/portia/builder/plan_builder_v2.py
+++ b/portia/builder/plan_builder_v2.py
@@ -756,6 +756,29 @@ class PlanBuilderV2:
 
         return self
 
+    def on_error(self, handler: Callable[[Exception], Any]) -> PlanBuilderV2:
+        """Attach an error handler to the previously added step.
+
+        The handler is invoked with any exception raised by the preceding step. It can
+        re-raise the exception to propagate the failure or return a value to use as the
+        step's output, allowing the plan to continue.
+
+        Args:
+            handler: Callable invoked with the exception raised by the previous step.
+
+        Raises:
+            PlanBuilderError: If called before any step has been added.
+
+        """
+        if not self.plan.steps:
+            raise PlanBuilderError("No step to attach error handler to.")
+        self.plan.steps[-1].on_error = handler
+        return self
+
+    def ignore_errors(self) -> PlanBuilderV2:
+        """Ignore errors from the previous step and continue with ``None`` output."""
+        return self.on_error(lambda _: None)
+
     def final_output(
         self,
         output_schema: type[BaseModel] | None = None,

--- a/portia/builder/step_v2.py
+++ b/portia/builder/step_v2.py
@@ -64,6 +64,15 @@ class StepV2(BaseModel, ABC):
     loop_block: LoopBlock | None = Field(
         default=None, description="The loop block this step is part of, if any."
     )
+    on_error: Callable[[Exception], Any] | None = Field(
+        default=None,
+        description=(
+            "Optional error handler. If provided, any exception raised during step"
+            " execution will be passed to this callable. The handler can re-raise"
+            " the exception to propagate the error or return a value to use as the"
+            " step's output and continue plan execution."
+        ),
+    )
 
     @abstractmethod
     async def run(self, run_data: RunContext) -> Any | LocalDataValue:  # noqa: ANN401


### PR DESCRIPTION
## Summary
- allow attaching error handlers to individual steps via `on_error`
- add `ignore_errors` helper to swallow step failures
- execute step-level error handlers during plan runs
- test new error handling behavior

## Testing
- `pytest tests/unit/test_portia_plan_v2.py::test_on_error_handler_returns_value tests/unit/test_portia_plan_v2.py::test_ignore_errors_continues_plan tests/unit/test_portia_plan_v2.py::test_on_error_reraises -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv)*
- `pip install pydantic` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_b_68badd1d6c3483239777cfa2bda21bb5