### PR TITLE
Unpack MCP tool response if it is a simple TextContent block

### DIFF
--- a/portia/tool.py
+++ b/portia/tool.py
@@ -933,11 +933,7 @@ class PortiaMcpTool(Tool[str]):
                     f"{tool_result.model_dump_json()}"
                 )
             # If the tool returned a single text content block, return the plain text
-            try:
-                content_blocks = tool_result.content  # mcp >= current spec
-            except AttributeError:
-                content_blocks = getattr(tool_result, "contents", None)  # safety for older variants
-
+            content_blocks = tool_result.content
             if isinstance(content_blocks, list) and len(content_blocks) == 1:
                 block = content_blocks[0]
                 if isinstance(block, TextContent):

--- a/portia/tool.py
+++ b/portia/tool.py
@@ -27,6 +27,7 @@ import httpx
 import mcp
 from jsonref import replace_refs
 from langchain_core.tools import StructuredTool
+from mcp.types import TextContent
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -931,6 +932,18 @@ class PortiaMcpTool(Tool[str]):
                     f"MCP tool {self.name}({self.id}) returned an error: "
                     f"{tool_result.model_dump_json()}"
                 )
+            # If the tool returned a single text content block, return the plain text
+            try:
+                content_blocks = tool_result.content  # mcp >= current spec
+            except AttributeError:
+                content_blocks = getattr(tool_result, "contents", None)  # safety for older variants
+
+            if isinstance(content_blocks, list) and len(content_blocks) == 1:
+                block = content_blocks[0]
+                if isinstance(block, TextContent):
+                    return block.text
+
+            # Fallback to returning the full JSON for non-text or multi-block results
             return tool_result.model_dump_json()
 
 


### PR DESCRIPTION
# Description

Improve ugly MCP tool response formatting by unpacking the response from the MCP SDK `CallToolResponse` object if it is an object with a single TextContent within it (the most common case).

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
