### PR TITLE
reference from_str

### DIFF
--- a/portia/builder/step_v2.py
+++ b/portia/builder/step_v2.py
@@ -169,16 +169,8 @@ class StepV2(BaseModel, ABC):
 
         def replace_reference(match: re.Match[str]) -> str:
             full_match = match.group(0)
-            ref_type_str = match.group(1)
-
-            # Extract the content inside the parentheses
-            # e.g., from "{{ StepOutput('step', path='field.name') }}"
-            # get "'step', path='field.name'"
-            paren_content = full_match[full_match.find("(") + 1 : full_match.rfind(")")]
-
             try:
-                ref_cls = StepOutput if ref_type_str == "StepOutput" else Input
-                ref_obj = self._parse_reference_expression(ref_cls, paren_content)
+                ref_obj = self._parse_reference_expression(full_match)
                 resolved = self._resolve_references(ref_obj, run_data)
                 return str(resolved)
             except (ValueError, AttributeError, KeyError):  # pragma: no cover
@@ -188,13 +180,13 @@ class StepV2(BaseModel, ABC):
         return re.sub(pattern, replace_reference, value)
 
     def _parse_reference_expression(
-        self, ref_cls: type[Reference], paren_content: str
+        self, templated_str: str
     ) -> Reference:
         """Parse the content inside StepOutput(...) or Input(...) to create the reference object.
 
         Args:
             ref_cls: The Reference class to instantiate (StepOutput or Input)
-            paren_content: The content inside the parentheses
+            templated_str: The content inside the parentheses
 
         Supports the following reference types:
         - StepOutput(step_name)
@@ -202,66 +194,13 @@ class StepV2(BaseModel, ABC):
         - Input(input_name)
 
         """
-        paren_content = paren_content.strip()
-
-        if paren_content.isdigit() and ref_cls == StepOutput:
-            # Reference with a step index - e.g. StepOutput(0)
-            return StepOutput(int(paren_content))
-
-        if ", path=" in paren_content:
-            return self._parse_reference_with_path(ref_cls, paren_content)
-
-        # Simple reference with no path - e.g. StepOutput("step_name") or Input("input_name")
-        if (paren_content.startswith('"') and paren_content.endswith('"')) or (
-            paren_content.startswith("'") and paren_content.endswith("'")
-        ):
-            name = paren_content[1:-1]  # Remove quotes
-            if ref_cls == StepOutput:
-                return StepOutput(name)
-            return Input(name)
-
-        raise ValueError(f"Invalid reference format: {paren_content}")  # pragma: no cover
-
-    def _parse_reference_with_path(self, ref_cls: type[Reference], paren_content: str) -> Reference:
-        """Parse reference expressions that include path parameters.
-
-        Args:
-            ref_cls: The Reference class to instantiate (StepOutput or Input)
-            paren_content: The content inside the parentheses
-
-        Handles cases like:
-        - 'step_name', path='field.name'
-        - 42, path='field.name'  (numeric step index)
-
-        Step/input names must be quoted strings, except for numeric step indices.
-
-        """
-        # Extract path parameter - should always be present since we detected a comma
-        path_match = re.search(r"\bpath\s*=\s*['\"]([^'\"]*)['\"]", paren_content)
-        if not path_match:
-            raise ValueError(  # pragma: no cover
-                f"Expected path parameter in reference expression: {paren_content}"
-            )
-        path_param = path_match.group(1)
-
-        # Extract the first parameter (step/input name)
-        # Split by comma and take the first part
-        first_param = paren_content.split(",")[0].strip()
-
-        if first_param.isdigit():
-            step_param = int(first_param)
-        elif (first_param.startswith('"') and first_param.endswith('"')) or (
-            first_param.startswith("'") and first_param.endswith("'")
-        ):
-            step_param = first_param[1:-1]  # Remove quotes
-        else:
-            raise ValueError(  # pragma: no cover
-                f"Expected quoted string or number for step/input name, got: {first_param}"
-            )
-
-        if ref_cls == StepOutput:
-            return StepOutput(step_param, path=path_param)
-        return Input(str(step_param), path=path_param)
+        match templated_str:
+            case s if "StepOutput" in s:
+                return StepOutput.from_str(templated_str)
+            case s if "Input" in s:
+                return Input.from_str(templated_str)
+            case _:
+                raise ValueError(f"Invalid reference format: {templated_str}")  # pragma: no cover
 
     def _resolve_input_names_for_printing(
         self,

--- a/tests/unit/builder/test_reference.py
+++ b/tests/unit/builder/test_reference.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
+import pytest
 from pydantic import BaseModel
 
 from portia.builder.plan_v2 import PlanV2
@@ -746,3 +747,196 @@ def test_multiple_inputs_and_outputs() -> None:
     # Test Input references
     assert Input("input1").get_legacy_name(plan) == "input1"
     assert Input("input2").get_legacy_name(plan) == "input2"
+
+
+# Test cases for the from_str method
+
+
+@pytest.mark.parametrize(
+    ("input_str", "expected_step", "expected_path"),
+    [
+        # Basic cases with integer step
+        ("StepOutput(0)", 0, None),
+        ("StepOutput(1)", 1, None),
+        ("StepOutput(42)", 42, None),
+        # Basic cases with string step
+        ("StepOutput('step_name')", "step_name", None),
+        ("StepOutput('my_step')", "my_step", None),
+        ("StepOutput('search_results')", "search_results", None),
+        # Cases with path parameter
+        ("StepOutput(0, path='field.name')", 0, "field.name"),
+        ("StepOutput('step_name', path='results.0.title')", "step_name", "results.0.title"),
+        ("StepOutput(1, path='data.user.profile')", 1, "data.user.profile"),
+        # Edge cases with quotes in path
+        ("StepOutput('step', path='field.subfield')", "step", "field.subfield"),
+        ("StepOutput(0, path='complex.path.with.dots')", 0, "complex.path.with.dots"),
+    ],
+)
+def test_step_output_from_str_valid_cases(
+    input_str: str, expected_step: str | int, expected_path: str | None
+) -> None:
+    """Test StepOutput.from_str with valid input strings."""
+    result = StepOutput.from_str(input_str)
+
+    assert isinstance(result, StepOutput)
+    assert result.step == expected_step
+    assert result.path == expected_path
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        # Malformed input strings
+        "{{ StepOutput(0) ", # missing closing brace
+        "StepOutput(0) }}", # missing opening brace
+        "StepOutput()",  # Missing arguments
+        "StepOutput",  # Missing parentheses
+        "StepOutput(",  # Incomplete
+        "StepOutput)",  # Missing opening
+        "StepOutput(,)",  # Empty arguments
+        "StepOutput(0, path=)",  # Missing path value
+        "StepOutput(0, path='unclosed)",  # Unclosed quote
+        "StepOutput(0, path='field.name', extra='value')",  # Extra parameter
+    ],
+)
+def test_step_output_from_str_invalid_cases(input_str: str) -> None:
+    """Test StepOutput.from_str with invalid input strings."""
+    with pytest.raises((ValueError, IndexError, TypeError)):
+        StepOutput.from_str(input_str)
+
+
+@pytest.mark.parametrize(
+    "step_output",
+    [
+        StepOutput(0, path=None),
+        StepOutput(0),
+        StepOutput("step_name"),
+        StepOutput(1, path="field.name"),
+        StepOutput("search", path="results.0.title"),
+    ],
+)
+def test_step_output_from_str_roundtrip(step_output: StepOutput) -> None:
+    """Test that from_str and str produce consistent results."""
+    str_repr = str(step_output)
+    # Remove the double braces for the from_str input
+    from_str_input = str_repr.replace("{{ ", "").replace(" }}", "")
+    reconstructed = StepOutput.from_str(from_str_input)
+
+    assert reconstructed.step == step_output.step
+    assert reconstructed.path == step_output.path
+
+
+@pytest.mark.parametrize(
+    ("input_str", "expected_name", "expected_path"),
+    [
+        # Basic cases
+        ("Input('input_name')", "input_name", None),
+        ("Input('user_query')", "user_query", None),
+        ("Input('api_key')", "api_key", None),
+        ("Input('max_results')", "max_results", None),
+        # Cases with path parameter
+        ("Input('user_data', path='profile.name')", "user_data", "profile.name"),
+        ("Input('search_input', path='query.terms')", "search_input", "query.terms"),
+        ("Input('config', path='settings.database.url')", "config", "settings.database.url"),
+        # Edge cases with various path formats
+        ("Input('data', path='field.subfield')", "data", "field.subfield"),
+        ("Input('items', path='list.0.name')", "items", "list.0.name"),
+        ("Input('complex', path='a.b.c.d.e')", "complex", "a.b.c.d.e"),
+    ],
+)
+def test_input_from_str_valid_cases(
+    input_str: str, expected_name: str, expected_path: str | None
+) -> None:
+    """Test Input.from_str with valid input strings."""
+    result = Input.from_str(input_str)
+
+    assert isinstance(result, Input)
+    assert result.name == expected_name
+    assert result.path == expected_path
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        # Malformed input strings
+        "{{ Input('name') ", # missing closing brace
+        "Input('name') }}", # missing opening brace
+        "Input()",  # Missing arguments
+        "Input",  # Missing parentheses
+        "Input(",  # Incomplete
+        "Input)",  # Missing opening
+        "Input(,)",  # Empty arguments
+        "Input('name', path=)",  # Missing path value
+        "Input('name', path='unclosed)",  # Unclosed quote
+        "Input('name', path='field.name', extra='value')",  # Extra parameter
+    ],
+)
+def test_input_from_str_invalid_cases(input_str: str) -> None:
+    """Test Input.from_str with invalid input strings."""
+    with pytest.raises((ValueError, IndexError, TypeError)):
+        Input.from_str(input_str)
+
+
+@pytest.mark.parametrize(
+    "input_ref",
+    [
+        Input("input_name"),
+        Input("user_query"),
+        Input("api_key", path="field.name"),
+        Input("search_input", path="results.0.title"),
+    ],
+)
+def test_input_from_str_roundtrip(input_ref: Input) -> None:
+    """Test that from_str and str produce consistent results."""
+    str_repr = str(input_ref)
+    # Remove the double braces for the from_str input
+    from_str_input = str_repr.replace("{{ ", "").replace(" }}", "")
+    reconstructed = Input.from_str(from_str_input)
+
+    assert reconstructed.name == input_ref.name
+    assert reconstructed.path == input_ref.path
+
+
+def test_input_from_str_with_special_characters() -> None:
+    """Test Input.from_str with special characters in names and paths."""
+    # Test with underscores, numbers, and other valid characters
+    result = Input.from_str("Input('input_123', path='field_1.sub_field')")
+    assert result.name == "input_123"
+    assert result.path == "field_1.sub_field"
+
+
+def test_from_str_with_whitespace() -> None:
+    """Test that from_str handles whitespace correctly."""
+    # Test with extra spaces - quoted strings preserve internal whitespace
+    step_output = StepOutput.from_str("StepOutput( 0 , path=' field.name ' )")
+    assert step_output.step == 0
+    assert step_output.path == " field.name "  # Quoted strings preserve whitespace
+
+    input_ref = Input.from_str("Input( 'input_name' , path=' field.name ' )")
+    assert input_ref.name == "input_name"
+    assert input_ref.path == " field.name "  # Quoted strings preserve whitespace
+
+
+def test_from_str_with_empty_path() -> None:
+    """Test from_str with empty path values."""
+    # This should work but path should be empty string, not None
+    step_output = StepOutput.from_str("StepOutput(0, path='')")
+    assert step_output.step == 0
+    assert step_output.path == ""
+
+    input_ref = Input.from_str("Input('name', path='')")
+    assert input_ref.name == "name"
+    assert input_ref.path == ""
+
+
+def test_from_str_preserves_type_consistency() -> None:
+    """Test that from_str preserves the original type consistency."""
+    # Test that integer steps remain integers
+    step_output_int = StepOutput.from_str("StepOutput(42)")
+    assert isinstance(step_output_int.step, int)
+    assert step_output_int.step == 42
+
+    # Test that string steps remain strings
+    step_output_str = StepOutput.from_str("StepOutput('step_name')")
+    assert isinstance(step_output_str.step, str)
+    assert step_output_str.step == "step_name"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '4'",
@@ -2095,7 +2095,7 @@ wheels = [
 
 [[package]]
 name = "portia-sdk-python"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Description
Tried to resolve full=True but then decided to solve this generally so we can ammend to these objects. Moves the templating logic to Reference.from_str(...) which now only needs to be ammended inside step_v2 via the match statement to indicate which object should be parsed. This should now also allow us to extend with more fields, though at this point only python primitives, with int and float only currently supported. Will add in more logic for boolean and None when I work on the StepOutput(..., full=True) logic once merged. 

Ticket Link: N/A 

## Type of change

(select all that apply)

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Refactor
- [ ] Requires sync with platform release
- [ ] Documentation update

## Screenshots

(If applicable, add screenshots to help explain your changes)

## Changelog

(If applicable, add a changelog [entry](https://keepachangelog.com/en/))
